### PR TITLE
Add automation workflows and manifest tooling

### DIFF
--- a/.github/workflows/daily-export.yml
+++ b/.github/workflows/daily-export.yml
@@ -1,0 +1,76 @@
+name: Daily Export
+
+# Secrets: nenhuma credencial adicional é necessária; o workflow utiliza apenas o GITHUB_TOKEN padrão.
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  export:
+    name: Run daily extraction and export
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install project
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Run incremental extract
+        run: baliza extract --lookback-days=3 --duckdb baliza.duckdb --dataset baliza_raw
+
+      - name: Export current month parquet snapshot
+        run: |
+          python scripts/export_parquet.py \
+            contratos \
+            --duckdb baliza.duckdb \
+            --dataset baliza_raw \
+            --output-dir data/contratos \
+            --date-col dataPublicacaoPncp \
+            --fallback-date-col dataAtualizacao \
+            --current-month
+
+      - name: Detect exported partition
+        id: partition
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          base = Path('data/contratos')
+          partitions = []
+          for year_dir in base.glob('ano=*'):
+            year = year_dir.name.split('=', 1)[1]
+            for month_dir in year_dir.glob('mes=*'):
+              month = month_dir.name.split('=', 1)[1]
+              partitions.append((year, month))
+
+          if not partitions:
+            raise SystemExit('No exported partitions found.')
+
+          partitions.sort()
+          year, month = partitions[-1]
+          with open('$GITHUB_OUTPUT', 'a', encoding='utf-8') as fh:
+            fh.write(f"year={year}\n")
+            fh.write(f"month={month}\n")
+          PY
+
+      - name: Package artifacts
+        run: |
+          tar -czf baliza-daily-${{ steps.partition.outputs.year }}-${{ steps.partition.outputs.month }}.tar.gz \
+            baliza.duckdb \
+            data/contratos/ano=${{ steps.partition.outputs.year }}/mes=${{ steps.partition.outputs.month }}
+
+      - name: Upload daily artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: baliza-daily-${{ steps.partition.outputs.year }}-${{ steps.partition.outputs.month }}
+          path: baliza-daily-${{ steps.partition.outputs.year }}-${{ steps.partition.outputs.month }}.tar.gz

--- a/.github/workflows/daily-export.yml
+++ b/.github/workflows/daily-export.yml
@@ -56,7 +56,7 @@ jobs:
           if not partitions:
             raise SystemExit('No exported partitions found.')
 
