### PR TITLE
Alinha documentação e parâmetros da API de Consultas

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,21 @@ controle.
 ## Visão geral
 
 - **Pipeline declarativo com [dlt](https://dlthub.com/):** a configuração YAML
-  em `src/baliza/config/pncp.yml` descreve como chamar o endpoint
-  `GET /v1/contratos` do PNCP, aplicando paginação, incremental por
-  `dataAtualizacao` e regras de limpeza.
+  em `src/baliza/config/pncp.yml` descreve como chamar o endpoint público
+  `GET /v1/contratos` do PNCP, paginando com `tamanhoPagina=500` e janelas de
+  `dataInicial`/`dataFinal` no formato `AAAAMMDD`.
 - **CLI enxuta:** o comando `baliza extract` executa o pipeline incremental e
   `baliza backfill` permite processar janelas mensais de forma determinística.
 - **Fluxo bronze → parquet:** `baliza extract` mantém o histórico bruto no
   DuckDB (`baliza.duckdb`) enquanto `baliza export` gera arquivos Parquet
   particionados por ano/mês em `data/<recurso>/ano=YYYY/mes=MM/*.parquet`.
 - **Entrega analítica imediata:** os dados são gravados no arquivo
-  `baliza.duckdb` (dataset `baliza_raw`) com *merge* incremental baseado em
-  chave primária (`numeroControlePNCP`).
+  `baliza.duckdb` (dataset `baliza_raw`) com *merge* incremental baseado na
+  chave oficial `numeroControlePNCP` (string completa `CNPJ-2-sequencial/ano`).
+- **Manifesto de cobertura:** cada página coletada gera metadados com
+  `totalPaginas` reportado, hashes de `numeroControlePNCP` e status das janelas.
+  O comando `baliza verify` audita o manifesto chamando apenas a primeira página
+  de cada janela e marcando lacunas ou crescimento tardio informado pela API.
 - **Documentação de arquitetura:** os arquivos em `docs/` registram decisões e
   próximos passos para evolução do pipeline.
 
@@ -45,8 +49,9 @@ uv run baliza export --table contratos --out data/contratos
 ```
 
 O comando `baliza extract` cria (ou atualiza) o arquivo `baliza.duckdb` no
-diretório atual. Por padrão, a execução repete os últimos três dias para
-garantir que registros atualizados sejam recapturados com segurança. Em seguida,
+diretório atual. Por padrão, a execução retrocede alguns dias (lookback) e abre
+janelas diárias `dataInicial`/`dataFinal`, enviando requisições paginadas com
+`tamanhoPagina=500` até que `totalPaginas` seja percorrido. Em seguida,
 `baliza export` lê a tabela do DuckDB e escreve os dados como Parquet
 particionado (ano/mês) no diretório informado (`data/contratos`, no exemplo).
 
@@ -89,10 +94,17 @@ print(contratos.head())
 A configuração declarativa do pipeline fica em `src/baliza/config/pncp.yml`.
 Nela é possível ajustar:
 
-- Parâmetros padrão de paginação (`tamanhoPagina`, `pagina`).
+- Parâmetros padrão de paginação (`tamanhoPagina=500`, `pagina=1`).
 - Datas inicial/final utilizadas pelo incremental (`initial_value`,
-  `lookback_days` via CLI).
-- Mapeamento de campos retornados (`data_selector`, chave primária etc.).
+  `lookback_days` via CLI) sempre convertidas para `AAAAMMDD`.
+- Mapeamento da resposta padronizada (`data`, `totalPaginas`, etc.),
+  preservando `numeroControlePNCP` como chave primária textual.
+
+A API pública do PNCP fica em `https://pncp.gov.br/api/consulta` e retorna um
+envelope com `data`, `totalRegistros`, `totalPaginas`, `numeroPagina`,
+`paginasRestantes` e `empty`. A configuração do Baliza consome esses campos,
+tratando respostas `204 No Content` como janelas vazias (sem erro) e sempre
+respeitando `tamanhoPagina ≤ 500`.
 
 Para usar uma configuração customizada, forneça o caminho via `--config`:
 
@@ -119,19 +131,46 @@ Opções úteis:
 
 Use `uv run baliza --help` para ver todos os parâmetros suportados.
 
+### Política incremental
+
+- **Lookback diário:** toda execução de `baliza extract` retrocede (por padrão)
+  três dias em relação ao cursor salvo, abrindo janelas `dataInicial`/`dataFinal`
+  nesse intervalo. Como a API pública não possui filtro por atualização global,
+  essa redundância garante captura de retificações recentes.
+- **Backfill mensal:** o comando `baliza backfill <AAAA-MM> <AAAA-MM>` reexecuta
+  meses inteiros em sequência, reaproveitando o mesmo DuckDB. Isso cobre
+  retificações tardias e consolida históricos.
+- **Manifesto de cobertura:** além de usar `write_disposition=merge`, o Baliza
+  registra `totalPaginas`, contagem de itens e hashes por página para auditar
+  janelas e identificar páginas ausentes.
+- **Preparado para futuras integrações:** o desenho atual separa a configuração
+  do cliente, permitindo plugar a API autenticada (Manual de Integração) em um
+  modo alternativo caso seja necessário aproveitar filtros por
+  `dataAtualizacaoGlobal` no futuro.
+
+### Exportação analítica
+
+- **Bronze no DuckDB:** os dados brutos permanecem em `baliza.duckdb` dentro do
+  dataset `baliza_raw`.
+- **Parquet particionado:** `baliza export` gera `data/<recurso>/ano=YYYY/mes=MM/*.parquet`
+  a partir de uma coluna de data do domínio (no caso de contratos, a data de
+  publicação no PNCP; na ausência, usa-se a melhor proxy disponível e ela é
+  documentada na CLI).
+- **Consumo incremental:** os arquivos Parquet seguem a mesma chave primária
+  utilizada no DuckDB, preservando a máscara oficial do `numeroControlePNCP`.
+
 ## Detecção de Gaps
 
 O plano descrito em [`docs/extraction_resumability_plan.md`](docs/extraction_resumability_plan.md)
 foi implementado a partir da criação de um manifesto de cobertura em
-`baliza_state.cobertura` e `baliza_state.janelas`. A cada página coletada o
-hash ordenado dos `numeroControlePNCP` é registrado, permitindo detectar
-alterações posteriores e correlacionar as janelas incrementais (com *lookback*
-diário) com o histórico processado. O comando `baliza verify` usa esse
-manifesto para chamar novamente o endpoint e identificar janelas não
-processadas, páginas ausentes e sequências suspeitas (`--sequencia` ativa a
-auditoria de `sequencialCompra`/`sequencialContrato`). O relatório retornado em
-JSON lista lacunas abertas, status consolidados e páginas que precisam ser
-reextraídas.
+`baliza_state.cobertura` e `baliza_state.janelas`. Cada página registrada guarda
+`pagina`, `total_paginas_observado`, hash dos `numeroControlePNCP` e momento da
+captura. O comando `baliza verify` chama apenas a página 1 de cada janela para
+comparar `totalPaginas` informado pela API com o manifesto, marcando janelas
+`ok`, `incompleto`, `nao_processado` ou `suspeito` (quando o hash diverge). O
+relatório em JSON lista lacunas abertas, páginas pendentes e quaisquer
+sequências suspeitas (`--sequencia` ativa a auditoria de
+`sequencialCompra`/`sequencialContrato`).
 
 ## Estrutura do repositório
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,10 +7,12 @@ houver base técnica e capacidade para sustentá-las.
 
 ## Estado atual (Q1 2025)
 
-- ✅ **Cobertura:** apenas o endpoint `GET /v1/contratos` está habilitado e é
-  executado através da configuração declarativa em `src/baliza/config/pncp.yml`.
+- ✅ **Cobertura:** apenas o endpoint público `GET /v1/contratos` está habilitado
+  e é executado através da configuração declarativa em `src/baliza/config/pncp.yml`.
 - ✅ **Execução:** os comandos `baliza extract` e `baliza backfill` operam sobre
-  um pipeline `dlt` que grava resultados em DuckDB via `write_disposition=merge`.
+  um pipeline `dlt` que abre janelas `dataInicial`/`dataFinal` (formato
+  `AAAAMMDD`), pagina com `tamanhoPagina=500` e grava resultados em DuckDB via
+  `write_disposition=merge`.
 - ⚠️ **Limitações conhecidas:**
   - o pipeline é *stateless* — a janela incremental depende apenas do
     *lookback* informado pelo usuário;
@@ -23,8 +25,8 @@ houver base técnica e capacidade para sustentá-las.
    - Implementar o `StateManager` e o `GapDetector` descritos em
      `docs/extraction_resumability_plan.md`, conectando-os diretamente ao
      pipeline declarativo existente.
-   - Registrar o maior `dataAtualizacao` processado e reaproveitar essa
-     informação em novas execuções.
+   - Consolidar o manifesto de janelas (`totalPaginas`, hashes, status) como
+     fonte de verdade para retomada e auditoria de cobertura.
 2. **Observabilidade e resiliência**
    - Adicionar logs estruturados com contagem de páginas, tempo total e totais
      de linhas processadas.

--- a/docs/dlt-migration-analysis.md
+++ b/docs/dlt-migration-analysis.md
@@ -6,8 +6,9 @@ Atualizado em: 28 de julho de 2025
 
 A migração do Baliza para o ecossistema **dlt** está funcional para o cenário
 principal (extração do endpoint `contratos` direto para DuckDB). A CLI `baliza`
-utiliza o pipeline declarativo definido em `src/baliza/config/pncp.yml`, e o
-incremental por `dataAtualizacao` está operando com *lookback* configurável.
+utiliza o pipeline declarativo definido em `src/baliza/config/pncp.yml`, que
+abre janelas `dataInicial`/`dataFinal` (`AAAAMMDD`) com *lookback* configurável
+e respeita a paginação máxima (`tamanhoPagina=500`).
 
 Ainda existem componentes legados no repositório e funcionalidades planejadas
 (deduplicação de requisições, múltiplos endpoints) que não foram concluídas.
@@ -50,8 +51,9 @@ migração.
 
 - **Destino:** DuckDB local via `dlt.destinations.duckdb`, garantindo portabilidade
   e facilidade de análise posterior.
-- **Incremental:** Uso de `cursor_path = dataAtualizacao` com `lookback` aplicado
-  em tempo de execução para evitar perdas por atrasos de publicação.
+- **Incremental:** Uso de janelas `dataInicial`/`dataFinal` convertidas via
+  `to_pncp_window`, com *lookback* aplicado em tempo de execução e manifesto de
+  páginas (`totalPaginas`, hashes) para auditoria.
 - **Configuração:** Estratégia "configuration over code" — o comportamento do
   pipeline deve residir em YAML para facilitar auditoria e ajustes por analistas.
 

--- a/docs/endpoint_extraction_strategy.md
+++ b/docs/endpoint_extraction_strategy.md
@@ -8,7 +8,8 @@ processo incremental, garantindo qualidade e rastreabilidade a cada expansão.
 
 - **Endpoint ativo:** `GET /v1/contratos`
   - Paginador `page_number` com 500 itens por página.
-  - Incremental baseado em `dataAtualizacao` com *lookback* configurável.
+  - Incremental baseado em janelas `dataInicial`/`dataFinal` (`AAAAMMDD`) com
+    *lookback* configurável e manifesto de cobertura (`totalPaginas`, hashes).
   - Escrita via `write_disposition = merge` em DuckDB.
 - **Estado do código:** o pipeline declarativo em `config/pncp.yml` possui apenas
   este recurso habilitado.
@@ -19,8 +20,10 @@ processo incremental, garantindo qualidade e rastreabilidade a cada expansão.
    YAML declarativo.
 2. **Uma chave primária por recurso** — definir `primary_key` claro para garantir
    merges consistentes.
-3. **Cursor validado** — confirmar se o endpoint possui campo de atualização
-   confiável antes de habilitar incremental.
+3. **Janela válida** — confirmar quais parâmetros de data cada endpoint suporta
+   (publicação, vigência, etc.) e como gerar janelas confiáveis antes de habilitar
+   incremental. Quando o endpoint expuser `totalPaginas`, ele deve alimentar o
+   manifesto de cobertura.
 4. **Testes obrigatórios** — cada novo endpoint deve incluir teste de integração
    com respostas mockadas.
 

--- a/docs/extraction_resumability_plan.md
+++ b/docs/extraction_resumability_plan.md
@@ -2,11 +2,15 @@
 
 ## Contexto
 
-O pipeline atual do Baliza utiliza dlt com incremental por `dataAtualizacao` e
-uma janela de *lookback* configurável. Essa abordagem garante idempotência no
-nível de dados (linhas duplicadas são descartadas pelo `write_disposition =
-merge`), porém ainda não evita chamadas HTTP redundantes nem permite retomar uma
-execução exatamente do ponto de falha.
+O pipeline atual do Baliza utiliza dlt com janelas explícitas de
+`dataInicial`/`dataFinal` (formato `AAAAMMDD`) e um *lookback* configurável. A
+cada execução, as janelas são percorridas página a página com
+`tamanhoPagina=500`, registrando `totalPaginas` e hash dos
+`numeroControlePNCP` em um manifesto (`baliza_state.cobertura`). Essa abordagem
+garante idempotência no nível de dados (linhas duplicadas são descartadas pelo
+`write_disposition = merge`) e oferece visibilidade sobre o que foi coletado,
+porém ainda não evita chamadas HTTP redundantes nem permite retomar uma execução
+exatamente do ponto de falha.
 
 Este documento detalha como evoluir para uma extração verdadeiramente
 resumível, minimizando requisições repetidas.
@@ -69,7 +73,8 @@ flowchart TD
 4. **Persistir estado** após cada execução bem-sucedida:
    - Atualizar `completed` com a janela processada (mesclando intervalos
      sobrepostos).
-   - Atualizar `cursor` com o maior valor retornado em `dataAtualizacao`.
+   - Armazenar o manifesto de páginas capturado (`totalPaginas`, hashes) para
+     detectar lacunas e crescimentos tardios no `baliza verify`.
 5. **Relatar progresso** ao usuário com logs e resumo final.
 
 ## Plano de implementação

--- a/src/baliza/cli.py
+++ b/src/baliza/cli.py
@@ -29,6 +29,7 @@ from .state import CoverageTracker
 
 
 from .utils import export_parquet
+from .utils.dates import to_pncp_window
 
 app = typer.Typer(help="Declarative PNCP pipeline runner")
 
@@ -75,10 +76,10 @@ def _parse_day(value: Optional[str], param_name: str) -> Optional[datetime]:
         raise typer.BadParameter(f"{param_name} must follow YYYY-MM-DD format") from exc
 
 
-def _isoformat_utc(value: Optional[datetime]) -> Optional[str]:
+def _pncp_date_param(value: Optional[datetime]) -> Optional[str]:
     if value is None:
         return None
-    return value.replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+    return to_pncp_window(value)
 
 
 def _filter_dict_none(values: Dict[str, Any]) -> Dict[str, Any]:
@@ -275,14 +276,17 @@ def verify(
                 inicio = entry.get("janela_inicio")
                 fim = entry.get("janela_fim")
                 if inicio:
-                    params["dataInicial"] = _isoformat_utc(inicio)
+                    params["dataInicial"] = _pncp_date_param(inicio)
                 if fim:
-                    params["dataFinal"] = _isoformat_utc(fim)
+                    params["dataFinal"] = _pncp_date_param(fim)
                 params = _filter_dict_none(params)
 
                 response = client.get(endpoint_url, params=params)
-                response.raise_for_status()
-                payload = response.json()
+                if response.status_code == 204:
+                    payload: Dict[str, Any] = {"data": [], "totalPaginas": 0}
+                else:
+                    response.raise_for_status()
+                    payload = response.json()
                 recorded_pages = set(entry["recorded_pages"])
                 fallback_total = entry["max_total"] or (max(recorded_pages) if recorded_pages else 0)
                 atual_total = _extract_total_paginas(payload, fallback_total)
@@ -313,8 +317,11 @@ def verify(
                         sample_params = dict(params)
                         sample_params["pagina"] = sample_page
                         sample_response = client.get(endpoint_url, params=sample_params)
-                        sample_response.raise_for_status()
-                        sample_payload = sample_response.json()
+                        if sample_response.status_code == 204:
+                            sample_payload: Dict[str, Any] = {"data": []}
+                        else:
+                            sample_response.raise_for_status()
+                            sample_payload = sample_response.json()
                         registros = (
                             sample_payload.get("data")
                             or sample_payload.get("items")

--- a/src/baliza/pipelines/pncp.py
+++ b/src/baliza/pipelines/pncp.py
@@ -19,6 +19,7 @@ ConfigPath = Union[str, Path, None]
 DEFAULT_PIPELINE_NAME = "baliza_pncp"
 BACKFILL_PIPELINE_NAME = "baliza_pncp_backfill"
 SECONDS_PER_DAY = 24 * 60 * 60
+MAX_PAGE_SIZE = 500
 
 
 def default_config_path() -> Path:
@@ -93,6 +94,10 @@ def _apply_incremental_overrides(
         incremental = endpoint.get("incremental") if isinstance(endpoint, dict) else None
         if not isinstance(incremental, dict):
             continue
+
+        params = endpoint.get("params") if isinstance(endpoint, dict) else None
+        if isinstance(params, dict):
+            _clamp_page_params(params)
 
         if lookback_days is not None:
             if lookback_days < 0:
@@ -248,3 +253,25 @@ def run_pncp(
     finally:
         tracker.close()
     return pipeline, run_info
+def _clamp_page_params(params: Dict[str, Any], *, limit: int = MAX_PAGE_SIZE) -> None:
+    if not isinstance(params, dict):
+        return
+
+    if params.get("pagina") is not None:
+        try:
+            pagina = int(params["pagina"])
+        except (TypeError, ValueError):  # pragma: no cover - defensive guard
+            pagina = 1
+        params["pagina"] = max(1, pagina)
+
+    page_size = params.get("tamanhoPagina")
+    if page_size is None:
+        return
+
+    try:
+        size_int = int(page_size)
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        return
+
+    clamped = max(1, min(size_int, limit))
+    params["tamanhoPagina"] = clamped


### PR DESCRIPTION
## Summary
- Atualiza README e guias de arquitetura para refletir o uso de janelas `dataInicial`/`dataFinal`, manifesto de cobertura e política de lookback/backfill.
- Ajusta a verificação da CLI para enviar datas compactas (`AAAAMMDD`) e tratar respostas 204 como janelas vazias.
- Garante limite de `tamanhoPagina` e `pagina` ao carregar a configuração declarativa do PNCP.

## Testing
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'xxhash')*

------
https://chatgpt.com/codex/tasks/task_e_68cadf8b7cac8325bbd9488970df13c8