### PR TITLE
docs: refresh README and align technical docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,227 +1,135 @@
-<div align="center">
-  <img src="https://raw.githubusercontent.com/franklinbaldo/baliza/main/assets/logo.png" alt="Logo do BALIZA: Um farol de dados sobre um mar de informações, com o nome BALIZA abaixo" width="400">
-  <br>
-  <h1>BALIZA</h1>
-  <h3>Backup Aberto de Licitações Zelando pelo Acesso</h3>
-  <p><strong>Guardando a memória das compras públicas no Brasil.</strong></p>
-  <p>
-    <a href="https://github.com/franklinbaldo/baliza/actions/workflows/etl_pipeline.yml"><img src="https://img.shields.io/github/actions/workflow/status/franklinbaldo/baliza/etl_pipeline.yml?branch=main&label=Build%20Di%C3%A1rio&style=for-the-badge" alt="Status do Build"></a>
-    <a href="https://github.com/franklinbaldo/baliza/blob/main/LICENSE"><img src="https://img.shields.io/github/license/franklinbaldo/baliza?style=for-the-badge" alt="Licença"></a>
-    <a href="https://pypi.org/project/baliza/"><img src="https://img.shields.io/pypi/v/baliza?style=for-the-badge" alt="Versão no PyPI"></a>
-    <a href="https://franklinbaldo.github.io/baliza/"><img src="https://img.shields.io/badge/docs-material-blue?style=for-the-badge" alt="Documentação"></a>
-  </p>
-</div>
+# Baliza
 
-> **BALIZA v2.0** é uma ferramenta de código aberto completamente reformulada que extrai dados do Portal Nacional de Contratações Públicas (PNCP) diretamente para arquivos Parquet, usando DLT (Data Load Tool) para máxima eficiência e confiabilidade.
+**Baliza** (Backup Aberto de Licitações Zelando pelo Acesso) é um extrator de
+código aberto que captura dados de contratos do Portal Nacional de Contratações
+Públicas (PNCP) e os armazena em um banco **DuckDB** pronto para análise. O
+projeto nasceu para preservar o histórico das compras públicas brasileiras e
+oferecer uma base consistente para jornalistas, pesquisadores e órgãos de
+controle.
 
----
+## Visão geral
 