-          partitions.sort()
+          partitions.sort(key=lambda pair: (int(pair[0]), int(pair[1])))
           year, month = partitions[-1]
           with open('$GITHUB_OUTPUT', 'a', encoding='utf-8') as fh:
             fh.write(f"year={year}\n")

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -1,0 +1,117 @@
+name: Monthly Release
+
+# Secrets: o workflow usa apenas o GITHUB_TOKEN padrão para criar publicações.
+on:
+  schedule:
+    - cron: '0 4 1 * *'
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Build and publish monthly dataset
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install project
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Resolve reference month
+        id: reference
+        run: |
+          python - <<'PY'
+          from datetime import datetime, timedelta, timezone
+
+          today = datetime.now(timezone.utc).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+          previous_month = today - timedelta(days=1)
+          reference = previous_month.strftime('%Y-%m')
+          year, month = reference.split('-')
+
+          with open('$GITHUB_OUTPUT', 'a', encoding='utf-8') as fh:
+            fh.write(f"reference={reference}\n")
+            fh.write(f"year={year}\n")
+            fh.write(f"month={month}\n")
+          PY
+
+      - name: Backfill previous month
+        run: |
+          baliza backfill ${{ steps.reference.outputs.reference }} ${{ steps.reference.outputs.reference }} \
+            --duckdb baliza.duckdb \
+            --dataset baliza_raw
+
+      - name: Export parquet for reference month
+        run: |
+          python scripts/export_parquet.py \
+            contratos \
+            --duckdb baliza.duckdb \
+            --dataset baliza_raw \
+            --output-dir data/contratos \
+            --date-col dataPublicacaoPncp \
+            --fallback-date-col dataAtualizacao \
+            --target-month ${{ steps.reference.outputs.reference }}
+
+      - name: Build manifest
+        id: manifest
+        env:
+          MANIFEST_DIR: data/contratos/ano=${{ steps.reference.outputs.year }}/mes=${{ steps.reference.outputs.month }}
+          DATASET_VERSION: ${{ steps.reference.outputs.reference }}
+        run: |
+          python scripts/build_manifest.py \
+            --parquet-dir "$MANIFEST_DIR" \
+            --dataset-version "$DATASET_VERSION"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          manifest_path = Path(os.environ['MANIFEST_DIR']) / 'manifest.json'
+          data = json.loads(manifest_path.read_text(encoding='utf-8'))
+          body = (
+              f"Dataset version: {data['dataset_version']}\n"
+              f"Row count: {data['row_count']}\n"
+              f"Interval: {data['min_data']} → {data['max_data']}\n"
+          )
+          with open('$GITHUB_OUTPUT', 'a', encoding='utf-8') as fh:
+            fh.write('manifest_path=' + str(manifest_path) + '\n')
+            fh.write('release_body<<EOF\n')
+            fh.write(body)
+            fh.write('EOF\n')
+          PY
+
+      - name: Package monthly snapshot
+        env:
+          MANIFEST_DIR: data/contratos/ano=${{ steps.reference.outputs.year }}/mes=${{ steps.reference.outputs.month }}
+          REFERENCE: ${{ steps.reference.outputs.reference }}
+        run: |
+          tar -czf contratos-${REFERENCE}.tar.gz "$MANIFEST_DIR"
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.reference.outputs.reference }}
+          release_name: Baliza contratos ${{ steps.reference.outputs.reference }}
+          body: ${{ steps.manifest.outputs.release_body }}
+          draft: false
+          prerelease: false
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: contratos-${{ steps.reference.outputs.reference }}.tar.gz
+          asset_name: contratos-${{ steps.reference.outputs.reference }}.tar.gz
+          asset_content_type: application/gzip

