### PR TITLE
Improve backend robustness and tests

### DIFF
--- a/src/baliza/backend.py
+++ b/src/baliza/backend.py
@@ -1,11 +1,15 @@
 import ibis
-from ibis.backends.duckdb.Backend import Backend
+from ibis.backends.duckdb import Backend
 from prefect import get_run_logger
 from pathlib import Path
 from typing import Dict, Any, List
+import logging
 from .config import settings
 
-logger = get_run_logger()
+try:
+    logger = get_run_logger()
+except Exception:  # pragma: no cover - outside flow context
+    logger = logging.getLogger(__name__)
 
 
 def load_sql_file(filename: str) -> str:

--- a/src/baliza/flows/raw.py
+++ b/src/baliza/flows/raw.py
@@ -116,7 +116,7 @@ async def extract_contratacoes_modalidade(
     modalidade_code: int,
     **filters
 ) -> ExtractionResult:
-    """Extract contratações for specific modalidade"""
+    """Extract contratacoes for specific modalidade"""
     logger = get_run_logger()
     start_time = datetime.now()
     
@@ -371,7 +371,7 @@ async def extract_phase_2a_concurrent(
             # Concurrent extraction for optimal performance
             tasks = []
             
-            # Extract contratações for each modalidade in parallel
+            # Extract contratacoes for each modalidade in parallel
             for modalidade in modalidades:
                 task = extract_contratacoes_modalidade.submit(
                     data_inicial=data_inicial,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,23 @@
+import pytest
+from unittest import mock
+from src.baliza import backend
+from src.baliza.config import settings
+
+
+def test_load_sql_file_success():
+    content = backend.load_sql_file("init_schema.sql")
+    assert "CREATE SCHEMA" in content
+
+
+def test_load_sql_file_missing():
+    with pytest.raises(FileNotFoundError):
+        backend.load_sql_file("missing.sql")
+
+
+def test_connect_uses_duckdb_connect(mocker):
+    fake_conn = mocker.Mock()
+    mocked_connect = mocker.patch("ibis.duckdb.connect", return_value=fake_conn)
+    conn = backend.connect()
+    mocked_connect.assert_called_once_with(settings.DATABASE_PATH)
+    assert conn is fake_conn
+    assert fake_conn.raw_sql.call_count >= 4


### PR DESCRIPTION
## Summary
- fix import path for DuckDB Backend and fallback to std logging when Prefect context missing
- ensure raw flow file is UTF-8 encoded and remove accents
- add basic tests for backend utilities

## Testing
- `pytest -q`
- `baliza --help`

------
https://chatgpt.com/codex/tasks/task_e_688288fe41188325b9f91f0a577aa665