-<div align="center">
-  <p style="color: red; font-weight: bold;">⚠️ ATENÇÃO: A funcionalidade de "detecção inteligente de gaps" (incremental inteligente) mencionada abaixo está em desenvolvimento e não está totalmente implementada na versão atual. A pipeline realiza deduplicação de dados, mas a otimização de requisições para buscar apenas dados faltantes ainda é um recurso futuro. Por padrão, a extração ainda pode re-solicitar dados já existentes, que serão descartados pela deduplicação.</p>
-</div>
+- **Pipeline declarativo com [dlt](https://dlthub.com/):** a configuração YAML
+  em `src/baliza/config/pncp.yml` descreve como chamar o endpoint
+  `GET /v1/contratos` do PNCP, aplicando paginação, incremental por
+  `dataAtualizacao` e regras de limpeza.
+- **CLI enxuta:** o comando `baliza extract` executa o pipeline incremental e
+  `baliza backfill` permite processar janelas mensais de forma determinística.
+- **Entrega analítica imediata:** os dados são gravados no arquivo
+  `baliza.duckdb` (dataset `baliza_raw`) com *merge* incremental baseado em
+  chave primária (`numeroControlePNCP`).
+- **Documentação de arquitetura:** os arquivos em `docs/` registram decisões e
+  próximos passos para evolução do pipeline.
 
-## 🚀 Início Rápido - Nova Versão Simplificada
+> 📌 **Escopo atual:** o pipeline cobre o endpoint de **contratos**. A inclusão
+> de demais recursos do PNCP está detalhada na
+> [`docs/endpoint_extraction_strategy.md`](docs/endpoint_extraction_strategy.md).
 
-**BALIZA v2.0** foi completamente reformulado com foco em simplicidade e eficiência. Uma única linha de comando extrai TODOS os dados históricos do PNCP:
+## Requisitos
+
+- Python 3.11 ou superior
+- [uv](https://github.com/astral-sh/uv) para gerenciamento de ambiente
+- Acesso à internet para consultar a API pública do PNCP
+
+## Início rápido
+
+Clone o repositório, instale as dependências e execute o pipeline incremental:
 
 ```bash
-# Instalação (Python 3.11+ e UV requeridos)
 uv sync
 uv run baliza extract
 ```
 
-**Pronto!** Por padrão, o BALIZA agora:
-- ✅ **Extrai TODOS os dados históricos** automaticamente (backfill completo)
-- ✅ **Deduplicação de dados** para evitar armazenamento de duplicatas (a detecção inteligente de gaps para otimização de requisições está em desenvolvimento)  
-- ✅ **Salva em Parquet** otimizado para análise
-- ✅ **Zero configuração** necessária
+O comando cria (ou atualiza) o arquivo `baliza.duckdb` no diretório atual. Por
+padrão, a execução repete os últimos três dias para garantir que registros
+atualizados sejam recapturados com segurança.
 
-## 🎯 O Problema: A Memória Volátil da Transparência
-
-O Portal Nacional de Contratações Públicas (PNCP) é um avanço, mas sua API **não garante um histórico permanente dos dados**. Informações podem ser alteradas ou desaparecer, comprometendo análises de longo prazo, auditorias e o controle social.
-
-## ✨ A Solução: Extração Simplificada e Completa
-
-O BALIZA v2.0 remove toda a complexidade desnecessária e foca no essencial: **extrair todos os dados do PNCP de forma eficiente e confiável**.
-
--   🛡️ **Completo por Padrão:** Extrai todo o histórico disponível sem configuração
--   🔍 **Inteligente:** Realiza deduplicação de dados (otimização de requisições em desenvolvimento)
--   📊 **Pronto para Análise:** Dados em Parquet para pandas, polars, DuckDB
--   🚀 **Zero Complexidade:** Uma única linha de comando para tudo
-
-## 💡 Novo CLI Intuitivo
-
-O CLI foi completamente reformulado para ser intuitivo e poderoso:
+### Exemplo: executar um *backfill* mensal
 
 ```bash
-# Padrão: Extrai TODOS os dados históricos
-baliza extract
-
-# Últimos 30 dias apenas  
-baliza extract --days 30
-
-# Mês específico
-baliza extract --date 2025-01
-
-# Apenas contratos
-baliza extract --types contracts
-
-# Ver o que seria extraído sem baixar
-baliza extract --dry-run
-
-# Informações e ajuda
-baliza info
-baliza --help
+uv run baliza backfill 2024-01 2024-03
 ```
 
-**Exemplos de Uso Real:**
+O comando acima processa, mês a mês, o intervalo de janeiro a março de 2024
+usando o mesmo arquivo `baliza.duckdb` como destino.
+
+## Inspecionando os dados
+
+Abra o DuckDB gerado diretamente pelo shell:
 
 ```bash
-# Analista de dados: Todos os contratos históricos
-baliza extract --types contracts
-
-# Jornalista: Dados de janeiro para reportagem  
-baliza extract --date 2025-01 --output reportagem/
-
-# Pesquisador: Dados completos com progresso detalhado
-baliza extract --verbose
-
-# Verificação rápida: Ver escopo sem baixar
-baliza extract --dry-run
+uv run python -m duckdb --batch <<'SQL'
+.open baliza.duckdb
+USE baliza_raw;
+SELECT COUNT(*) AS total_contratos,
+       MAX(dataatualizacao) AS ultima_atualizacao
+FROM contratos;
+SQL
 ```
 
-## 🔧 Arquitetura Moderna e Simplificada
-
-O BALIZA v2.0 foi reformulado com tecnologias modernas:
-
-```mermaid
-flowchart TD
-    A[PNCP API] -->|DLT REST Source| B[Smart Gap Detection]
-    B -->|Only Missing Data| C[DLT Pipeline Engine]
-    C -->|Deduplication| D[Parquet Files]
-    D -->|Ready for Analysis| E[pandas/polars/DuckDB]
-```
-
-**Tecnologias Core:**
-- **DLT (Data Load Tool):** Pipeline robusto com retry automático e schema evolution
-- **Gap Detection:** Deduplicação de dados (otimização de requisições em desenvolvimento)
-- **Hash-based Deduplication:** Evita dados duplicados automaticamente
-- **Parquet:** Formato otimizado para análise de dados
-
-## 📊 Análise Imediata dos Dados
-
-Com os dados em Parquet, a análise é imediata:
+Também é possível utilizar pandas ou polars:
 
 ```python
-import pandas as pd
 import duckdb
 
-# Ler dados extraídos
-contratos = pd.read_parquet('data/contratos.parquet')
-print(f"Total de contratos: {len(contratos):,}")
-
-# Análise com DuckDB (mais eficiente para grandes volumes)
-con = duckdb.connect()
-resultado = con.sql("""
-    SELECT 
-        razao_social_fornecedor,
-        COUNT(*) as total_contratos,
-        SUM(valor_inicial) as valor_total
-    FROM 'data/contratos.parquet'
-    WHERE data_vigencia_inicio >= '2024-01-01'
-    GROUP BY razao_social_fornecedor
-    ORDER BY valor_total DESC
-    LIMIT 10
-""").df()
-print(resultado)
+con = duckdb.connect("baliza.duckdb")
+con.execute("USE baliza_raw")
+contratos = con.execute("SELECT * FROM contratos").df()
+print(contratos.head())
 ```
 
-## 🏗️ Estrutura do Projeto (Limpa e Focada)
+## Configuração
 
-```
-baliza/
-├── src/baliza/
-│   ├── extraction/          # 🔄 Motor de extração DLT
-│   │   ├── config.py        #   Configuração da API PNCP
-│   │   ├── pipeline.py      #   Pipelines de extração
-│   │   └── gap_detector.py  #   Detecção inteligente de gaps
-│   ├── cli.py              # 💻 Interface de linha de comando
-│   ├── schemas.py          # 📋 Esquemas PNCP (enums em português)
-│   ├── models.py           # 🏗️  Modelos Pydantic
-│   ├── settings.py         # ⚙️  Configurações da aplicação
-│   └── utils.py            # 🔧 Utilitários (hash, etc.)
-├── tests/e2e/              # ✅ Testes end-to-end
-├── docs/                   # 📚 Documentação  
-└── pyproject.toml          # 📦 Dependências mínimas
-```
+A configuração declarativa do pipeline fica em `src/baliza/config/pncp.yml`.
+Nela é possível ajustar:
 
-**Benefícios da Nova Arquitetura:**
-- 🎯 **70% menos código** - focado apenas no essencial
-- 🚀 **Setup instantâneo** - dependências mínimas com UV
-- 🧹 **Zero legado** - arquitetura limpa sem folders "legacy"
-- 📦 **Single Purpose** - só extração de dados para Parquet
+- Parâmetros padrão de paginação (`tamanhoPagina`, `pagina`).
+- Datas inicial/final utilizadas pelo incremental (`initial_value`,
+  `lookback_days` via CLI).
+- Mapeamento de campos retornados (`data_selector`, chave primária etc.).
 
-## ⚡ Principais Melhorias da v2.0
-
-| Aspecto | v1.0 (Complexo) | v2.0 (Simplificado) |
-|---------|-----------------|---------------------|
-| **Setup** | 15+ comandos de configuração | `uv sync && uv run baliza extract` |
-| **CLI** | 12 comandos confusos | 1 comando principal intuitivo |
-| **Dependências** | 25+ bibliotecas | 8 bibliotecas essenciais |
-| **Arquitetura** | Prefect + Ibis + DuckDB + Custom | DLT + Parquet |
-| **Incremental** | Manual gap detection | Deduplicação de dados (otimização de requisições em desenvolvimento) |
-| **Output** | DuckDB proprietário | Parquet padrão da indústria |
-| **Performance** | ~70 min por mês | ~8 min por mês + incremental |
-
-## 🔄 Migração da v1.0
-
-Se você usava a versão anterior:
+Para usar uma configuração customizada, forneça o caminho via `--config`:
 
 ```bash
-# v1.0 (antigo - complexo)
-baliza init
-baliza run --latest
-baliza transform --mes 2024-01  
-baliza query "SELECT COUNT(*) FROM contracts"
-
-# v2.0 (novo - simples)
-baliza extract  # Faz tudo automaticamente!
+uv run baliza extract --config configs/pncp-custom.yml
 ```
 
-Os dados ficam em Parquet padrão, muito mais fáceis de usar!
+## Comandos disponíveis
 
-## 💾 Formatos de Dados Suportados
+| Comando | Descrição |
+|---------|-----------|
+| `baliza extract` | Executa o pipeline incremental usando o *lookback* informado (padrão: 3 dias). |
+| `baliza backfill <AAAA-MM> <AAAA-MM>` | Processa, mês a mês, o intervalo informado sem reaproveitar estado. |
 
-| Endpoint PNCP | Arquivo Parquet | Descrição |
-|---------------|-----------------|-----------|
-| `contratos` | `data/contratos.parquet` | Dados de contratos |
-| `contratacoes_publicacao` | `data/contratacoes_publicacao.parquet` | Publicações de contratações |
-| `atas` | `data/atas.parquet` | Atas e documentos |
+Opções úteis:
 
-Todos os arquivos incluem metadados de extração (`_baliza_extracted_at`, `_dlt_id`) para rastreabilidade.
+- `--duckdb /caminho/arquivo.duckdb` — define o arquivo DuckDB de destino.
+- `--dataset nome` — define o *schema* dentro do DuckDB (padrão: `baliza_raw`).
+- `--lookback-days N` — retrocede `N` dias em relação ao último cursor salvo ao
+  construir a janela incremental.
 
-## 🙌 Como Contribuir
+Use `uv run baliza --help` para ver todos os parâmetros suportados.
 
-**Sua ajuda é fundamental para fortalecer o controle social no Brasil!**
+## Estrutura do repositório
 
-1.  **Reporte um Bug:** Encontrou um problema? [Abra uma issue](https://github.com/franklinbaldo/baliza/issues).
-2.  **Sugira uma Melhoria:** Tem uma ideia? Adoraríamos ouvi-la nas issues.
-3.  **Desenvolva:** Faça um fork, crie uma branch e envie um Pull Request.
-4.  **Dissemine:** Use os dados, crie análises, publique reportagens e compartilhe o projeto!
+```
+├── src/baliza/
+│   ├── cli.py              # Interface de linha de comando
+│   ├── pipelines/pncp.py   # Execução do pipeline dlt
+│   ├── config/pncp.yml     # Configuração declarativa do endpoint
+│   └── utils/              # Funções auxiliares (datas, hashing, etc.)
+├── docs/                   # Guias de arquitetura e planos de evolução
+├── tests/                  # Testes automatizados (em construção)
+└── pyproject.toml          # Metadados e dependências do projeto
+```
 
-## 📋 Requisitos
+## Contribuindo
 
-- **Python 3.11+**
-- **UV** (gerenciador de pacotes) - [Instalar aqui](https://github.com/astral-sh/uv)
-- **10GB+ de espaço** para dados completos (varia conforme o período)
+1. Abra uma issue descrevendo o problema ou melhoria desejada.
+2. Crie um fork e uma branch baseada em `main`.
+3. Rode os testes relevantes (`uv run pytest`) antes de abrir o PR.
+4. Descreva claramente o impacto das mudanças e atualize a documentação.
 
-## 📜 Licença
+## Licença
 
-Este projeto é licenciado sob a **Licença MIT**. Veja o arquivo [LICENSE](LICENSE) para mais detalhes.
-
----
-
-<div align="center">
-  <p><strong>BALIZA v2.0 - Simples, Rápido, Completo</strong></p>
-  <p>🚀 Agora é só <code>baliza extract</code> e pronto!</p>
-</div>
+Baliza é distribuído sob a licença [MIT](LICENSE).

--- a/docs/cleanup-plan.md
+++ b/docs/cleanup-plan.md
@@ -1,422 +1,65 @@
-# Repository Cleanup Plan - Extract & Export to Parquet Only
-
-**Goal**: Streamline repository to contain only what's needed for PNCP data extraction and Parquet export.
-
-## Current State Analysis
-
-### Core Components (KEEP & REORGANIZE) ✅
-```
-src/baliza/
-├── extraction/
-│   ├── config.py          # 🔄 RENAMED from pncp_config.py - API configuration
-│   ├── pipeline.py        # 🔄 RENAMED from pncp.py - extraction functions
-│   └── gap_detector.py    # ✅ NEW - smart gap detection for incremental loading
-├── schemas.py             # 🔄 RENAMED from enums.py - PNCP schemas & enums
-├── models.py              # 🔄 MOVED from legacy/ - Pydantic response models  
-├── utils.py               # 🔄 MOVED from legacy/utils/ - hash & utility functions
-├── settings.py            # 🔄 RENAMED from config.py - app settings
-├── cli.py                 # Entry points for extraction
-└── __init__.py
-```
-
-### Legacy Components (DELETE) ❌
-```
-src/baliza/
-├── flows/                 # ❌ Prefect flows - no longer needed
-├── legacy/
-│   ├── sql/              # ❌ Old SQL schemas - dlt handles schema
-│   ├── utils/
-│   │   ├── circuit_breaker.py  # ❌ dlt has built-in retries
-│   │   ├── endpoints.py        # ❌ Replaced by pncp_config.py
-│   │   ├── http_client.py      # ❌ dlt REST API source handles HTTP
-│   │   └── io.py              # ❌ File I/O utilities not needed
-│   └── validators.py     # ❌ Pydantic models handle validation
-├── metrics/              # ❌ Data quality - dlt has built-in metrics
-├── transforms/           # ❌ Ibis transforms - focus on extraction only
-├── types.py             # ❌ Type definitions - using Pydantic
-├── ui/                  # ❌ UI components not needed
-├── backend.py           # ❌ DuckDB backend - dlt handles destinations
-├── logger.py            # ❌ Custom logging - dlt has built-in logging
-└── pncp_schemas.py      # ❌ Duplicate of models.py
-```
-
-### Test Components (SIMPLIFY) 🔄
-```
-tests/
-├── e2e/
-│   └── test_pncp_pipeline.py  # 🔄 Update for new dlt pipeline
-├── test_backend.py            # ❌ Remove - no custom backend
-├── test_endpoints.py          # ❌ Remove - using dlt built-ins
-└── test_http_client.py        # ❌ Remove - using dlt built-ins
-```
-
-### Documentation (KEEP/UPDATE) 📝
-```
-docs/
-├── dlt-migration-analysis.md  # ✅ Keep - documents migration
-├── cleanup-plan.md           # ✅ This file
-└── README.md                 # 🔄 Update with simplified usage
-```
-
-## Cleanup Actions
-
-### Phase 1: Reorganize & Rename for Production
-```bash
-# Create new extraction module
-mkdir -p src/baliza/extraction/
-
-# Move and rename pipeline components with better names
-mv src/baliza/pipelines/pncp_config.py src/baliza/extraction/config.py
-mv src/baliza/pipelines/pncp.py src/baliza/extraction/pipeline.py
-mv src/baliza/pipelines/gap_detector.py src/baliza/extraction/gap_detector.py
-
-# Move and rename core components
-mv src/baliza/legacy/enums.py src/baliza/schemas.py      # Better name: schemas
-mv src/baliza/legacy/models.py src/baliza/models.py      # Keep: models
-mv src/baliza/legacy/utils/hash_utils.py src/baliza/utils.py  # Keep: utils
-mv src/baliza/config.py src/baliza/settings.py          # Better name: settings
-
-# Remove obsolete structure
-rm -rf src/baliza/legacy/
-rm -rf src/baliza/pipelines/
-```
-
-### Phase 2: Update Imports with Better Names
-Update all import statements with cleaner, production-ready names:
-```python
-# OLD imports (migration artifacts)
-from baliza.legacy.enums import ModalidadeContratacao, PncpEndpoint
-from baliza.legacy.utils.hash_utils import hash_sha256
-from baliza.pipelines.pncp_config import create_pncp_rest_config
-from baliza.pipelines.pncp import run_priority_extraction
-
-# NEW imports (clean production names)
-from baliza.schemas import ContractType, Endpoint  # Better enum names
-from baliza.utils import hash_sha256
-from baliza.extraction.config import create_api_config
-from baliza.extraction.pipeline import extract_priority_data
-```
-
-Files to update:
-- `src/baliza/extraction/config.py` (renamed from pncp_config.py)
-- `src/baliza/extraction/pipeline.py` (renamed from pncp.py)
-- `src/baliza/settings.py` (renamed from config.py)
-- `src/baliza/cli.py`
-- `tests/e2e/test_extraction_pipeline.py` (renamed test file)
-
-### Phase 3: Revamp CLI - Intuitive & Minimal Commands
-
-**Design Principles:**
-- **Single purpose**: Only data extraction to Parquet
-- **Intuitive defaults**: Most common use cases work with minimal flags
-- **Smart date handling**: Natural language and flexible formats
-- **Clear output**: Progress indicators and helpful messages
-
-**NEW CLI Design:**
-```python
-# Main command: baliza extract [options]
-@app.command()
-def extract(
-    # Smart date options (pick one) - DEFAULT: backfill everything
-    backfill_all: bool = typer.Option(True, "--backfill/--no-backfill", help="Extract all available historical data (default)"),
-    days: int = typer.Option(None, "--days", "-d", help="Extract last N days (overrides backfill)"),
-    date_input: str = typer.Option(None, "--date", help="Date (YYYY-MM-DD, YYYY-MM) (overrides backfill)"),
-    date_range: str = typer.Option(None, "--range", "-r", help="Date range (YYYY-MM:YYYY-MM) (overrides backfill)"),
-    
-    # Data selection
-    types: str = typer.Option("all", "--types", "-t", help="Data types: all,contracts,publications,agreements"),
-    
-    # Output options  
-    output: Path = typer.Option("data/", "--output", "-o", help="Output directory"),
-    
-    # Utility flags
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Show what would be extracted")
-):
-    """Extract PNCP data to Parquet files. By default, backfills all available historical data."""
-```
-
-**REMOVE obsolete commands:**
-- `baliza run` (Prefect flows)
-- `baliza init` (database setup)  
-- `baliza doctor` (health checks)
-- `baliza ui` (Prefect UI)
-- `baliza reset` (database management)
-- `baliza query` (SQL queries)
-- `baliza verify` (data integrity)
-- `baliza transform` (staging/marts)
-
-### Phase 4: Remove Obsolete Code
-```bash
-# Remove entire obsolete infrastructure (legacy/ already moved)
-rm -rf src/baliza/flows/
-rm -rf src/baliza/metrics/
-rm -rf src/baliza/transforms/
-rm -rf src/baliza/ui/
-rm src/baliza/backend.py
-rm src/baliza/logger.py
-rm src/baliza/pncp_schemas.py
-rm src/baliza/types.py
-
-# Remove obsolete tests
-rm tests/test_backend.py
-rm tests/test_endpoints.py  
-rm tests/test_http_client.py
-```
-
-### Phase 2: Simplify CLI
-Update `src/baliza/cli.py` to only include:
-- `baliza extract --date-range YYYYMMDD:YYYYMMDD --output parquet/`
-- `baliza extract --latest --output parquet/`
-- Remove all Prefect flow commands
-- Remove database management commands
-- Remove UI commands
-
-### Phase 3: Update Configuration
-Simplify `src/baliza/config.py`:
-- Keep only ENDPOINT_CONFIG
-- Keep only PNCP API settings
-- Remove DuckDB settings (dlt handles destinations)
-- Remove circuit breaker settings
-- Remove UI settings
-
-### Phase 4: Streamline Dependencies
-Update `pyproject.toml`:
-
-**Remove:**
-- `prefect` and all Prefect dependencies
-- `ibis-framework` (not needed for extraction only)
-- `polars` (dlt handles data processing)
-- `msgpack` (not used in streamlined version)
-- `psutil` (monitoring not needed)
-
-**Keep:**
-- `dlt>=1.14.1` 
-- `pydantic>=2.0`
-- `pydantic-settings`
-- `httpx` (dlt dependency)
-- `typer` (for CLI)
-
-### Phase 8: Final Clean Structure
-```
-baliza/
-├── src/baliza/
-│   ├── extraction/
-│   │   ├── __init__.py
-│   │   ├── config.py         # API configuration (clean names)
-│   │   └── pipeline.py       # Extraction functions (clean names)
-│   ├── __init__.py
-│   ├── cli.py                # Simplified CLI
-│   ├── settings.py           # App settings (ENDPOINT_CONFIG)
-│   ├── schemas.py            # Business schemas & enums (clean names)
-│   ├── models.py             # Pydantic response models
-│   └── utils.py              # Hash & utility functions
-├── tests/
-│   ├── __init__.py
-│   └── e2e/
-│       ├── __init__.py
-│       └── test_extraction.py # Simplified extraction tests
-├── docs/
-│   ├── cleanup-plan.md
-│   ├── migration-analysis.md  # Renamed for clarity
-│   └── README.md
-├── pyproject.toml           # Minimal dependencies
-└── uv.lock
-```
-
-## Simplified Usage After Cleanup
-
-### Installation
-```bash
-uv sync
-```
-
-### Extract to Parquet (Intuitive CLI)
-```bash
-# Smart defaults - BACKFILL ALL HISTORICAL DATA (new default behavior)
-baliza extract
-
-# Override backfill with specific time periods  
-baliza extract --days 30                    # Last 30 days only
-baliza extract --date 2025-01              # Entire January 2025 only
-baliza extract --date 2025-01-15           # Single day only
-baliza extract --range 2025-01:2025-03     # January to March only
-
-# Disable backfill explicitly
-baliza extract --no-backfill --days 7      # Just last 7 days
-
-# Specific data types (still backfills all historical data for selected types)
-baliza extract --types contracts           # All historical contracts
-baliza extract --types contracts,agreements # All historical contracts & agreements
-
-# Custom output location (still backfills everything)
-baliza extract --output /my/data/path      # All data to custom directory
-
-# Dry run to see what would be extracted (shows full backfill scope)
-baliza extract --dry-run                   # See all available historical data
-baliza extract --range 2025-01:2025-03 --dry-run  # See specific range
-
-# Get help and info
-baliza --help                              # Command help
-baliza info                                # Available data types
-baliza version                             # Version info
-```
-
-### CLI Examples with Real Use Cases
-```bash
-# Data analyst: Get ALL historical contracts (default backfill behavior)
-baliza extract --types contracts
-
-# Data analyst: Get ONLY recent contracts (override backfill)
-baliza extract --no-backfill --days 30 --types contracts
-
-# Compliance team: Get specific month for reporting  
-baliza extract --date 2025-01 --output reports/january/
-
-# Research: Get comprehensive historical data (leverages default backfill)
-baliza extract --verbose
-
-# Research: Get specific date range only
-baliza extract --range 2024-06:2024-12 --verbose
-
-# Quick check: See full scope of available historical data
-baliza extract --dry-run
-
-# Quick check: See what specific range would include
-baliza extract --days 7 --dry-run
-```
-
-### Python API (Clean Production Names)
-```python
-from baliza.extraction.pipeline import extract_data
-from baliza.schemas import ContractType, DataType
-from datetime import date, timedelta
-
-# DEFAULT: Backfill all historical data (new behavior)
-result = extract_data(
-    output_dir="data/",
-    data_types=["contracts", "agreements"],
-    backfill_all=True  # Default value
-)
-
-# Override backfill with specific dates
-result = extract_data(
-    start_date="2025-01-01",
-    end_date="2025-01-31", 
-    output_dir="data/",
-    data_types=["contracts", "agreements"],
-    backfill_all=False  # Explicit override
-)
-
-# Use business enums (Portuguese names for manual verification)
-modalidade = ModalidadeContratacao.PREGAO_ELETRONICO  # Matches PNCP manual
-endpoint = Endpoint.CONTRATOS  # Matches API documentation
-
-# Smart date handling (when not using backfill)
-last_week = date.today() - timedelta(days=7)
-result = extract_data(
-    start_date=last_week.isoformat(),
-    end_date=date.today().isoformat(),
-    output_dir="data/recent/",
-    backfill_all=False
-)
-```
-
-## Benefits of Cleanup
-
-1. **🎯 Focused Purpose**: Only extraction and parquet export
-2. **📉 Reduced Complexity**: ~70% fewer files and dependencies
-3. **🚀 Faster Setup**: Minimal dependencies, quicker installation
-4. **🧹 Maintainable**: Clear separation of concerns, no "legacy" folders
-5. **📦 Lightweight**: Smaller package size
-6. **🔧 Simple CLI**: Single intuitive command with smart defaults
-7. **🏗️ Clean Architecture**: Business logic in main module with clear names
-8. **🌍 Professional Naming**: English names, clear business meaning
-9. **📁 Logical Organization**: `extraction/` module groups related functionality
-10. **🎯 User-Friendly**: Natural language dates, helpful defaults, progress indicators
-
-## Migration Safety
-
-- **Keep git history**: All removed code remains in git history
-- **Tag current version**: `git tag v1.0-full-features` before cleanup
-- **Test after each phase**: Ensure extraction still works
-- **Document removed features**: Note what was removed and why
-
-## Success Criteria
-
-- ✅ Single intuitive CLI command with smart defaults
-- ✅ No Prefect dependencies
-- ✅ No custom HTTP client code
-- ✅ No database management code
-- ✅ Extraction to Parquet works
-- ✅ All PNCP endpoints supported
-- ✅ Business logic promoted to main module (no legacy/ folder)
-- ✅ Clean import paths (`from baliza.schemas import ContractType`)
-- ✅ Professional English naming for classes/functions
-- ✅ Logical module organization (`extraction/` grouping)
-- ✅ Test suite covers extraction only
-
-## Naming Convention Guidelines
-
-### Enum Names (Keep Portuguese for Manual Verification)
-- `ModalidadeContratacao` ✅ KEEP - matches PNCP manual exactly
-- `PREGAO_ELETRONICO` ✅ KEEP - official legal terminology  
-- `CONCORRENCIA_ELETRONICA` ✅ KEEP - official legal terminology
-- `AmparoLegal` ✅ KEEP - legal basis references
-- Only rename containers: `PncpEndpoint` → `Endpoint` (class name, not values)
-
-### Function Names (Verb-Object Pattern)
-- `pncp_source()` → `create_extraction_source()`
-- `run_priority_extraction()` → `extract_priority_data()`
-- `get_default_config()` → `get_development_config()`
-
-### Module Names (Business Domain)
-- `pncp_config.py` → `config.py` (in extraction/ module)
-- `enums.py` → `schemas.py` (includes enums + schemas)
-- `config.py` → `settings.py` (app-level settings)
-
-### CLI Command Design
-- **One main command**: `baliza extract` (not multiple subcommands)
-- **Smart defaults**: `baliza extract` works without flags (last 7 days)
-- **Natural language**: `--days 30`, `--date 2025-01`, `--range 2025-01:2025-03`
-- **Clear options**: `--types contracts` instead of `--endpoints contratacoes_publicacao`
-- **Helpful utilities**: `--dry-run`, `--verbose`, `baliza info`
-
-## CLI Design Philosophy
-
-### Before (Complex & Technical)
-```bash
-# Multiple confusing commands
-baliza run --latest                           # What does "run" mean?
-baliza extract --mes 2024-01                # Portuguese flag names
-baliza transform --mes 2024-01              # Separate transform step?
-baliza query "SELECT * FROM raw.audit_log"  # SQL knowledge required
-baliza reset --force                        # Dangerous database operations
-baliza doctor                               # What does this check?
-```
-
-### After (Simple & Intuitive)  
-```bash
-# One clear command with smart defaults
-baliza extract                              # Just works - BACKFILLS ALL HISTORICAL DATA
-baliza extract --days 30                   # Natural language (overrides backfill)
-baliza extract --date 2025-01             # Flexible date formats (overrides backfill)
-baliza extract --types contracts          # Clear business terms (still backfills all)
-baliza info                               # Helper information
-```
-
-### Key Improvements
-1. **🎯 Single Purpose**: One command for one job - data extraction
-2. **🧠 Smart Defaults**: `baliza extract` backfills ALL historical data by default - perfect for 90% of use cases  
-3. **🌍 Natural Language**: `--days 30` instead of `--mes 2024-01`
-4. **📋 Manual Compliance**: Enum values kept in Portuguese for PNCP manual verification
-5. **🗃️ Complete by Default**: No partial data - backfill ensures comprehensive historical coverage
-6. **🔒 Safe**: No database management or destructive operations
-7. **📋 Self-Documenting**: `baliza info` shows available options
-8. **🚀 Fast**: No complex setup or configuration files needed
-
-**Result**: Professional, maintainable repository with intuitive CLI, clear English naming, and logical organization for PNCP data extraction to Parquet files.
-
-# TODO: Update this document to reflect the new `FIXME` and `TODO` comments added to the codebase,
-#       especially those related to improving `dlt` usage and integration. This will ensure
-#       the documentation accurately reflects areas for future development and optimization.
+# Plano de limpeza do repositório
+
+Este documento acompanha o esforço de redução de legado e simplificação do
+Baliza após a migração para o pipeline declarativo com dlt. O objetivo é manter
+apenas os componentes necessários para extrair dados do PNCP e entregá-los em
+formato analítico.
+
+## Estado atual
+
+- O pipeline declarativo (`src/baliza/pipelines/pncp.py`) já orquestra a
+  extração com dlt e grava os dados no DuckDB local.
+- O pacote `baliza.extraction` ainda contém utilitários experimentais e código
+  parcialmente migrado que não é utilizado pela CLI atual.
+- Há diretórios herdados (`pipelines/`, `extraction/`, `utils/`) com funções
+  sobrepostas, além de arquivos de configuração duplicados.
+- A suíte de testes end-to-end foi removida durante a migração e precisa ser
+  recriada.
+
+## Ações concluídas ✅
+
+- Criação da configuração declarativa `config/pncp.yml` para o endpoint de
+  contratos.
+- Substituição do fluxo Prefect pelo comando `baliza extract` baseado em dlt.
+- Documentação do fluxo incremental e dos parâmetros de execução na nova
+  `README.md`.
+
+## Próximos passos
+
+### 1. Consolidar módulos de extração
+
+- Remover funções não utilizadas em `baliza.extraction.*` ou migrá-las para
+  `baliza.pipelines` quando ainda forem necessárias.
+- Eliminar arquivos de backup (`settings.py.backup`) e referências ao antigo
+  layout.
+- Revisar imports para garantir que toda a CLI dependa apenas dos módulos
+  consolidados.
+
+### 2. Atualizar e expandir testes
+
+- Recriar um teste end-to-end mínimo que execute `run_pncp` com um mock do
+  endpoint e valide a escrita no DuckDB.
+- Adicionar testes unitários para `_apply_incremental_overrides` e outras
+  funções utilitárias críticas.
+
+### 3. Remover documentação obsoleta
+
+- Substituir referências à arquitetura antiga (Prefect, múltiplos comandos)
+  pelos planos descritos nos documentos atualizados em `docs/`.
+- Garantir que novos PRs atualizem sempre README e documentos técnicos quando
+  introduzirem funcionalidades.
+
+### 4. Automatizar verificações básicas
+
+- Configurar `ruff` e `mypy` no `pyproject.toml` (ou em pre-commit) para evitar
+  regressões de estilo e tipos.
+- Adicionar um fluxo de CI simples que execute `uv run pytest` e as checagens de
+  lint.
+
+## Como contribuir com a limpeza
+
+1. Verifique esta lista antes de iniciar uma tarefa para evitar duplicidade.
+2. Prefira PRs focados (ex.: "Remover módulo legado X"), acompanhados de testes
+   quando aplicável.
+3. Atualize este documento adicionando um item em "Ações concluídas" após o
+   merge.

--- a/docs/dlt-migration-analysis.md
+++ b/docs/dlt-migration-analysis.md
@@ -1,295 +1,69 @@
-# DLT Migration Analysis & Implementation Status
-
-**Status**: Migração para DLT concluída com sucesso ✅
-
-**Implementação Atual**: Pipeline DLT totalmente funcional com `rest_api_source`, detecção de lacunas, deduplicação por hash e suporte a todos os 12 endpoints PNCP.
-
-**Date**: July 25, 2025  
-**Status**: Migration in progress  
-**Current State**: WIP with legacy preservation structure
-
-## Current State Analysis
-
-### What's Already Done ✅
-
-1. **Legacy preservation structure** - Code moved to `src/baliza/legacy/`
-   - Models, enums, utils successfully preserved
-   - Import paths updated in existing code
-   - Hash utilities extracted and working
-
-2. **DLT skeleton** - Basic pipeline structure created
-   - `src/baliza/pipelines/pncp.py` with dlt source definition
-   - Three resources implemented: contratacoes_publicacao, contratos, atas
-   - Hash-based deduplication pattern in place
-
-3. **Test infrastructure** - E2E test structure exists
-   - `tests/e2e/test_pncp_pipeline.py` with comprehensive mocks
-   - All tests currently skipped due to known issues
-
-4. **Configuration** - ENDPOINT_CONFIG preserved and working
-   - All 11 PNCP endpoints properly configured
-   - Legacy enums (PncpEndpoint, ModalidadeContratacao) working
-
-### Critical Blocker Identified 🚨
-
-**Prefect Dependency Issue**: The legacy `EndpointExtractor` requires Prefect context (`get_run_logger()`) which is not available in dlt context. This breaks the "legacy preservation" strategy.
-
-**Impact**: Cannot reuse existing HTTP client as-is without major modifications.
-
-## Root Cause Analysis
-
-The problem is architectural mismatch:
-- **Legacy code**: Designed for Prefect flows with context-dependent logging
-- **DLT code**: Different execution context, no Prefect dependency
-
-The original "preservation" plan assumed we could wrap legacy components without modification, but this is not feasible due to runtime context dependencies.
-
-## DLT Built-in Capabilities Assessment
-
-### Key Findings ✅
-
-**Research conducted**: July 25, 2025
-
-1. **REST API Source**: `dlt.sources.rest_api.rest_api_source()` 
-   - Handles all HTTP operations automatically
-   - Built-in authentication, retries, rate limiting
-   - Configurable via `RESTAPIConfig` 
-
-2. **Pagination Support**: Multiple built-in paginators
-   - `PageNumberPaginator` (matches PNCP's `pagina` parameter)
-   - `OffsetPaginator` (for endpoints using offset/limit)
-   - `JSONResponseCursorPaginator` (for cursor-based pagination)
-
-3. **Incremental Loading**: `dlt.sources.incremental()`
-   - Built-in support for date-based incremental sync
-   - Perfect match for PNCP's `dataInicial`/`dataFinal` pattern
-
-4. **Processing Steps**: Custom data transformation pipeline
-   - Can apply legacy hash functions for deduplication
-   - No need for custom HTTP client or pagination logic
-
-### Impact on Migration Strategy
-
-**MAJOR SIMPLIFICATION**: ~80% of custom code can be eliminated by using dlt built-ins!
-
-- ❌ No custom HTTP client needed
-- ❌ No custom pagination logic
-- ❌ No custom retry/rate limiting
-- ✅ Pure configuration-driven approach
-
-## Revised Migration Strategy
-
-### Strategy Pivot: "Configuration Over Code"
-
-Instead of preserving all legacy code, we preserve only the **data definitions** and **business logic**, while rewriting the **execution layer**.
-
-#### Keep (Zero Changes)
-- ✅ `legacy/enums.py` - All enums including PncpEndpoint, ModalidadeContratacao
-- ✅ `legacy/models.py` - Pydantic models for validation
-- ✅ `legacy/utils/hash_utils.py` - Hash functions for deduplication
-- ✅ `legacy/sql/` - SQL schemas and cleanup scripts
-- ✅ `config.py` - ENDPOINT_CONFIG dictionary
-
-#### Rewrite (DLT-Native)
-- 🔄 HTTP client layer - Use dlt's built-in REST API source
-- 🔄 Circuit breaker - Use dlt's built-in retry mechanisms
-- 🔄 Rate limiting - Use dlt's built-in rate limiting
-- 🔄 Pagination logic - Use dlt's pagination helpers
-
-#### Remove (Technical Debt)
-- ❌ Prefect flows (`flows/` directory)
-- ❌ Prefect-dependent utilities
-- ❌ Complex circuit breaker (over-engineered for dlt)
-
-## Implementation Plan (Revised)
-
-### Phase 1: Configure DLT REST API Source (Week 1)
-
-**BREAKTHROUGH**: DLT has comprehensive REST API built-ins that eliminate need for custom HTTP client!
-
-Research findings:
-- ✅ `rest_api_source()` function handles HTTP requests automatically
-- ✅ Built-in pagination support: `PageNumberPaginator`, `OffsetPaginator`, etc.
-- ✅ Built-in authentication, retries, rate limiting
-- ✅ `EndpointResource` configuration matches our needs perfectly
-
-Create `src/baliza/pipelines/pncp_config.py`:
-- Convert `ENDPOINT_CONFIG` to dlt `RESTAPIConfig` format
-- Map PNCP pagination patterns to dlt paginators
-- Configure authentication and rate limiting
-- Leverage legacy enums for parameter validation
-
-**Success Criteria**: All 11 endpoints configured as dlt REST API resources
-
-### Phase 2: Replace Custom Pipeline (Week 1)
-
-Replace `src/baliza/pipelines/pncp.py` with dlt REST API source:
-- Use `rest_api_source(config)` instead of custom `@dlt.source`
-- Configure incremental loading with `dlt.sources.incremental()`  
-- Apply legacy hash functions for deduplication in processing steps
-- Remove all custom HTTP client code
-
-**Success Criteria**: Zero custom HTTP code, everything uses dlt built-ins
-
-### Phase 3: E2E Testing (Week 2)
-
-Fix and expand `tests/e2e/test_pncp_pipeline.py`:
-- Remove skipped tests
-- Test against real API endpoints (not mocks)
-- Validate hash-based deduplication
-- Performance benchmarks vs legacy system
-
-**Success Criteria**: All tests passing, performance >= legacy system
-
-### Phase 4: CLI Integration (Week 2)
-
-Update `src/baliza/cli.py`:
-- Replace Prefect flow calls with dlt pipeline runs
-- Maintain existing CLI interface for backward compatibility
-- Add feature flag for legacy vs dlt mode
-
-**Success Criteria**: `baliza run --latest` works with dlt backend
-
-### Phase 5: Shadow Mode (Week 3)
-
-Implement parallel validation:
-- Run dlt pipeline alongside legacy (feature flag)
-- Compare row counts and hash checksums
-- Log divergences for analysis
-
-**Success Criteria**: 99.9% data consistency between legacy and dlt
-
-### Phase 6: Cutover (Week 4)
-
-Remove legacy Prefect flows:
-- Delete `flows/` directory
-- Remove Prefect dependencies from pyproject.toml
-- Update documentation
-
-**Success Criteria**: Legacy code removed, dlt is the only ETL engine
-
-## Technical Decisions
-
-### HTTP Client Design
-
-**Decision**: Use dlt built-in HTTP capabilities instead of custom client
-
-**Rationale**:
-- dlt has built-in HTTP sources and REST API helpers
-- dlt handles retries, rate limiting, and error handling automatically
-- dlt's pagination helpers eliminate custom logic
-- Avoids reinventing HTTP client functionality
-
-**Research Needed**: Investigate dlt's REST API source and HTTP helpers
-
-**Implementation Strategy**:
-```python
-from dlt.sources.rest_api import rest_api_source, RESTAPIConfig
-from baliza.legacy.enums import PncpEndpoint, ModalidadeContratacao
-
-# Convert ENDPOINT_CONFIG to RESTAPIConfig
-config = RESTAPIConfig(
-    client={"base_url": "https://pncp.gov.br/api/consulta"},
-    resources=[
-        {
-            "name": "contratacoes_publicacao",
-            "endpoint": "/v1/contratacoes/publicacao",
-            "paginator": "page_number",  # dlt built-in
-            # Use legacy enums for validation
-        }
-    ]
-)
-
-# Zero custom HTTP code needed!
-source = rest_api_source(config)
-```
-
-### Enum Reuse Strategy
-
-**Decision**: Import legacy enums directly in dlt code
-
-**Rationale**:
-- Enums contain validated business logic (enum values match API)
-- No execution context dependencies
-- Zero risk of breaking existing validation rules
-
-**Implementation**:
-```python
-from baliza.legacy.enums import PncpEndpoint, ModalidadeContratacao
-# Use directly in dlt resources
-```
-
-### Deduplication Strategy
-
-**Decision**: Use legacy hash_sha256 function
-
-**Rationale**:
-- Function is pure (no side effects)
-- Already handles JSON serialization edge cases
-- Maintains compatibility with existing data
-
-## Risk Assessment
-
-| Risk | Probability | Impact | Mitigation |
-|------|-------------|--------|------------|
-| API schema changes | Medium | High | Real endpoint testing, schema validation |
-| Performance regression | Low | Medium | Benchmark tests, parallel validation |
-| Data consistency issues | Low | High | Shadow mode with hash comparison |
-| Missing edge cases | Medium | Medium | Comprehensive test suite with real data |
-
-## Success Metrics
-
-### Performance Targets
-- **Extraction time**: <= 30 minutes per month (legacy baseline: ~70 min)
-- **Memory usage**: <= 4GB peak (DuckDB + concurrent requests)
-- **Data consistency**: 99.9% hash match with legacy system
-
-### Quality Targets
-- **Test coverage**: 90%+ for new HTTP client and dlt resources
-- **E2E tests**: All endpoints tested with real API calls
-- **Documentation**: Complete migration guide and new architecture docs
-
-## Migration Timeline
-
-```
-Week 1: HTTP Client + DLT Resources (July 25-31)
-Week 2: Testing + CLI Integration (Aug 1-7)
-Week 3: Shadow Mode + Validation (Aug 8-14)
-Week 4: Cutover + Cleanup (Aug 15-21)
-```
-
-## Dependencies & Prerequisites
-
-### External Dependencies
-- ✅ dlt >= 1.14.1 (already added)
-- ✅ httpx (for HTTP client)
-- ✅ DuckDB (destination)
-
-### Internal Dependencies
-- ✅ Legacy enums and models preserved
-- ✅ ENDPOINT_CONFIG available
-- ✅ Hash utilities working
-
-## Rollback Plan
-
-If migration fails:
-1. **Immediate**: Use feature flag to switch back to legacy Prefect flows
-2. **Short-term**: Keep legacy code in separate branch until dlt is stable
-3. **Long-term**: Gradual endpoint migration (1-2 endpoints at a time)
-
-The "legacy preservation" structure enables safe rollback at any point.
-
-## Next Actions
-
-1. **Immediate**: Fix Prefect logging dependency in test environment
-2. **Today**: Implement SimpleHTTPClient without Prefect dependencies
-3. **This week**: Complete dlt resources for all 11 endpoints
-4. **Next week**: Enable real API testing
-
----
-
-**Conclusion**: The revised plan abandons the "preserve everything" approach in favor of "preserve data definitions, rewrite execution layer". This is more realistic given the Prefect context dependencies and will result in cleaner, more maintainable code.
-
-# TODO: Update this document to reflect the new `FIXME` and `TODO` comments added to the codebase,
-#       especially those related to improving `dlt` usage and integration. This will ensure
-#       the documentation accurately reflects areas for future development and optimization.
+# DLT Migration Status
+
+Atualizado em: 28 de julho de 2025
+
+## Resumo executivo
+
+A migração do Baliza para o ecossistema **dlt** está funcional para o cenário
+principal (extração do endpoint `contratos` direto para DuckDB). A CLI `baliza`
+utiliza o pipeline declarativo definido em `src/baliza/config/pncp.yml`, e o
+incremental por `dataAtualizacao` está operando com *lookback* configurável.
+
+Ainda existem componentes legados no repositório e funcionalidades planejadas
+(deduplicação de requisições, múltiplos endpoints) que não foram concluídas.
+Este documento consolida o status atual e os próximos passos para finalizar a
+migração.
+
+## Entregas concluídas ✅
+
+- Pipeline `run_pncp` baseado em `dlt.pipeline` com destino DuckDB local.
+- Configuração declarativa YAML descrevendo paginador, parâmetros padrão e regra
+  incremental.
+- CLI `baliza extract` e `baliza backfill` usando exclusivamente o pipeline dlt.
+- Hashing e utilitários de data migrados para `baliza.utils` e reutilizados na
+  configuração.
+
+## Itens pendentes 🚧
+
+1. **Cobertura de endpoints adicionais**
+   - Expandir `config/pncp.yml` para suportar os demais recursos do PNCP.
+   - Validar chaves primárias e cursores antes de habilitar cada recurso.
+
+2. **Limpeza de legado**
+   - Remover referências a Prefect e módulos descontinuados (ver
+     `docs/cleanup-plan.md`).
+   - Consolidar utilitários duplicados entre `extraction/` e `pipelines/`.
+
+3. **Resiliência e estado avançado**
+   - Implementar estratégia de resumibilidade descrita em
+     `docs/extraction_resumability_plan.md` (estado centralizado e *gap
+     detection* real).
+   - Avaliar caching ou *rate limiting* quando adicionarmos endpoints mais
+     sensíveis.
+
+4. **Testes automatizados**
+   - Restaurar testes end-to-end para validar a execução do pipeline com mocks
+     controlados da API.
+   - Adicionar testes unitários para funções críticas (_apply_incremental_...).
+
+## Decisões técnicas registradas
+
+- **Destino:** DuckDB local via `dlt.destinations.duckdb`, garantindo portabilidade
+  e facilidade de análise posterior.
+- **Incremental:** Uso de `cursor_path = dataAtualizacao` com `lookback` aplicado
+  em tempo de execução para evitar perdas por atrasos de publicação.
+- **Configuração:** Estratégia "configuration over code" — o comportamento do
+  pipeline deve residir em YAML para facilitar auditoria e ajustes por analistas.
+
+## Riscos e mitigação
+
+| Risco | Impacto | Mitigação |
+|-------|---------|-----------|
+| Falta de testes automatizados | Regressões silenciosas | Priorizar recriação dos testes E2E antes de expandir endpoints |
+| Estado incremental limitado ao DuckDB local | Dificuldade de executar em múltiplos ambientes | Parametrizar diretório de trabalho do pipeline e documentar como exportar os dados |
+| Documentação desatualizada | Dificulta onboarding | Revisão contínua sempre que novos recursos forem ativados |
+
+## Próxima revisão
+
+Revisar este documento após a habilitação do segundo endpoint no pipeline ou, no
+máximo, em 30 dias.

--- a/docs/endpoint_extraction_strategy.md
+++ b/docs/endpoint_extraction_strategy.md
@@ -1,347 +1,61 @@
-# Estratégia de Extração PNCP - Todos os Endpoints
+# Estratégia de extração de endpoints do PNCP
 
-**Status**: Implementação completa - todos os 12 endpoints PNCP são processados por padrão.
+Este guia descreve como o Baliza planeja ampliar a cobertura da API do PNCP a
+partir da base já funcional para o endpoint de contratos. O objetivo é seguir um
+processo incremental, garantindo qualidade e rastreabilidade a cada expansão.
 
-**Nota**: A estratégia de fases foi descontinuada. O sistema atual processa todos os endpoints automaticamente, usando detecção inteligente de lacunas para extrações incrementais eficientes.
+## Situação atual
 
-## Fase 2A (MVP) - 3 Endpoints Essenciais
+- **Endpoint ativo:** `GET /v1/contratos`
+  - Paginador `page_number` com 500 itens por página.
+  - Incremental baseado em `dataAtualizacao` com *lookback* configurável.
+  - Escrita via `write_disposition = merge` em DuckDB.
+- **Estado do código:** o pipeline declarativo em `config/pncp.yml` possui apenas
+  este recurso habilitado.
 
-### **Objetivo:** Pipeline básico funcional com dados principais
+## Princípios para novos endpoints
 
-```python
-PHASE_2A_ENDPOINTS = {
-    "contratacoes_publicacao": {
-        "path": "/v1/contratacoes/publicacao",
-        "method": "GET",
-        "priority": 1,
-        "schedule": "daily",
-        "required_params": ["dataInicial", "dataFinal", "codigoModalidadeContratacao", "pagina"],
-        "optional_params": ["uf", "cnpj", "codigoUnidadeAdministrativa", "idUsuario"],
-        "page_size": 50,
-        "page_size_limits": {"min": 10, "max": 50},
-        "description": "Contratações publicadas por período"
-    },
-    "contratos": {
-        "path": "/v1/contratos",
-        "method": "GET",
-        "priority": 2,
-        "schedule": "daily",
-        "required_params": ["dataInicial", "dataFinal", "pagina"],
-        "optional_params": ["cnpjOrgao", "codigoUnidadeAdministrativa", "usuarioId"],
-        "page_size": 500,
-        "page_size_limits": {"min": 10, "max": 500},
-        "description": "Contratos/empenhos por período"
-    },
-    "atas": {
-        "path": "/v1/atas",
-        "method": "GET",
-        "priority": 3,
-        "schedule": "daily",
-        "required_params": ["dataInicial", "dataFinal", "pagina"],
-        "optional_params": ["idUsuario", "cnpj", "codigoUnidadeAdministrativa"],
-        "page_size": 500,
-        "page_size_limits": {"min": 10, "max": 500},
-        "description": "Atas de registro de preços por vigência"
-    }
-}
-```
+1. **Configuração antes de código** — sempre que possível, usar apenas ajustes no
+   YAML declarativo.
+2. **Uma chave primária por recurso** — definir `primary_key` claro para garantir
+   merges consistentes.
+3. **Cursor validado** — confirmar se o endpoint possui campo de atualização
+   confiável antes de habilitar incremental.
+4. **Testes obrigatórios** — cada novo endpoint deve incluir teste de integração
+   com respostas mockadas.
 
-### **Lógica de Extração MVP:**
-1. **Range de datas:** Últimos 30 dias como padrão
-2. **Modalidades priorizadas:** Pregão (6,7), Dispensa (8), Concorrência (4,5)
-3. **Processamento:** Sequencial com rate limiting básico
+## Roadmap proposto
 
-## Fase 2B (ETL Completo) - 7 Endpoints Adicionais
+| Fase | Endpoints | Objetivo |
+|------|-----------|----------|
+| 1 | `contratacoes_publicacao`, `contratos_atualizacao` | Cobrir eventos de publicação e atualizações de contratos |
+| 2 | `atas`, `atas_atualizacao` | Expandir para atas de registro de preços |
+| 3 | Demais endpoints públicos (pca, instrumentos de cobrança, etc.) | Completar espelho da API pública |
 
-### **Endpoints de Sincronização (Atualizações)**
+Cada fase deve seguir os passos:
 
-```python
-PHASE_2B_SYNC_ENDPOINTS = {
-    "contratacoes_atualizacao": {
-        "path": "/v1/contratacoes/atualizacao",
-        "method": "GET",
-        "priority": 4,
-        "schedule": "hourly",
-        "sync_type": "incremental",
-        "watermark_field": "dataAtualizacaoGlobal",
-        "required_params": ["dataInicial", "dataFinal", "codigoModalidadeContratacao", "pagina"]
-    },
-    "contratos_atualizacao": {
-        "path": "/v1/contratos/atualizacao",
-        "method": "GET",
-        "priority": 5,
-        "schedule": "hourly",
-        "sync_type": "incremental",
-        "watermark_field": "dataAtualizacaoGlobal",
-        "required_params": ["dataInicial", "dataFinal", "pagina"]
-    },
-    "atas_atualizacao": {
-        "path": "/v1/atas/atualizacao",
-        "method": "GET",
-        "priority": 6,
-        "schedule": "hourly",
-        "sync_type": "incremental",
-        "watermark_field": "dataAtualizacaoGlobal",
-        "required_params": ["dataInicial", "dataFinal", "pagina"]
-    }
-}
-```
+1. **Mapeamento:** documentar parâmetros obrigatórios/opcionais e limites de
+   paginação no YAML.
+2. **Validação local:** executar `uv run baliza extract --config ...` com mocks ou
+   janela de datas pequena para validar estrutura.
+3. **Documentação:** atualizar este arquivo e o README com os novos dados
+   produzidos.
+4. **Monitoramento:** registrar métricas básicas (quantidade de linhas, datas
+   mínimas/máximas) após a primeira execução.
 
-### **Endpoints Especializados**
+## Considerações sobre desempenho
 
-```python
-PHASE_2B_SPECIALIZED_ENDPOINTS = {
-    "pca_usuario": {
-        "path": "/v1/pca/usuario",
-        "method": "GET",
-        "priority": 7,
-        "schedule": "weekly",
-        "required_params": ["anoPca", "idUsuario", "pagina"],
-        "description": "Planos de contratação por usuário"
-    },
-    "contratacoes_proposta": {
-        "path": "/v1/contratacoes/proposta",
-        "method": "GET",
-        "priority": 8,
-        "schedule": "daily",
-        "required_params": ["dataFinal", "pagina"],
-        "description": "Contratações com propostas abertas"
-    },
-    "instrumentos_cobranca": {
-        "path": "/v1/instrumentoscobranca/inclusao",
-        "method": "GET",
-        "priority": 9,
-        "schedule": "weekly",
-        "required_params": ["dataInicial", "dataFinal", "pagina"],
-        "page_size": 100,
-        "page_size_limits": {"min": 10, "max": 100},
-        "description": "Instrumentos de cobrança"
-    },
-    "pca_atualizacao": {
-        "path": "/v1/pca/atualizacao",
-        "method": "GET",
-        "priority": 10,
-        "schedule": "daily",
-        "required_params": ["dataInicio", "dataFim", "pagina"],
-        "description": "PCA por data de atualização"
-    }
-}
-```
+- A API do PNCP não possui limites explícitos de requisição, mas o aumento de
+  endpoints pode multiplicar o número total de chamadas; revise a seção de
+  deduplicação de requisições em `docs/request-deduplication-strategy.md`.
+- Avaliar a necessidade de executar backfills em *batchs* menores para evitar
+  timeouts.
 
-## Fase 2C (Production) - Endpoints Detalhados
+## Próximos passos imediatos
 
-### **Endpoints de Drill-Down**
-
-```python
-PHASE_2C_DETAIL_ENDPOINTS = {
-    "contratacao_especifica": {
-        "path": "/v1/orgaos/{cnpj}/compras/{ano}/{sequencial}",
-        "method": "GET",
-        "priority": 11,
-        "schedule": "on_demand",
-        "path_params": ["cnpj", "ano", "sequencial"],
-        "description": "Detalhes específicos de contratação",
-        "trigger": "missing_details"
-    },
-    "pca_classificacao": {
-        "path": "/v1/pca/",
-        "method": "GET",
-        "priority": 12,
-        "schedule": "monthly",
-        "required_params": ["anoPca", "codigoClassificacaoSuperior", "pagina"],
-        "description": "PCA por classificação superior"
-    }
-}
-```
-
-## Configuração por Ambiente
-
-### **Desenvolvimento**
-```python
-DEV_CONFIG = {
-    "rate_limit": {
-        "requests_per_minute": 30,
-        "requests_per_hour": 1000
-    },
-    "retry": {
-        "max_attempts": 3,
-        "backoff_factor": 2,
-        "backoff_max": 300
-    },
-    "timeout": {
-        "connect": 10,
-        "read": 30
-    },
-    "date_ranges": {
-        "default": "last_7_days",
-        "max_range": "30_days"
-    }
-}
-```
-
-### **Produção**
-```python
-PROD_CONFIG = {
-    "rate_limit": {
-        "requests_per_minute": 60,
-        "requests_per_hour": 3000,
-        "burst_allowance": 10
-    },
-    "retry": {
-        "max_attempts": 5,
-        "backoff_factor": 2,
-        "backoff_max": 600,
-        "jitter": True
-    },
-    "timeout": {
-        "connect": 15,
-        "read": 60
-    },
-    "date_ranges": {
-        "default": "last_30_days",
-        "max_range": "365_days"
-    }
-}
-```
-
-## Modalidades de Contratação por Prioridade
-
-### **Alta Prioridade (80% do volume)**
-```python
-HIGH_PRIORITY_MODALIDADES = [
-    6,   # Pregão Eletrônico
-    7,   # Pregão Presencial
-    8,   # Dispensa de Licitação
-    4,   # Concorrência Eletrônica
-    5    # Concorrência Presencial
-]
-```
-
-### **Média Prioridade**
-```python
-MEDIUM_PRIORITY_MODALIDADES = [
-    9,   # Inexigibilidade
-    1,   # Leilão Eletrônico
-    2,   # Diálogo Competitivo
-    13   # Leilão Presencial
-]
-```
-
-### **Baixa Prioridade**
-```python
-LOW_PRIORITY_MODALIDADES = [
-    3,   # Concurso
-    10,  # Manifestação de Interesse
-    11,  # Pré-qualificação
-    12   # Credenciamento
-]
-```
-
-## Estratégia de Processamento
-
-### **1. Processamento Paralelo por Modalidade**
-```python
-# Para contratacoes/publicacao
-async def extract_contratacoes_by_modalidade(date_range, modalidades):
-    tasks = []
-    for modalidade in modalidades:
-        task = extract_contratacao_modalidade(date_range, modalidade)
-        tasks.append(task)
-
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-    return process_results(results)
-```
-
-### **2. Chunking de Datas Inteligente**
-```python
-def get_optimal_date_chunks(start_date, end_date, endpoint_name):
-    """Determina chunks ótimos baseado no endpoint"""
-
-    chunk_sizes = {
-        "contratacoes_publicacao": 7,    # 7 dias
-        "contratos": 15,                 # 15 dias
-        "atas": 30,                      # 30 dias
-        "instrumentos_cobranca": 30      # 30 dias
-    }
-
-    chunk_size = chunk_sizes.get(endpoint_name, 7)
-    return create_date_chunks(start_date, end_date, chunk_size)
-```
-
-### **3. Circuit Breaker por Endpoint**
-```python
-endpoint_circuit_breakers = {
-    endpoint_name: CircuitBreaker(
-        failure_threshold=5,
-        recovery_timeout=300,
-        expected_exception=HTTPException
-    )
-    for endpoint_name in ALL_ENDPOINTS
-}
-```
-
-## Métricas de Monitoramento
-
-### **Métricas por Endpoint**
-```python
-ENDPOINT_METRICS = {
-    "requests_total": "Counter",
-    "requests_duration": "Histogram",
-    "requests_errors": "Counter",
-    "records_extracted": "Counter",
-    "pagination_depth": "Histogram",
-    "rate_limit_hits": "Counter",
-    "circuit_breaker_trips": "Counter"
-}
-```
-
-### **SLOs (Service Level Objectives)**
-```python
-ENDPOINT_SLOS = {
-    "contratacoes_publicacao": {
-        "success_rate": 0.99,       # 99% success
-        "p95_latency": 5000,        # 5s p95
-        "availability": 0.995       # 99.5% uptime
-    },
-    "contratos": {
-        "success_rate": 0.98,
-        "p95_latency": 8000,
-        "availability": 0.99
-    }
-}
-```
-
-## Comandos CLI Resultantes
-
-### **Extração por Fase**
-```bash
-# Fase 2A - MVP
-baliza extract --phase 2a --date-range last_30_days
-
-# Fase 2B - Full
-baliza extract --phase 2b --date-range 2024-01-01:2024-12-31
-
-# Específico por endpoint
-baliza extract --endpoint contratacoes_publicacao --modalidade 6,7,8
-
-# Sincronização incremental
-baliza sync --endpoints contratacoes_atualizacao,contratos_atualizacao
-```
-
-### **Monitoramento**
-```bash
-# Status por endpoint
-baliza status --endpoints
-
-# Métricas de performance
-baliza metrics --endpoint contratacoes_publicacao --period last_24h
-
-# Health check
-baliza doctor --check-endpoints
-```
-
----
-
-**Cobertura Total: 12 endpoints mapeados**
-**Estratégia: Implementação incremental por fases**
-**Priorização: Volume de dados + criticidade de negócio**
+1. Adicionar `contratacoes_publicacao` ao YAML com `page_size = 50` e cursor
+   `dataPublicacao`.
+2. Validar se `contratos_atualizacao` compartilha a mesma chave primária de
+   `contratos` para permitir `merge` seguro.
+3. Atualizar testes para garantir que múltiplos recursos sejam criados na mesma
+   execução do pipeline.

--- a/docs/extraction_resumability_plan.md
+++ b/docs/extraction_resumability_plan.md
@@ -1,178 +1,92 @@
-Of course. Here is a much-improved `docs/extraction_resumability_plan.md` that provides a concrete, actionable plan for making the Baliza extraction pipeline efficient and resumable.
+# Plano de resumibilidade e eficiência da extração
 
-This new document replaces the higher-level `docs/request-deduplication-strategy.md` with a detailed, DLT-native architectural design.
+## Contexto
 
----
+O pipeline atual do Baliza utiliza dlt com incremental por `dataAtualizacao` e
+uma janela de *lookback* configurável. Essa abordagem garante idempotência no
+nível de dados (linhas duplicadas são descartadas pelo `write_disposition =
+merge`), porém ainda não evita chamadas HTTP redundantes nem permite retomar uma
+execução exatamente do ponto de falha.
 
-# Extraction Resumability and Efficiency Plan
+Este documento detalha como evoluir para uma extração verdadeiramente
+resumível, minimizando requisições repetidas.
 
-## 1. Executive Summary
+## Objetivos
 
-This document outlines a stateful, DLT-native architecture to make the Baliza extraction pipeline **efficient, resumable, and intelligent**. The current pipeline successfully prevents duplicate *data* storage but suffers from inefficient *request* duplication, re-fetching data that already exists.
+1. **Persistir estado de execução** — registrar, para cada recurso, quais faixas
+   de datas já foram extraídas com sucesso.
+2. **Detectar lacunas automaticamente** — antes de cada execução, identificar os
+   períodos ainda não cobertos e construir a lista de janelas a serem processadas.
+3. **Reduzir chamadas redundantes** — evitar reprocessar janelas completas quando
+   nenhuma atualização ocorreu desde a última execução.
 
-The proposed solution is to implement a **State Manager** that tracks successfully completed extractions. This will enable a rewritten **Gap Detector** to identify the precise date ranges and modalities that are missing, ensuring the DLT pipeline only requests new data.
-
-**Key Objectives:**
-
-1.  **Eliminate Redundant API Calls:** Only fetch data that is not already present.
-2.  **Enable True Resumability:** Failed or interrupted pipelines can be restarted and will seamlessly continue from where they left off.
-3.  **Increase Extraction Speed:** Subsequent runs will be significantly faster as they only process deltas.
-4.  **Leverage DLT-native Features:** Properly utilize `dlt`'s state and incremental loading capabilities.
-
-This plan transitions Baliza from a stateless, idempotent extractor to a stateful, intelligent one, drastically improving performance and robustness.
-
-## 2. Problem Statement
-
-The current DLT-based pipeline has two major inefficiencies:
-
-1.  **Request-Level Inefficiency:** The pipeline is idempotent at the **data level** (thanks to hash-based deduplication) but not at the **request level**. Running `baliza extract --days 7` twice in a row will make the exact same API calls both times. The second run's data is simply discarded, wasting bandwidth, API quota, and time.
-
-2.  **Gap Detection Implementation:** The gap detection in `src/baliza/extraction/gap_detector.py` has been implemented and is now functional. It uses filesystem completion tracking to identify missing date ranges accurately.
-
-3.  **Inefficient State Tracking:** The current method of creating `.completed` files for each `(endpoint, month)` is brittle, hard to query, and does not support granular tracking (e.g., by day or by modalidade).
-
-As a result, the pipeline is not truly resumable and cannot perform efficient incremental updates.
-
-## 3. Proposed Architecture: A Stateful DLT Pipeline
-
-We will introduce a state management layer that integrates with the DLT pipeline to track progress and guide subsequent extractions.
-
-### 3.1. Core Components
+## Arquitetura proposta
 
 ```mermaid
 flowchart TD
-    subgraph CLI
-        A[baliza extract --days 7]
-    end
-    
-    subgraph Baliza Pipeline
-        B(1. Parse Date/Endpoint Options)
-        C(2. Gap Detector)
-        D(3. DLT Source Generation)
-        E(4. DLT Pipeline Execution)
-        F(5. State Manager)
-    end
-
-    subgraph Artifacts
-        G[State Store<br>(pipeline_state.json)]
-        H[Parquet Files]
-    end
-
-    A --> B
-    B --> C
-    C -- reads from --> G
-    C -- identifies gaps --> D
-    D -- generates sources for gaps --> E
-    E -- writes to --> H
-    E -- on success, updates --> F
-    F -- writes to --> G
+    A[CLI baliza] --> B(State Loader)
+    B --> C{Gaps pendentes?}
+    C -- não --> D[Finaliza]
+    C -- sim --> E[Gerar fontes dlt para cada gap]
+    E --> F[dlt.pipeline.run]
+    F --> G[Atualizar estado]
+    G --> B
 ```
 
-### 3.2. The State Manager & State Store
+### Componentes
 
-We will create a `StateManager` class responsible for abstracting the read/write operations to a central state file (`pipeline_state.json`) located in the DLT pipeline's working directory.
-
-**`pipeline_state.json` Structure:**
+- **State Store (`pipeline_state.json`)**
+  - Localizado no diretório do pipeline dlt.
+  - Estrutura proposta:
 
 ```json
 {
-  "version": "1.0",
-  "last_updated": "2025-07-26T10:00:00Z",
-  "completed_ranges": {
-    "contratos": [
-      ["20240101", "20240331"],
-      ["20240501", "20240515"]
-    ],
-    "contratacoes_publicacao": {
-      "6": [["20240101", "20240229"]],
-      "8": [["20240101", "20240131"]]
-    },
-    "atas": [
-      ["20230101", "20240630"]
-    ]
-  },
-  "incremental_watermarks": {
-    "contratos_atualizacao": "2025-07-25T14:30:00Z",
-    "atas_atualizacao": "2025-07-25T14:28:00Z"
+  "version": 1,
+  "updated_at": "2025-07-28T12:00:00Z",
+  "resources": {
+    "contratos": {
+      "completed": [["2024-01-01", "2024-01-31"]],
+      "cursor": "2025-07-27T18:45:00Z"
+    }
   }
 }
 ```
 
-**Key Features:**
+- **StateManager**
+  - Responsável por carregar, validar e persistir o JSON.
+  - Expõe métodos para obter faixas concluídas e registrar novas janelas.
 
--   **Completed Ranges:** Stores a list of `[start_date, end_date]` strings for each endpoint. For endpoints requiring `modalidade`, the state is nested under the modalidade code.
--   **Watermarks:** Stores the last successfully processed value for `dlt.sources.incremental` cursors (e.g., `dataAtualizacaoGlobal`).
--   **Atomicity:** Writes to the state file will be atomic to prevent corruption.
+- **GapDetector**
+  - Recebe o intervalo solicitado (ou `None` para incremental) e os dados do
+    estado.
+  - Retorna uma lista ordenada de lacunas a serem extraídas.
 
-### 3.3. The Rewritten Gap Detector
+## Fluxo proposto
 
-The `gap_detector.py` module will be rewritten to be the intelligent core of the pipeline.
+1. **Carregar estado** na inicialização do comando (`extract` ou `backfill`).
+2. **Calcular lacunas** considerando o intervalo solicitado e o *lookback*.
+3. **Executar pipeline** uma vez por lacuna para evitar janelas muito grandes.
+4. **Persistir estado** após cada execução bem-sucedida:
+   - Atualizar `completed` com a janela processada (mesclando intervalos
+     sobrepostos).
+   - Atualizar `cursor` com o maior valor retornado em `dataAtualizacao`.
+5. **Relatar progresso** ao usuário com logs e resumo final.
 
-**Logic:**
+## Plano de implementação
 
-1.  **Input:** A requested extraction range (`start_date`, `end_date`), a list of endpoints, and optional modalities.
-2.  **Action:**
-    -   Load the current state from `pipeline_state.json` using the `StateManager`.
-    -   For each endpoint/modalidade combination, calculate the "missing" date ranges by subtracting the `completed_ranges` from the `requested_range`.
-    -   This is a set-difference operation on date ranges.
-3.  **Output:** A list of `DataGap` objects representing the precise, non-overlapping periods that need to be fetched.
+| Etapa | Descrição | Resultado esperado |
+|-------|-----------|--------------------|
+| 1 | Implementar `StateManager` com leitura/escrita atômica | Arquivo de estado confiável | 
+| 2 | Criar `GapDetector` que calcula diferença entre intervalos solicitados e concluídos | Lista de lacunas correta | 
+| 3 | Integrar na CLI (`baliza extract`) executando o pipeline uma vez por lacuna | Extração resiliente | 
+| 4 | Adicionar testes unitários para `StateManager` e `GapDetector` | Garantia contra regressões |
+| 5 | Documentar variáveis de configuração (ex.: caminho do estado) | Onboarding facilitado |
 
-## 4. Implementation Plan
+## Considerações adicionais
 
-### Phase 1: Implement the State Manager
-
--   **Task:** Create `src/baliza/extraction/state_manager.py`.
--   **Class `StateManager`:**
-    -   `__init__(self, pipeline: dlt.Pipeline)`: Locates the state file in the pipeline's working directory.
-    -   `load_state() -> dict`: Reads and validates the state JSON.
-    -   `save_state(self, state: dict)`: Atomically writes the state JSON.
-    -   `get_completed_ranges(self, endpoint: str, modalidade: int = None) -> list`: Returns sorted, merged date ranges.
-    -   `mark_range_completed(self, endpoint: str, start_date: str, end_date: str, modalidade: int = None)`: Adds a new range and merges overlaps.
--   **Goal:** A robust, tested class for state manipulation. The inefficient `.completed` file logic in `pipeline.py` will be removed.
-
-### Phase 2: Rewrite the Gap Detector
-
--   **Task:** Overhaul `src/baliza/extraction/gap_detector.py`.
--   **Function `find_extraction_gaps`:**
-    -   Will now instantiate `StateManager`.
-    -   Implement the range-difference algorithm.
-        -   Example: Request `[Jan 1, Jan 31]`, State has `[Jan 10, Jan 20]`.
-        -   Output gaps: `[Jan 1, Jan 9]` and `[Jan 21, Jan 31]`.
-    -   It will correctly handle per-modalidade state for endpoints like `contratacoes_publicacao`.
--   **Goal:** `find_extraction_gaps` returns an accurate list of `DataGap` objects, or an empty list if the requested range is already complete.
-
-### Phase 3: Integrate into the DLT Pipeline
-
--   **Task:** Modify `src/baliza/extraction/pipeline.py`.
--   **Function `pncp_source`:**
-    -   The call to `find_extraction_gaps` will now be functional.
-    -   It will iterate over the returned `DataGap` objects and dynamically generate a `dlt` source for each one.
--   **Task:** Modify `src/baliza/cli.py`.
--   **Function `extract`:**
-    -   After a successful `pipeline.run()`, it will call the `StateManager` to update the state with the newly completed ranges.
--   **Goal:** The end-to-end flow is complete. The pipeline is now stateful.
-
-### Phase 4: DLT-native Incremental Sync
-
--   **Task:** Implement incremental sync for `*_atualizacao` endpoints.
--   **Action:**
-    -   Create a new DLT resource function decorated with `@dlt.resource`.
-    -   Inside this function, use `dlt.sources.incremental` with `dataAtualizacaoGlobal` as the `cursor_path`.
-    -   The `StateManager` will be extended to manage `last_value` watermarks for these incremental endpoints.
--   **Goal:** Utilize DLT's most efficient sync method for endpoints that support it, reducing the reliance on date-range gap detection for those specific cases.
-
-## 5. Deprecation and Cleanup
-
--   **To be Removed:**
-    -   The placeholder logic in `gap_detector.py`.
-    -   The `.completed` file creation/checking logic in `pipeline.py` (`mark_extraction_completed`, `is_extraction_completed`, etc.).
--   **To be Deprecated:**
-    -   The `docs/request-deduplication-strategy.md` file will be replaced by this document.
-
-## 6. Benefits
-
--   **Efficiency:** A backfill of one year of data, if interrupted halfway, will resume from the exact day it stopped, not from the beginning of the year.
--   **Speed:** Daily runs to fetch the "last 7 days" will only make API calls for the single most recent day not yet processed.
--   **Robustness:** The state is managed centrally and atomically, making it resilient to failures.
--   **Cost Savings:** Reduces egress bandwidth from the PNCP API and compute time on the client side.
--   **Correctness:** Finally implements the "smart" extraction promised in the project's vision.
+- Enquanto a resumibilidade completa não estiver implementada, mantenha o
+  *lookback* padrão em 3 dias para cobrir eventuais atrasos.
+- Quando múltiplos endpoints forem ativados, o estado deve ser particionado por
+  recurso (e por modalidade, se necessário).
+- Avaliar o uso de armazenamento externo (S3/Blob) se o pipeline passar a rodar
+  em múltiplas máquinas.

--- a/docs/request-deduplication-strategy.md
+++ b/docs/request-deduplication-strategy.md
@@ -1,164 +1,73 @@
-# Request-Level Deduplication Strategy
+# Estratégia de deduplicação de requisições
 
-## Problem Statement
+## Problema
 
-After migration to DLT, we have effective **data-level deduplication** but not **request-level deduplication**:
+Após a migração para dlt, passamos a contar com **deduplicação no nível de
+dados** (via `write_disposition = merge`), mas ainda não possuímos
+**deduplicação de requisições**. Quando o usuário executa o mesmo comando duas
+vezes, o pipeline repete todas as chamadas HTTP, desperdiçando banda e tempo.
 
-- ✅ **Data Deduplication**: Hash-based deduplication prevents saving duplicate records to database
-- ❌ **Request Deduplication**: Same HTTP requests are made repeatedly, wasting bandwidth and API quota
-
-## Research Findings
-
-**DLT does NOT provide request-level caching or deduplication:**
-- DLT focuses on data processing, not HTTP optimization  
-- REST API source makes HTTP requests regardless of existing data
-- Incremental loading reduces data volume but doesn't prevent duplicate requests
-- No built-in HTTP caching or URL-level state tracking
-
-## Current Behavior (Without Request Deduplication)
+## Comportamento atual (sem deduplicação de requisições)
 
 ```bash
-# First run: Extract January 2025
-baliza extract --date 2025-01
-# Makes HTTP requests: pages 1-100 for January
+# Primeira execução: extração incremental cobrindo os últimos 7 dias
+baliza extract --lookback-days 7
+# -> Faz todas as requisições necessárias para o intervalo "hoje-7" .. "hoje"
 
-# Second run: Same command  
-baliza extract --date 2025-01
-# Makes HTTP requests: pages 1-100 for January AGAIN
-# But data deduplication prevents saving duplicates to database
+# Segunda execução: mesmo comando
+baliza extract --lookback-days 7
+# -> Repete exatamente as mesmas requisições HTTP
+# -> Registros duplicados são ignorados pelo DuckDB, mas o custo das requisições permanece
 ```
 
-**Result**: Unnecessary HTTP requests but no duplicate data stored.
+**Consequência:** o armazenamento continua limpo, porém o tempo total de execução
+cresce linearmente com a quantidade de reruns.
 
-## Solution Options
+## Achados da pesquisa
 
-### Option 1: Accept Current Behavior (Recommended for MVP)
+- O dlt não oferece cache ou rastreamento de URLs para fontes REST.
+- O incremental reduz o volume gravado, mas não evita refazer páginas já
+  consultadas.
+- A API do PNCP não documenta limites de requisição, mas latências acumuladas
+  podem tornar grandes janelas impraticáveis.
 
-**Rationale:**
-- Data deduplication prevents storage bloat (primary concern)
-- PNCP API has no explicit rate limiting
-- HTTP requests are relatively fast (< 1s per page)
-- Implementation complexity vs. benefit trade-off
+## Caminhos possíveis
 
-**When to use:** MVP, development, low-volume usage
+### Opção 1 — Aceitar o comportamento atual (recomendado para o MVP)
 
-### Option 2: Infrastructure-Level Caching
+- Manter o *lookback* curto (3 dias) para limitar redundância.
+- Documentar a limitação no README.
+- Monitorar a duração das execuções enquanto apenas o endpoint `contratos` está
+  habilitado.
 
-Implement HTTP caching outside of the application:
+### Opção 2 — Cache em infraestrutura
 
-**A. Reverse Proxy Cache (Nginx/HAProxy)**
-```nginx
-location /api/consulta/ {
-    proxy_pass https://pncp.gov.br;
-    proxy_cache_valid 200 24h;  # Cache successful responses for 24h
-    proxy_cache_key "$request_uri";
-}
-```
+Implementar cache HTTP fora do Baliza:
 
-**B. Redis-based HTTP Cache**
-```python
-# Custom HTTP client wrapper with Redis caching
-class CachedPNCPClient:
-    def get(self, url):
-        cached = redis.get(f"pncp:url:{hash(url)}")
-        if cached:
-            return json.loads(cached)
-        
-        response = httpx.get(url)
-        redis.setex(f"pncp:url:{hash(url)}", 3600, response.text)
-        return response.json()
-```
+- **Reverse proxy (Nginx/HAProxy)** com `proxy_cache_key` baseado na URL.
+- **Redis** armazenando respostas por poucas horas.
 
-**When to use:** Production, high-volume usage, multiple applications
+Vantagens: nenhuma alteração no código Python; útil quando múltiplos serviços
+consumirem a mesma API.
 
-### Option 3: Application-Level Request Tracking
+### Opção 3 — Rastreamento de URLs no aplicativo
 
-Track processed URLs in database to skip redundant requests:
+Persistir hashes das URLs requisitadas em uma tabela DuckDB ou arquivo de
+estado. Antes de cada requisição, verificar se o hash foi processado
+recentemente.
 
-```python
-# Create a processed_urls table
-CREATE TABLE processed_urls (
-    url_hash VARCHAR(64) PRIMARY KEY,
-    processed_at TIMESTAMP,
-    page_count INTEGER
-);
+- Permite granularidade fina (por endpoint/página).
+- Exige política de expiração para evitar crescimento indefinido.
 
-# Before making request
-def should_skip_request(url):
-    url_hash = sha256(normalize_url(url))
-    return db.exists("processed_urls", url_hash=url_hash)
-```
+### Opção 4 — Reaproveitar mecanismo legado
 
-**When to use:** Medium-scale production, custom control needed
+Migrar o antigo registro `raw.audit_log` que guardava requisições concluídas.
+Exige portar o schema e as validações para o fluxo atual.
 
-### Option 4: Legacy System Integration
+## Caminho recomendado
 
-Keep the existing Baliza request deduplication system:
-
-- Preserve `raw.audit_log` table for request tracking
-- Maintain `EndpointExtractor._check_existing_request()` logic
-- Adapt existing URL-based deduplication for DLT context
-
-**When to use:** Preserve existing investment, gradual migration
-
-## Recommended Implementation Plan
-
-### Phase 1: MVP (Current State) ✅
-- Use DLT with hash-based data deduplication
-- Accept redundant HTTP requests
-- Document the limitation
-- **Status**: Completed
-
-### Phase 2: Infrastructure Caching (Future)
-- Implement Nginx reverse proxy with caching
-- Cache successful API responses for 1-24 hours
-- No application code changes needed
-- **Effort**: 1-2 days infrastructure work
-
-### Phase 3: Smart Request Tracking (Advanced)
-- Track URL processing state in DLT pipeline state
-- Skip requests for URLs processed in last N hours
-- Implement cache invalidation based on data freshness requirements
-- **Effort**: 1 week development
-
-## Performance Impact Analysis
-
-### Current State (Data Deduplication Only)
-```
-Full backfill extraction:
-- HTTP Requests: ~50,000 (all historical pages)
-- Time: ~4 hours (50k requests × 0.3s avg)
-- Bandwidth: ~5GB (50k × 100KB avg response)
-- Database Storage: ~2GB (after deduplication)
-```
-
-### With Request Deduplication
-```
-Re-run same extraction:
-- HTTP Requests: ~0 (all skipped)
-- Time: ~5 minutes (database queries only)  
-- Bandwidth: ~0MB
-- Database Storage: ~2GB (unchanged)
-```
-
-**Performance Gain**: 48x faster for re-runs, 100% bandwidth savings
-
-## Decision Matrix
-
-| Solution | Complexity | Performance Gain | Maintenance | Best For |
-|----------|------------|------------------|-------------|----------|
-| Accept Current | Low | 0% | Low | MVP, Development |
-| Nginx Cache | Medium | 90%+ | Low | Production |
-| Redis Cache | Medium | 95%+ | Medium | Multi-app |
-| App-level Tracking | High | 98%+ | High | Custom Control |
-| Legacy Integration | Very High | 99%+ | High | Migration |
-
-## Conclusion
-
-**For Baliza migration**: Start with **Option 1 (Accept Current Behavior)** for MVP.
-
-**For production scale**: Implement **Option 2 (Infrastructure Caching)** with Nginx.
-
-The current DLT implementation with hash-based data deduplication provides the essential functionality (no duplicate data storage) while keeping the implementation simple and maintainable.
-
-Request-level deduplication can be added later as a performance optimization when the system reaches sufficient scale to justify the additional complexity.
+1. Manter o comportamento atual enquanto somente `contratos` estiver ativo.
+2. Implementar o **StateManager/GapDetector** descrito em
+   `docs/extraction_resumability_plan.md` antes de habilitar novos endpoints.
+3. Reavaliar a necessidade de cache infraestrutural após medir o custo de
+   backfills completos com múltiplos recursos.


### PR DESCRIPTION
## Summary
- rewrite the README to reflect the current dlt-based pipeline, CLI usage and DuckDB output
- update cleanup, migration, endpoint strategy and resumability documents to match the repository's actual state and next steps
- align the request deduplication strategy with the available CLI options and new resumability plan

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ca2cb6eb80832586e1ff3b167e717e