--- a/scripts/build_manifest.py
+++ b/scripts/build_manifest.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Generate a manifest.json summary for exported Parquet datasets."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import duckdb
+
+
+def _format_datetime(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat()
+    if hasattr(value, "isoformat"):
+        return value.isoformat()  # type: ignore[return-value]
+    return str(value)
+
+
+def _detect_date_columns(con: duckdb.DuckDBPyConnection, glob: str) -> List[str]:
+    description = con.execute(
+        "DESCRIBE SELECT * FROM read_parquet(?);",
+        [glob],
+    ).fetchall()
+    columns = {row[0]: row[1] for row in description}
+
+    preferred = [
+        column
+        for column in ("dataPublicacaoPncp", "dataAtualizacao")
+        if column in columns
+    ]
+    if preferred:
+        return preferred
+
+    fallbacks = [
+        name
+        for name, dtype in columns.items()
+        if "DATE" in dtype.upper() or "TIMESTAMP" in dtype.upper()
+    ]
+    return sorted(fallbacks)
+
+
+def _compute_sha256(files: Iterable[Path]) -> str:
+    digest = hashlib.sha256()
+    for file_path in files:
+        with file_path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_directory(path: Path) -> Tuple[Path, List[Path]]:
+    if not path.exists():
+        raise FileNotFoundError(f"Parquet directory not found: {path}")
+    if not path.is_dir():
+        raise NotADirectoryError(f"Expected a directory with Parquet files: {path}")
+
+    files = sorted(path.rglob("*.parquet"))
+    if not files:
+        raise FileNotFoundError(f"No Parquet files found under {path}")
+    return path, files
+
+
+def build_manifest(parquet_dir: Path, dataset_version: str) -> Path:
+    directory, files = _validate_directory(parquet_dir)
+    glob = str(directory / "**/*.parquet")
+    con = duckdb.connect()
+
+    row_count = con.execute(
+        "SELECT COUNT(*) FROM read_parquet(?);",
+        [glob],
+    ).fetchone()[0]
+
+    date_columns = _detect_date_columns(con, glob)
+    min_data: str | None = None
+    max_data: str | None = None
+    if date_columns:
+        if len(date_columns) == 1:
+            expression = date_columns[0]
+        else:
+            expression = "COALESCE(" + ", ".join(date_columns) + ")"
+
+        min_value, max_value = con.execute(
+            f"SELECT MIN({expression}), MAX({expression}) FROM read_parquet(?);",
+            [glob],
+        ).fetchone()
+        min_data = _format_datetime(min_value)
+        max_data = _format_datetime(max_value)
+
+    checksum = _compute_sha256(files)
+
+    manifest = {
+        "dataset_version": dataset_version,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "row_count": int(row_count),
+        "min_data": min_data,
+        "max_data": max_data,
+        "sha256": checksum,
+        "parquet_files": [str(path.relative_to(directory)) for path in files],
+    }
+
+    manifest_path = directory / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return manifest_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build a manifest for Parquet exports")
+    parser.add_argument("--parquet-dir", required=True, type=Path, help="Directory containing Parquet files")
+    parser.add_argument("--dataset-version", required=True, help="Semantic version or tag for the export batch")
+    args = parser.parse_args()
+
+    manifest_path = build_manifest(args.parquet_dir, args.dataset_version)
+    print(f"Manifest written to {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_parquet.py
+++ b/scripts/export_parquet.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Helper utility to standardize Baliza Parquet exports."""
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+
+def _build_command(args: argparse.Namespace) -> List[str]:
+    command = [
+        "baliza",
+        "export",
+        args.table,
+        "--duckdb",
+        str(args.duckdb),
+        "--dataset",
+        args.dataset,
+        "--out",
+        str(args.output_dir),
+    ]
+
+    if args.date_col:
+        command.extend(["--date-col", args.date_col])
+    if args.fallback_date_col:
+        command.extend(["--fallback-date-col", args.fallback_date_col])
+
+    if args.current_month:
+        command.append("--current-month")
+    if args.target_month:
+        command.extend(["--target-month", args.target_month])
+
+    return command
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Wrapper around `baliza export` ensuring consistent options "
+            "across automation workflows."
+        )
+    )
+    parser.add_argument("table", help="Target table name for the export command")
+    parser.add_argument(
+        "--duckdb",
+        default=Path("baliza.duckdb"),
+        type=Path,
+        help="Path to the DuckDB database file",
+    )
+    parser.add_argument(
+        "--dataset",
+        default="baliza_raw",
+        help="Dataset (schema) name inside DuckDB",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=Path("data") / "contratos",
+        type=Path,
+        help="Directory that will receive the exported Parquet files",
+    )
+    parser.add_argument(
+        "--date-col",
+        default="dataPublicacaoPncp",
+        help="Primary date column used to partition exports",
+    )
+    parser.add_argument(
+        "--fallback-date-col",
+        default="dataAtualizacao",
+        help="Secondary date column used when the primary date is missing",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--current-month",
+        action="store_true",
+        help="Export only the files for the current UTC month",
+    )
+    group.add_argument(
+        "--target-month",
+        help="Export data for a specific YYYY-MM month",
+    )
+
+    parsed = parser.parse_args()
+    command = _build_command(parsed)
+
+    print("Executing:", " ".join(shlex.quote(part) for part in command))
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError as exc:
+        return exc.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a daily export workflow that extracts, exports and uploads the latest partition artifact
- create a shared export wrapper and manifest builder script for parquet datasets
- publish a monthly release workflow that backfills the previous month, generates metadata and uploads a release asset

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cab6d6326883258c3b98a0f64105aa