### PR TITLE
Handle optional HTTP and hashing dependencies

### DIFF
--- a/debug_api.py
+++ b/debug_api.py
@@ -7,42 +7,43 @@ import requests
 import json
 from datetime import datetime
 
+
 def test_pncp_endpoint(endpoint_path, params):
     """Test a PNCP API endpoint with given parameters"""
     base_url = "https://pncp.gov.br/api/consulta"
     url = f"{base_url}{endpoint_path}"
-    
+
     headers = {
         "Accept": "application/json",
-        "User-Agent": "Baliza/2.0.0-dev Debug Script"
+        "User-Agent": "Baliza/2.0.0-dev Debug Script",
     }
-    
+
     print(f"🔍 Testing: {url}")
     print(f"📋 Parameters: {params}")
     print(f"🕐 Time: {datetime.now()}")
     print("-" * 80)
-    
+
     try:
         response = requests.get(url, params=params, headers=headers, timeout=30)
-        
+
         print(f"📊 Status Code: {response.status_code}")
         print(f"📏 Content Length: {len(response.content)}")
         print(f"🏷️  Content Type: {response.headers.get('content-type', 'unknown')}")
-        
+
         if response.status_code == 204:
             print("✅ 204 No Content - Empty result (normal for no data)")
             return {"status": "empty", "data": []}
-        
+
         if response.status_code != 200:
             print(f"❌ HTTP Error: {response.status_code}")
             print(f"Response: {response.text[:500]}")
             return {"status": "error", "error": f"HTTP {response.status_code}"}
-        
+
         # Try to parse JSON
         try:
             data = response.json()
             print("✅ Valid JSON received")
-            
+
             if isinstance(data, dict):
                 if "data" in data:
                     print(f"📈 Data array length: {len(data['data'])}")
@@ -50,14 +51,18 @@ def test_pncp_endpoint(endpoint_path, params):
                         print(f"📄 Total pages: {data['totalPaginas']}")
                 else:
                     print(f"🔑 JSON keys: {list(data.keys())}")
-            
+
             return {"status": "success", "data": data}
-            
+
         except json.JSONDecodeError as e:
             print(f"❌ JSON Parse Error: {e}")
             print(f"Raw content (first 200 chars): {response.text[:200]}")
-            return {"status": "json_error", "error": str(e), "content": response.text[:500]}
-            
+            return {
+                "status": "json_error",
+                "error": str(e),
+                "content": response.text[:500],
+            }
+
     except requests.exceptions.Timeout:
         print("⏰ Request timeout (30s)")
         return {"status": "timeout"}
@@ -65,13 +70,14 @@ def test_pncp_endpoint(endpoint_path, params):
         print(f"🌐 Network error: {e}")
         return {"status": "network_error", "error": str(e)}
 
+
 def main():
     """Test various PNCP endpoint scenarios"""
-    
+
     print("=" * 80)
     print("🚀 PNCP API Debug Script")
     print("=" * 80)
-    
+
     # Test 1: contratacoes_publicacao with modalidade 1 (January 2021)
     print("\n🧪 Test 1: contratacoes_publicacao with modalidade 1 (Jan 2021)")
     result1 = test_pncp_endpoint(
@@ -81,10 +87,10 @@ def main():
             "pagina": 1,
             "dataInicial": "20210101",
             "dataFinal": "20210131",
-            "codigoModalidadeContratacao": 1
-        }
+            "codigoModalidadeContratacao": 1,
+        },
     )
-    
+
     # Test 2: Try a more recent date (December 2024)
     print("\n🧪 Test 2: contratacoes_publicacao with modalidade 1 (Dec 2024)")
     result2 = test_pncp_endpoint(
@@ -94,10 +100,10 @@ def main():
             "pagina": 1,
             "dataInicial": "20241201",
             "dataFinal": "20241231",
-            "codigoModalidadeContratacao": 1
-        }
+            "codigoModalidadeContratacao": 1,
+        },
     )
-    
+
     # Test 3: Try different modalidade (6 = Pregão Eletrônico)
     print("\n🧪 Test 3: contratacoes_publicacao with modalidade 6 (Dec 2024)")
     result3 = test_pncp_endpoint(
@@ -107,10 +113,10 @@ def main():
             "pagina": 1,
             "dataInicial": "20241201",
             "dataFinal": "20241231",
-            "codigoModalidadeContratacao": 6
-        }
+            "codigoModalidadeContratacao": 6,
+        },
     )
-    
+
     # Test 4: Try contratos endpoint (no modalidade required)
     print("\n🧪 Test 4: contratos endpoint (no modalidade - Dec 2024)")
     result4 = test_pncp_endpoint(
@@ -119,10 +125,10 @@ def main():
             "tamanhoPagina": 500,
             "pagina": 1,
             "dataInicial": "20241201",
-            "dataFinal": "20241231"
-        }
+            "dataFinal": "20241231",
+        },
     )
-    
+
     # Test 5: Check if the API has data for recent dates
     print("\n🧪 Test 5: contratacoes_publicacao with modalidade 6 (Jan 2025)")
     result5 = test_pncp_endpoint(
@@ -132,14 +138,14 @@ def main():
             "pagina": 1,
             "dataInicial": "20250101",
             "dataFinal": "20250131",
-            "codigoModalidadeContratacao": 6
-        }
+            "codigoModalidadeContratacao": 6,
+        },
     )
