### PR TITLE
Handle legacy coverage hashes when xxhash missing

### DIFF
--- a/src/baliza/cli.py
+++ b/src/baliza/cli.py
@@ -419,8 +419,23 @@ def verify(
                             or sample_payload.get("results")
                             or []
                         )
-                        sample_hash = tracker.hash_registros(registros)
-                        if sample_hash and sample_hash != stored_page.hash_ids:
+                        try:
+                            try:
+                                algoritmo, stored_digest = CoverageTracker.parse_hash_value(
+                                    stored_page.hash_ids
+                                )
+                            except ValueError:
+                                algoritmo = None
+                                stored_digest = stored_page.hash_ids
+                            sample_digest = tracker.hash_registros(
+                                registros,
+                                algorithm=algoritmo,
+                                include_algorithm=algoritmo is None,
+                            )
+                        except RuntimeError as exc:
+                            typer.echo(str(exc), err=True)
+                            raise typer.Exit(code=1) from exc
+                        if sample_digest and sample_digest != stored_digest:
                             motivo = f"hash divergente na pagina {sample_page}"
                             tracker.mark_window_status(
                                 resource, periodo, "suspeito", motivo

--- a/src/baliza/state/coverage.py
+++ b/src/baliza/state/coverage.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from hashlib import sha256
 from pathlib import Path
+import string
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import duckdb  # type: ignore[import-untyped]
@@ -218,7 +219,26 @@ class CoverageTracker:
     # Hashing and anomaly detection
     # ------------------------------------------------------------------
     @staticmethod
-    def hash_registros(registros: Iterable[Dict[str, Any]]) -> Optional[str]:
+    def _hash_payload(payload: bytes, algorithm: str) -> str:
+        if algorithm == "xxh64":
+            if xxhash is None:  # pragma: no cover - depends on optional dependency
+                raise RuntimeError(
+                    "Cannot compute xxh64 digests because the 'xxhash' package is not installed. "
+                    "Install baliza[xxhash] to verify legacy coverage data."
+                )
+            return xxhash.xxh64_hexdigest(payload)
+        if algorithm == "sha256":
+            return sha256(payload).hexdigest()
+        raise ValueError(f"Unsupported hash algorithm: {algorithm}")
+
+    @classmethod
+    def hash_registros(
+        cls,
+        registros: Iterable[Dict[str, Any]],
+        *,
+        algorithm: Optional[str] = None,
+        include_algorithm: bool = True,
+    ) -> Optional[str]:
         ids = [
             str(item["numeroControlePNCP"])
             for item in registros
@@ -228,9 +248,27 @@ class CoverageTracker:
             return None
         ids.sort()
         payload = "\n".join(ids).encode("utf-8")
-        if xxhash is not None:
-            return xxhash.xxh64_hexdigest(payload)
-        return sha256(payload).hexdigest()
+        algo = algorithm or ("xxh64" if xxhash is not None else "sha256")
+        digest = cls._hash_payload(payload, algo)
+        if include_algorithm:
+            return f"{algo}:{digest}"
+        return digest
+
+    @staticmethod
+    def parse_hash_value(value: str) -> Tuple[str, str]:
+        if not value:
+            raise ValueError("Empty hash value")
+        if ":" in value:
+            algorithm, digest = value.split(":", 1)
+            if not algorithm or not digest:
+                raise ValueError(f"Invalid hash encoding: {value!r}")
+            return algorithm, digest
+        is_hex = all(ch in string.hexdigits for ch in value)
+        if is_hex and len(value) == 16:
+            return "xxh64", value
+        if is_hex and len(value) == 64:
+            return "sha256", value
+        raise ValueError(f"Unrecognized hash format: {value!r}")
 
     def _detect_sequence_anomalies(
         self, registros: Iterable[Dict[str, Any]]

--- a/tests/unit/test_coverage_tracker.py
+++ b/tests/unit/test_coverage_tracker.py
@@ -41,10 +41,16 @@ def test_record_page_creates_manifest_and_hash(temp_tracker: CoverageTracker) ->
         registros=records,
     )
 
+    hash_value = temp_tracker.hash_registros(records)
+    assert hash_value is not None
+    algoritmo, digest = CoverageTracker.parse_hash_value(hash_value)
+    assert algoritmo in {"xxh64", "sha256"}
+    assert digest
+
     rows = temp_tracker.conn.execute(
         "SELECT recurso, pagina, total_paginas_observado, hash_ids FROM baliza_state.cobertura"
     ).fetchall()
-    assert rows == [("contratos", 1, 2, temp_tracker.hash_registros(records))]
+    assert rows == [("contratos", 1, 2, hash_value)]
 
     status_rows = temp_tracker.conn.execute(
         "SELECT status, motivo FROM baliza_state.janelas"
@@ -91,3 +97,26 @@ def test_summarize_windows_detects_missing_periods(
     assert len(missing_labels) == 1
     # The missing window should correspond to 2024-01-04
     assert "2024-01-04" in missing_labels[0]
+
+
+def test_parse_hash_value_legacy_formats() -> None:
+    algoritmo, digest = CoverageTracker.parse_hash_value("0123456789abcdef")
+    assert algoritmo == "xxh64"
+    assert digest == "0123456789abcdef"
+
+    algoritmo, digest = CoverageTracker.parse_hash_value("a" * 64)
+    assert algoritmo == "sha256"
+    assert digest == "a" * 64
+
+
+def test_hash_registros_requires_xxhash_for_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
+    registros = [{"numeroControlePNCP": "LEG-1"}]
+    monkeypatch.setattr("baliza.state.coverage.xxhash", None)
+
+    fallback_hash = CoverageTracker.hash_registros(registros)
+    assert fallback_hash and fallback_hash.startswith("sha256:")
+
+    with pytest.raises(RuntimeError):
+        CoverageTracker.hash_registros(
+            registros, algorithm="xxh64", include_algorithm=False
+        )


### PR DESCRIPTION
## Summary
- include the hash algorithm in coverage digests and expose helpers to parse legacy values
- teach CLI verification to respect stored hash algorithms and fail fast when xxhash digests cannot be recomputed
- cover the new hashing behaviour with regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb0c16970083258963f69b1089b894