-    
+
     print("\n" + "=" * 80)
     print("📊 SUMMARY")
     print("=" * 80)
-    
+
     tests = [
         ("contratacoes_publicacao modalidade=1 (Jan 2021)", result1),
         ("contratacoes_publicacao modalidade=1 (Dec 2024)", result2),
@@ -147,22 +153,29 @@ def main():
         ("contratos (no modalidade - Dec 2024)", result4),
         ("contratacoes_publicacao modalidade=6 (Jan 2025)", result5),
     ]
-    
+
     for name, result in tests:
         status = result.get("status", "unknown")
         if status == "success":
-            data_count = len(result["data"].get("data", [])) if isinstance(result["data"], dict) else 0
+            data_count = (
+                len(result["data"].get("data", []))
+                if isinstance(result["data"], dict)
+                else 0
+            )
             print(f"✅ {name}: SUCCESS ({data_count} records)")
         elif status == "empty":
             print(f"📭 {name}: EMPTY (204 No Content)")
         else:
             print(f"❌ {name}: {status.upper()}")
-    
+
     print("\n💡 Recommendations:")
-    print("- If all tests return 204 (No Content), the API may not have data for those date ranges")
+    print(
+        "- If all tests return 204 (No Content), the API may not have data for those date ranges"
+    )
     print("- If JSON errors occur, there might be API response format issues")
     print("- Try different date ranges or modalidades to find data")
     print("- Consider checking PNCP documentation for data availability periods")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/build_manifest.py
+++ b/scripts/build_manifest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Generate a manifest.json summary for exported Parquet datasets."""
+
 from __future__ import annotations
 
 import argparse
@@ -107,14 +108,25 @@ def build_manifest(parquet_dir: Path, dataset_version: str) -> Path:
     }
 
     manifest_path = directory / "manifest.json"
-    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
     return manifest_path
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Build a manifest for Parquet exports")
-    parser.add_argument("--parquet-dir", required=True, type=Path, help="Directory containing Parquet files")
-    parser.add_argument("--dataset-version", required=True, help="Semantic version or tag for the export batch")
+    parser.add_argument(
+        "--parquet-dir",
+        required=True,
+        type=Path,
+        help="Directory containing Parquet files",
+    )
+    parser.add_argument(
+        "--dataset-version",
+        required=True,
+        help="Semantic version or tag for the export batch",
+    )
     args = parser.parse_args()
 
     manifest_path = build_manifest(args.parquet_dir, args.dataset_version)

--- a/scripts/discover_pncp_parameter_values.py
+++ b/scripts/discover_pncp_parameter_values.py
@@ -9,142 +9,151 @@ from urllib.parse import urljoin
 
 BASE_URL = "https://pncp.gov.br/api/consulta/v1/"
 
+
 def test_parameter_values(endpoint, base_params, param_name, test_values):
     """Test different parameter values and track successful ones"""
-    
-    print(f"\n{'='*60}")
+
+    print(f"\n{'=' * 60}")
     print(f"Testing parameter '{param_name}' for endpoint: {endpoint}")
-    print(f"{'='*60}")
-    
+    print(f"{'=' * 60}")
+
     working_values = []
-    
+
     for i, value in enumerate(test_values, 1):
         params = base_params.copy()
         params[param_name] = value
-        
+
         url = urljoin(BASE_URL, endpoint)
         print(f"\n{i}. Testing {param_name}={value}")
-        
+
         try:
             response = requests.get(url, params=params, timeout=30)
             print(f"   Status: {response.status_code}")
-            
+
             if response.status_code == 200:
                 try:
                     data = response.json()
-                    if isinstance(data, dict) and 'data' in data:
-                        item_count = len(data.get('data', []))
-                        total_records = data.get('totalRegistros', 0)
-                        print(f"   ✅ SUCCESS: {item_count} items returned, {total_records} total records")
-                        working_values.append({
-                            'value': value,
-                            'item_count': item_count,
-                            'total_records': total_records
-                        })
+                    if isinstance(data, dict) and "data" in data:
+                        item_count = len(data.get("data", []))
+                        total_records = data.get("totalRegistros", 0)
+                        print(
+                            f"   ✅ SUCCESS: {item_count} items returned, {total_records} total records"
+                        )
+                        working_values.append(
+                            {
+                                "value": value,
+                                "item_count": item_count,
+                                "total_records": total_records,
+                            }
+                        )
                     else:
                         print("   ✅ SUCCESS: Valid response structure")
-                        working_values.append({'value': value, 'item_count': 0, 'total_records': 0})
-                        
+                        working_values.append(
+                            {"value": value, "item_count": 0, "total_records": 0}
+                        )
+
                 except json.JSONDecodeError:
                     print("   ⚠️  SUCCESS but no JSON")
-                    
+
             elif response.status_code == 204:
                 print("   ✅ SUCCESS: No content (valid)")
-                working_values.append({'value': value, 'item_count': 0, 'total_records': 0})
-                
+                working_values.append(
+                    {"value": value, "item_count": 0, "total_records": 0}
+                )
+
             else:
                 print(f"   ❌ FAILED: {response.text[:100]}...")
-                
+
         except requests.exceptions.RequestException as e:
             print(f"   ❌ REQUEST FAILED: {e}")
-    
+
     return working_values
+
 
 def main():
     results = {}
-    
+
     print("=== DISCOVERING PNCP PARAMETER VALUES ===")
-    
+
     # 1. Test modalidade codes for contratacoes_publicacao
     modalidade_codes = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
     base_params = {
         "tamanhoPagina": 10,
         "pagina": 1,
         "dataInicial": "20210101",
-        "dataFinal": "20210131"
+        "dataFinal": "20210131",
     }
-    
+
     results["modalidades_contratacoes_publicacao"] = test_parameter_values(
         "contratacoes/publicacao",
         base_params,
         "codigoModalidadeContratacao",
-        modalidade_codes
+        modalidade_codes,
     )
-    
+
     # 2. Test classification codes for pca
     # Common classification codes from experience
-    classification_codes = ["00", "01", "02", "03", "04", "05", "10", "11", "12", "20", "21", "30", "40", "50", "60", "70", "80", "90", "99"]
-    base_params_pca = {
-        "tamanhoPagina": 10,
-        "pagina": 1,
-        "anoPca": 2024
-    }
-    
+    classification_codes = [
+        "00",
+        "01",
+        "02",
+        "03",
+        "04",
+        "05",
+        "10",
+        "11",
+        "12",
+        "20",
+        "21",
+        "30",
+        "40",
+        "50",
+        "60",
+        "70",
+        "80",
+        "90",
+        "99",
+    ]
+    base_params_pca = {"tamanhoPagina": 10, "pagina": 1, "anoPca": 2024}
+
     results["classification_codes_pca"] = test_parameter_values(
-        "pca/",
-        base_params_pca,
-        "codigoClassificacaoSuperior",
-        classification_codes
+        "pca/", base_params_pca, "codigoClassificacaoSuperior", classification_codes
     )
-    
+
     # 3. Test different years for pca
     years = [2021, 2022, 2023, 2024, 2025]
     base_params_pca_year = {
         "tamanhoPagina": 10,
         "pagina": 1,
-        "codigoClassificacaoSuperior": "00"
+        "codigoClassificacaoSuperior": "00",
     }
-    
+
     results["years_pca"] = test_parameter_values(
-        "pca/",
-        base_params_pca_year,
-        "anoPca",
-        years
+        "pca/", base_params_pca_year, "anoPca", years
     )
-    
+
     # 4. Test user IDs for pca_usuario (common IDs from manual)
     user_ids = [1, 2, 3, 4, 5, 36, 100, 194035]  # Mix of small and known IDs
-    base_params_usuario = {
-        "tamanhoPagina": 10,
-        "pagina": 1,
-        "anoPca": 2024
-    }
-    
+    base_params_usuario = {"tamanhoPagina": 10, "pagina": 1, "anoPca": 2024}
+
     results["user_ids_pca_usuario"] = test_parameter_values(
-        "pca/usuario",
-        base_params_usuario,
-        "idUsuario",
-        user_ids
+        "pca/usuario", base_params_usuario, "idUsuario", user_ids
     )
-    
+
     # 5. Test modalidade codes for contratacoes_proposta (optional parameter)
-    base_params_proposta = {
-        "tamanhoPagina": 10,
-        "pagina": 1,
-        "dataFinal": "20300101"
-    }
-    
+    base_params_proposta = {"tamanhoPagina": 10, "pagina": 1, "dataFinal": "20300101"}
+
     results["modalidades_contratacoes_proposta"] = test_parameter_values(
         "contratacoes/proposta",
         base_params_proposta,
         "codigoModalidadeContratacao",
-        modalidade_codes
+        modalidade_codes,
     )
-    
-    print("\n" + "="*80)
+
+    print("\n" + "=" * 80)
     print("SUMMARY OF WORKING PARAMETER VALUES")
-    print("="*80)
-    
+    print("=" * 80)
+
     for category, working_values in results.items():
         print(f"\n{category.upper()}:")
         if working_values:
@@ -152,35 +161,52 @@ def main():
                 print(f"  - {item['value']}: {item['total_records']} records")
         else:
             print("  - No working values found")
-    
+
     # Generate configuration suggestions
-    print("\n" + "="*80)
+    print("\n" + "=" * 80)
     print("CONFIGURATION SUGGESTIONS")
-    print("="*80)
-    
+    print("=" * 80)
+
     print("\n# Suggested parameter variations for DLT configuration:")
-    
+
     # Modalidades with data
-    modalidades_with_data = [item['value'] for item in results.get("modalidades_contratacoes_publicacao", []) if item['total_records'] > 0]
+    modalidades_with_data = [
+        item["value"]
+        for item in results.get("modalidades_contratacoes_publicacao", [])
+        if item["total_records"] > 0
+    ]
     if modalidades_with_data:
         print(f"MODALIDADES_WITH_DATA = {modalidades_with_data}")
-    
+
     # Classification codes with data
-    classifications_with_data = [item['value'] for item in results.get("classification_codes_pca", []) if item['total_records'] > 0]
+    classifications_with_data = [
+        item["value"]
+        for item in results.get("classification_codes_pca", [])
+        if item["total_records"] > 0
+    ]
     if classifications_with_data:
         print(f"CLASSIFICATION_CODES_WITH_DATA = {classifications_with_data}")
-    
+
     # Years with data
-    years_with_data = [item['value'] for item in results.get("years_pca", []) if item['total_records'] > 0]
+    years_with_data = [
+        item["value"]
+        for item in results.get("years_pca", [])
+        if item["total_records"] > 0
+    ]
     if years_with_data:
         print(f"YEARS_WITH_DATA = {years_with_data}")
-    
+
     # User IDs with data
-    user_ids_with_data = [item['value'] for item in results.get("user_ids_pca_usuario", []) if item['total_records'] > 0]
+    user_ids_with_data = [
+        item["value"]
+        for item in results.get("user_ids_pca_usuario", [])
+        if item["total_records"] > 0
+    ]
     if user_ids_with_data:
         print(f"USER_IDS_WITH_DATA = {user_ids_with_data}")
-    
+
     return results
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/export_parquet.py
+++ b/scripts/export_parquet.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Helper utility to standardize Baliza Parquet exports."""
+
 from __future__ import annotations
 
 import argparse

--- a/scripts/test_pncp_endpoints_v2.py
+++ b/scripts/test_pncp_endpoints_v2.py
@@ -11,10 +11,20 @@ def test_run_pncp_uses_duckdb(tmp_path: Path) -> None:
     fake_run = MagicMock()
     fake_pipeline.run.return_value = fake_run
 
-    with patch("baliza.pipelines.pncp.dlt.pipeline", return_value=fake_pipeline) as pipeline_mock, \
-        patch("baliza.pipelines.pncp.dlt.destinations.duckdb", return_value="duck") as duckdb_mock, \
-        patch("baliza.pipelines.pncp.pncp_source", return_value="source") as source_mock:
-        pipeline, run_info = pncp.run_pncp(duckdb_path=tmp_path / "db.duckdb", dataset="test")
+    with (
+        patch(
+            "baliza.pipelines.pncp.dlt.pipeline", return_value=fake_pipeline
+        ) as pipeline_mock,
+        patch(
+            "baliza.pipelines.pncp.dlt.destinations.duckdb", return_value="duck"
+        ) as duckdb_mock,
+        patch(
+            "baliza.pipelines.pncp.pncp_source", return_value="source"
+        ) as source_mock,
+    ):
+        pipeline, run_info = pncp.run_pncp(
+            duckdb_path=tmp_path / "db.duckdb", dataset="test"
+        )
 
     duckdb_mock.assert_called_once_with(str(tmp_path / "db.duckdb"))
     pipeline_mock.assert_called_once_with(

--- a/src/baliza/cli.py
+++ b/src/baliza/cli.py
@@ -4,14 +4,16 @@ import json
 
 from datetime import date, datetime, timedelta, timezone
 
-from datetime import date, datetime, timezone
-
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional, Tuple
+from contextlib import AbstractContextManager
+from typing import Any, Callable, Dict, Iterable, Optional, Protocol, Tuple
 
 import duckdb
 
-import httpx
+try:  # pragma: no cover - optional dependency
+    import httpx
+except ModuleNotFoundError:  # pragma: no cover - fallback path
+    httpx = None  # type: ignore[assignment]
 
 
 import typer
@@ -34,17 +36,90 @@ from .utils.dates import to_pncp_window
 app = typer.Typer(help="Declarative PNCP pipeline runner")
 
 
+class _HttpClient(Protocol):
+    def get(self, url: str, params: Optional[Dict[str, Any]] = None) -> Any:  # pragma: no cover - protocol definition
+        ...
+
+
+HttpClientFactory = Callable[..., AbstractContextManager[_HttpClient]]
+
+
+class _FallbackResponse:
+    def __init__(self, *, status_code: int, text: str) -> None:
+        self.status_code = status_code
+        self._text = text
+
+    def json(self) -> Any:
+        if not self._text:
+            return {}
+        return json.loads(self._text)
+
+    def raise_for_status(self) -> None:
+        if 400 <= self.status_code:
+            raise RuntimeError(f"HTTP request failed with status {self.status_code}")
+
+
+class _FallbackClient(AbstractContextManager["_FallbackClient"]):
+    def __init__(self, *, headers: Optional[Dict[str, str]] = None, timeout: int = 30) -> None:
+        self.headers = headers or {}
+        self.timeout = timeout
+
+    def __enter__(self) -> "_FallbackClient":
+        return self
+
+    def __exit__(self, exc_type, exc, exc_tb) -> None:  # pragma: no cover - no cleanup needed
+        return None
+
+    def get(self, url: str, params: Optional[Dict[str, Any]] = None) -> _FallbackResponse:
+        from urllib import parse, request
+
+        query = parse.urlencode(params or {}, doseq=True)
+        full_url = f"{url}?{query}" if query else url
+        req = request.Request(full_url, headers=self.headers)
+        try:
+            with request.urlopen(req, timeout=self.timeout) as response:  # type: ignore[attr-defined]
+                status = int(response.getcode() or 0)
+                text = response.read().decode("utf-8")
+        except Exception as exc:  # pragma: no cover - network not exercised in tests
+            raise RuntimeError(f"HTTP request to {full_url} failed: {exc}") from exc
+        return _FallbackResponse(status_code=status, text=text)
+
+
+def _default_http_client_factory(
+    *, headers: Optional[Dict[str, str]] = None, timeout: int = 30
+) -> AbstractContextManager[_HttpClient]:
+    if httpx is not None:
+        return httpx.Client(headers=headers or None, timeout=timeout)
+    return _FallbackClient(headers=headers or None, timeout=timeout)
+
+
+_HTTP_CLIENT_FACTORY: HttpClientFactory = _default_http_client_factory
+
+
+def set_http_client_factory(factory: HttpClientFactory) -> None:
+    global _HTTP_CLIENT_FACTORY
+    _HTTP_CLIENT_FACTORY = factory
+
+
+def reset_http_client_factory() -> None:
+    set_http_client_factory(_default_http_client_factory)
+
+
 def _resolve_config_path(config: Optional[Path]) -> Path:
     if config is None:
         return default_config_path()
     return config
 
 
-def _month_windows(start_month: str, end_month: str) -> Iterable[Tuple[datetime, datetime]]:
+def _month_windows(
+    start_month: str, end_month: str
+) -> Iterable[Tuple[datetime, datetime]]:
     """Generate inclusive month windows between two YYYY-MM strings."""
 
     try:
-        start = datetime.strptime(start_month, "%Y-%m").replace(tzinfo=timezone.utc, day=1)
+        start = datetime.strptime(start_month, "%Y-%m").replace(
+            tzinfo=timezone.utc, day=1
+        )
     except ValueError as exc:  # pragma: no cover - handled by Typer
         raise typer.BadParameter("start_month must follow YYYY-MM format") from exc
 
@@ -64,7 +139,6 @@ def _month_windows(start_month: str, end_month: str) -> Iterable[Tuple[datetime,
             next_month = current.replace(month=current.month + 1)
         yield current, next_month
         current = next_month
-
 
 
 def _parse_day(value: Optional[str], param_name: str) -> Optional[datetime]:
@@ -92,7 +166,9 @@ def _parse_optional_date(value: Optional[str], *, option_name: str) -> Optional[
     try:
         return date.fromisoformat(value)
     except ValueError as exc:  # pragma: no cover - handled by Typer
-        raise typer.BadParameter(f"{option_name} must follow YYYY-MM-DD format") from exc
+        raise typer.BadParameter(
+            f"{option_name} must follow YYYY-MM-DD format"
+        ) from exc
 
 
 @app.command("extract")
@@ -185,7 +261,6 @@ def backfill(
     typer.echo(json.dumps({"windows": results}, indent=2, default=str))
 
 
-
 @app.command("verify")
 def verify(
     resource: str = typer.Option(
@@ -237,11 +312,17 @@ def verify(
         config_data = load_pncp_config(config_path)
         resources_cfg = config_data.get("resources", [])
         resource_cfg = next(
-            (r for r in resources_cfg if isinstance(r, dict) and r.get("name") == resource),
+            (
+                r
+                for r in resources_cfg
+                if isinstance(r, dict) and r.get("name") == resource
+            ),
             None,
         )
         if resource_cfg is None:
-            raise typer.BadParameter(f"resource '{resource}' not found in configuration")
+            raise typer.BadParameter(
+                f"resource '{resource}' not found in configuration"
+            )
 
         endpoint_cfg = resource_cfg.get("endpoint", {}) or {}
         table_name = resource_cfg.get("table_name") or resource
@@ -259,13 +340,17 @@ def verify(
             params_cfg = {}
         default_params = _filter_dict_none(dict(params_cfg))
 
-        coverage = tracker.fetch_pages_by_window(resource, start=inicio_filtro, end=fim_exclusivo)
+        coverage = tracker.fetch_pages_by_window(
+            resource, start=inicio_filtro, end=fim_exclusivo
+        )
         coverage_keys = set(coverage.keys())
-        status_map = {row["periodo"]: row for row in tracker.fetch_window_statuses(resource)}
+        status_map = {
+            row["periodo"]: row for row in tracker.fetch_window_statuses(resource)
+        }
         pending_pages: Dict[str, list[int]] = {}
         hash_alerts: list[Dict[str, Any]] = []
 
-        with httpx.Client(headers=headers or None, timeout=timeout) as client:
+        with _HTTP_CLIENT_FACTORY(headers=headers or None, timeout=timeout) as client:
             if endpoint_path.startswith("http"):
                 endpoint_url = endpoint_path
             else:
@@ -288,7 +373,9 @@ def verify(
                     response.raise_for_status()
                     payload = response.json()
                 recorded_pages = set(entry["recorded_pages"])
-                fallback_total = entry["max_total"] or (max(recorded_pages) if recorded_pages else 0)
+                fallback_total = entry["max_total"] or (
+                    max(recorded_pages) if recorded_pages else 0
+                )
                 atual_total = _extract_total_paginas(payload, fallback_total)
                 atual_total = max(atual_total, entry["max_total"], fallback_total)
                 faltantes = [
@@ -304,7 +391,11 @@ def verify(
                     motivo = f"paginas faltantes: {faltantes}"
                     tracker.mark_window_status(resource, periodo, "incompleto", motivo)
                 else:
-                    if existing_status and existing_status.get("status") == "suspeito" and not sequencia:
+                    if (
+                        existing_status
+                        and existing_status.get("status") == "suspeito"
+                        and not sequencia
+                    ):
                         # Preserve previous suspicion when sequence audits are disabled
                         pass
                     else:
@@ -331,8 +422,12 @@ def verify(
                         sample_hash = tracker.hash_registros(registros)
                         if sample_hash and sample_hash != stored_page.hash_ids:
                             motivo = f"hash divergente na pagina {sample_page}"
-                            tracker.mark_window_status(resource, periodo, "suspeito", motivo)
-                            hash_alerts.append({"periodo": periodo, "pagina": sample_page})
+                            tracker.mark_window_status(
+                                resource, periodo, "suspeito", motivo
+                            )
+                            hash_alerts.append(
+                                {"periodo": periodo, "pagina": sample_page}
+                            )
 
         candidatos = tracker.derive_window_candidates(
             table_name,
@@ -380,7 +475,6 @@ def verify(
 
     finally:
         tracker.close()
-
 
 
 @app.command("export")

--- a/src/baliza/pipelines/pncp.py
+++ b/src/baliza/pipelines/pncp.py
@@ -29,21 +29,23 @@ def default_config_path() -> Path:
 
 def _import_from_string(dotted_path: str) -> Any:
     """Import a dotted path as a Python object."""
-    module_path, _, attr = dotted_path.rpartition('.')
+    module_path, _, attr = dotted_path.rpartition(".")
     if not module_path:
         raise ValueError(f"Invalid import path '{dotted_path}'")
     module = import_module(module_path)
     try:
         return getattr(module, attr)
     except AttributeError as exc:  # pragma: no cover - defensive guard
-        raise ValueError(f"Object '{attr}' not found in module '{module_path}'") from exc
+        raise ValueError(
+            f"Object '{attr}' not found in module '{module_path}'"
+        ) from exc
 
 
 def _resolve_callable_entries(node: Any) -> None:
     """Convert any declarative callable references into live callables."""
     if isinstance(node, dict):
         for key, value in list(node.items()):
-            if key == 'convert' and isinstance(value, str):
+            if key == "convert" and isinstance(value, str):
                 node[key] = _import_from_string(value)
             else:
                 _resolve_callable_entries(value)
@@ -72,7 +74,7 @@ def _resolve_config_path(config_path: ConfigPath) -> Path:
 def load_pncp_config(config_path: ConfigPath = None) -> Dict[str, Any]:
     """Load and post-process the PNCP REST configuration."""
     path = _resolve_config_path(config_path)
-    with path.open('r', encoding='utf-8') as fh:
+    with path.open("r", encoding="utf-8") as fh:
         config = yaml.safe_load(fh) or {}
     _resolve_callable_entries(config)
     return config
@@ -91,7 +93,9 @@ def _apply_incremental_overrides(
     resources = adjusted.get("resources", [])
     for resource in resources:
         endpoint = resource.get("endpoint") if isinstance(resource, dict) else None
-        incremental = endpoint.get("incremental") if isinstance(endpoint, dict) else None
+        incremental = (
+            endpoint.get("incremental") if isinstance(endpoint, dict) else None
+        )
         if not isinstance(incremental, dict):
             continue
 
@@ -132,12 +136,19 @@ def _extract_window_bounds(params: Dict[str, Any]) -> tuple[Any, Any]:
         or params.get("dataInicial[]")
         or params.get("dataInicial1")
     )
-    end = params.get("dataFinal") or params.get("dataFinal[]") or params.get("dataFinal1")
+    end = (
+        params.get("dataFinal") or params.get("dataFinal[]") or params.get("dataFinal1")
+    )
     return start, end
 
 
 def _extract_total_paginas(payload: Dict[str, Any], fallback: int) -> int:
-    for key in ("totalPaginas", "total_paginas", "totalPages", "total_paginas_observado"):
+    for key in (
+        "totalPaginas",
+        "total_paginas",
+        "totalPages",
+        "total_paginas_observado",
+    ):
         if payload.get(key) is not None:
             try:
                 return int(payload[key])
@@ -181,7 +192,9 @@ def _attach_coverage_tracker(source: DltSource, tracker: CoverageTracker) -> Non
                         payload = page.response.json()  # type: ignore[attr-defined]
                     except Exception:  # pragma: no cover - defensive
                         payload = {}
-                    params = _normalize_request_params(getattr(page.request, "params", {}))
+                    params = _normalize_request_params(
+                        getattr(page.request, "params", {})
+                    )
                     start, end = _extract_window_bounds(params)
                     pagina = _extract_pagina(payload, params)
                     try:
@@ -226,8 +239,8 @@ def pncp_source(
 
 def run_pncp(
     config_path: ConfigPath = None,
-    dataset: str = 'baliza_raw',
-    duckdb_path: Union[str, Path] = 'baliza.duckdb',
+    dataset: str = "baliza_raw",
+    duckdb_path: Union[str, Path] = "baliza.duckdb",
     *,
     lookback_days: Optional[int] = None,
     range_start: Any = None,
@@ -253,6 +266,8 @@ def run_pncp(
     finally:
         tracker.close()
     return pipeline, run_info
+
+
 def _clamp_page_params(params: Dict[str, Any], *, limit: int = MAX_PAGE_SIZE) -> None:
     if not isinstance(params, dict):
         return

--- a/src/baliza/state/coverage.py
+++ b/src/baliza/state/coverage.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
+from hashlib import sha256
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import duckdb  # type: ignore[import-untyped]
-import xxhash
+
+try:  # pragma: no cover - exercised indirectly
+    import xxhash
+except ModuleNotFoundError:  # pragma: no cover - fallback path
+    xxhash = None
 
 
 @dataclass
@@ -223,7 +228,9 @@ class CoverageTracker:
             return None
         ids.sort()
         payload = "\n".join(ids).encode("utf-8")
-        return xxhash.xxh64_hexdigest(payload)
+        if xxhash is not None:
+            return xxhash.xxh64_hexdigest(payload)
+        return sha256(payload).hexdigest()
 
     def _detect_sequence_anomalies(
         self, registros: Iterable[Dict[str, Any]]
@@ -321,7 +328,15 @@ class CoverageTracker:
 
         grouped: Dict[str, Dict[str, Any]] = {}
         for row in rows:
-            janela_inicio_dt, janela_fim_dt, pagina, total_paginas, n_registros, hash_ids, fetched_at = row
+            (
+                janela_inicio_dt,
+                janela_fim_dt,
+                pagina,
+                total_paginas,
+                n_registros,
+                hash_ids,
+                fetched_at,
+            ) = row
             key = self._period_key(janela_inicio_dt, janela_fim_dt)
             entry = grouped.setdefault(
                 key,
@@ -440,7 +455,9 @@ class CoverageTracker:
             if self._period_key(start_dt, end_dt) not in coverage_keys
         ]
 
-        suspeitas = [row for row in statuses.values() if row.get("status") == "suspeito"]
+        suspeitas = [
+            row for row in statuses.values() if row.get("status") == "suspeito"
+        ]
 
         return {
             "windows": summary_windows,

--- a/src/baliza/utils/export.py
+++ b/src/baliza/utils/export.py
@@ -76,7 +76,7 @@ def _build_where_clause(
 
 
 def _quote_identifier(identifier: str) -> str:
-    escaped = identifier.replace("\"", "\"\"")
+    escaped = identifier.replace('"', '""')
     return f'"{escaped}"'
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Optional
+from urllib.parse import urlencode
+
+import pytest
+
+from baliza import cli
+
+
+@dataclass
+class _MockResponse:
+    status_code: int
+    _json_data: Any
+
+    def json(self) -> Any:
+        return self._json_data
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+Matcher = Callable[[str], bool | re.Match[str] | None]
+
+
+class _MockClient:
+    def __init__(self, responses: Iterable[tuple[Matcher, _MockResponse]]):
+        self._responses = list(responses)
+
+    def __enter__(self) -> "_MockClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def get(self, url: str, params: Optional[Dict[str, Any]] = None) -> _MockResponse:
+        if params:
+            query = urlencode(params, doseq=True)
+            if query:
+                url = f"{url}?{query}"
+        for matcher, response in self._responses:
+            if matcher(url):
+                return response
+        raise AssertionError(f"No mock response available for {url}")
+
+
+class HttpxMock:
+    def __init__(self) -> None:
+        self._entries: List[tuple[Matcher, _MockResponse]] = []
+
+    def add_response(
+        self,
+        *,
+        url: Optional[str | re.Pattern[str]] = None,
+        json: Optional[Any] = None,
+        status_code: int = 200,
+    ) -> None:
+        payload = json if json is not None else {}
+        if url is None:
+            def matcher(target: str) -> bool:
+                return True
+        elif isinstance(url, re.Pattern):
+            matcher = url.match
+        else:
+            def matcher(target: str, *, expected: str = url) -> bool:
+                return target == expected
+        self._entries.append((matcher, _MockResponse(status_code=status_code, _json_data=payload)))
+
+    def create_client(self) -> _MockClient:
+        return _MockClient(self._entries)
+
+
+@pytest.fixture()
+def httpx_mock() -> HttpxMock:
+    mock = HttpxMock()
+
+    def factory(*, headers: Optional[Dict[str, str]] = None, timeout: int = 30):
+        return mock.create_client()
+
+    original_factory = cli._HTTP_CLIENT_FACTORY
+    cli.set_http_client_factory(factory)
+    try:
+        yield mock
+    finally:
+        cli.set_http_client_factory(original_factory)

--- a/tests/e2e/test_pncp_pipeline.py
+++ b/tests/e2e/test_pncp_pipeline.py
@@ -52,9 +52,17 @@ def test_run_pncp_uses_duckdb_destination(tmp_path: Path) -> None:
     fake_run = MagicMock()
     fake_pipeline.run.return_value = fake_run
 
-    with patch("baliza.pipelines.pncp.dlt.pipeline", return_value=fake_pipeline) as pipeline_mock, \
-        patch("baliza.pipelines.pncp.dlt.destinations.duckdb", return_value="duck") as duckdb_mock, \
-        patch("baliza.pipelines.pncp.pncp_source", return_value="source") as source_mock:
+    with (
+        patch(
+            "baliza.pipelines.pncp.dlt.pipeline", return_value=fake_pipeline
+        ) as pipeline_mock,
+        patch(
+            "baliza.pipelines.pncp.dlt.destinations.duckdb", return_value="duck"
+        ) as duckdb_mock,
+        patch(
+            "baliza.pipelines.pncp.pncp_source", return_value="source"
+        ) as source_mock,
+    ):
         pipeline, run = pncp.run_pncp(
             duckdb_path=tmp_path / "baliza.duckdb",
             dataset="demo",
@@ -89,10 +97,12 @@ def test_cli_extract_emits_json(monkeypatch) -> None:
         cli, "run_pncp", MagicMock(return_value=(MagicMock(), run_info))
     )
 
-    result = runner.invoke(cli.app, ["extract", "--dataset", "cli_demo", "--lookback-days", "2"])
+    result = runner.invoke(
+        cli.app, ["extract", "--dataset", "cli_demo", "--lookback-days", "2"]
+    )
 
     assert result.exit_code == 0
-    assert "\"rows\": 10" in result.stdout
+    assert '"rows": 10' in result.stdout
 
 
 def test_cli_backfill_invokes_pipeline_per_month(monkeypatch) -> None:

--- a/tests/unit/test_coverage_tracker.py
+++ b/tests/unit/test_coverage_tracker.py
@@ -53,7 +53,9 @@ def test_record_page_creates_manifest_and_hash(temp_tracker: CoverageTracker) ->
     assert "salto" in status_rows[0][1]
 
 
-def test_summarize_windows_detects_missing_periods(temp_tracker: CoverageTracker) -> None:
+def test_summarize_windows_detects_missing_periods(
+    temp_tracker: CoverageTracker,
+) -> None:
     # Prepare sample coverage
     records = [
         {
@@ -65,7 +67,9 @@ def test_summarize_windows_detects_missing_periods(temp_tracker: CoverageTracker
     ]
     start = "2024-01-03T00:00:00Z"
     end = "2024-01-04T00:00:00Z"
-    temp_tracker.record_page("contratos", start, end, pagina=1, total_paginas=1, registros=records)
+    temp_tracker.record_page(
+        "contratos", start, end, pagina=1, total_paginas=1, registros=records
+    )
 
     # Populate raw dataset with two daily entries (one missing from coverage)
     temp_tracker.conn.execute('CREATE SCHEMA IF NOT EXISTS "baliza_raw"')

--- a/tests/unit/test_incremental_overrides.py
+++ b/tests/unit/test_incremental_overrides.py
@@ -26,7 +26,9 @@ def base_config() -> dict:
     }
 
 
-def test_apply_incremental_overrides_does_not_mutate_original(base_config: dict) -> None:
+def test_apply_incremental_overrides_does_not_mutate_original(
+    base_config: dict,
+) -> None:
     original = deepcopy(base_config)
     pncp._apply_incremental_overrides(base_config, lookback_days=1)
     assert base_config == original
@@ -55,19 +57,25 @@ def test_apply_incremental_overrides_sets_range_bounds(base_config: dict) -> Non
     assert incremental["end_value"] == "2024-01-31"
 
 
-def test_apply_incremental_overrides_clears_end_value_when_not_provided(base_config: dict) -> None:
+def test_apply_incremental_overrides_clears_end_value_when_not_provided(
+    base_config: dict,
+) -> None:
     adjusted = pncp._apply_incremental_overrides(base_config, range_start="2024-01-01")
     incremental = adjusted["resources"][0]["endpoint"]["incremental"]
     assert incremental["initial_value"] == "2024-01-01"
     assert "end_value" not in incremental
 
 
-def test_apply_incremental_overrides_preserves_end_value_without_overrides(base_config: dict) -> None:
+def test_apply_incremental_overrides_preserves_end_value_without_overrides(
+    base_config: dict,
+) -> None:
     adjusted = pncp._apply_incremental_overrides(base_config)
     incremental = adjusted["resources"][0]["endpoint"]["incremental"]
     assert incremental["end_value"] == "placeholder"
 
 
-def test_apply_incremental_overrides_rejects_negative_lookback(base_config: dict) -> None:
+def test_apply_incremental_overrides_rejects_negative_lookback(
+    base_config: dict,
+) -> None:
     with pytest.raises(ValueError):
         pncp._apply_incremental_overrides(base_config, lookback_days=-1)


### PR DESCRIPTION
## Summary
- add optional imports and fallback HTTP client factory so the CLI works without httpx installed
- provide a lightweight pytest fixture to mock HTTP interactions without pytest-httpx
- fall back to hashlib-based hashing when xxhash is unavailable

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68cae415e3208325a98c0fee7a21c2d5