### PR TITLE
Make Internet Archive upload resumable and tracked

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -10,6 +10,8 @@ jobs:
   release:
     name: Build and publish monthly dataset
     runs-on: ubuntu-latest
+    env:
+      IA_SUMMARY_PATH: internet-archive-summary.json
 
     steps:
       - name: Checkout repository
@@ -93,6 +95,34 @@ jobs:
           REFERENCE: ${{ steps.reference.outputs.reference }}
         run: |
           tar -czf contratos-${REFERENCE}.tar.gz "$MANIFEST_DIR"
+
+      - name: Install Internet Archive client
+        if: ${{ secrets.IA_ACCESS_KEY && secrets.IA_SECRET_KEY }}
+        run: |
+          pip install internetarchive
+
+      - name: Upload package to Internet Archive
+        if: ${{ secrets.IA_ACCESS_KEY && secrets.IA_SECRET_KEY }}
+        env:
+          IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
+          IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
+          MANIFEST_PATH: ${{ steps.manifest.outputs.manifest_path }}
+          REFERENCE: ${{ steps.reference.outputs.reference }}
+        run: |
+          python scripts/upload_internet_archive.py \
+            --file contratos-${REFERENCE}.tar.gz \
+            --manifest "$MANIFEST_PATH" \
+            --identifier baliza-contratos-${REFERENCE} \
+            --metadata-output "$IA_SUMMARY_PATH"
+
+      - name: Publicar artefato sincronizado com o Internet Archive
+        if: ${{ secrets.IA_ACCESS_KEY && secrets.IA_SECRET_KEY }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: internet-archive-${{ steps.reference.outputs.reference }}
+          path: |
+            contratos-${{ steps.reference.outputs.reference }}.tar.gz
+            ${{ env.IA_SUMMARY_PATH }}
 
       - name: Create release
         id: create_release

--- a/scripts/upload_internet_archive.py
+++ b/scripts/upload_internet_archive.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Upload packaged datasets to the Internet Archive.
+
+The script is designed to be *resumable*: if the same file was previously
+published for the same identifier, the upload is skipped and a structured
+summary is emitted. The summary can be stored as a GitHub Actions artifact so
+that the state of the Internet Archive stays in sync with the workflow run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping
+
+import internetarchive
+
+
+Summary = Dict[str, Any]
+
+
+def _load_manifest(manifest_path: Path) -> Dict[str, Any]:
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+        raise ValueError(f"Invalid JSON manifest at {manifest_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("Manifest JSON must be an object")
+    return data
+
+
+def _build_metadata(
+    manifest: Dict[str, Any] | None,
+    extra_metadata: Iterable[str],
+) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {
+        "mediatype": "data",
+        "collection": "opensource",
+        "language": "por",
+        "subject": [
+            "dados abertos",
+            "brasil",
+            "pncp",
+            "contratos",
+        ],
+        "creator": "Projeto Baliza",
+    }
+
+    if manifest is not None:
+        dataset_version = manifest.get("dataset_version")
+        row_count = manifest.get("row_count")
+        min_data = manifest.get("min_data")
+        max_data = manifest.get("max_data")
+        checksum = manifest.get("sha256")
+
+        if dataset_version:
+            metadata.setdefault(
+                "title", f"Baliza contratos {dataset_version}"
+            )
+            metadata.setdefault("date", dataset_version)
+            metadata.setdefault("dataset_version", dataset_version)
+
+        description_lines: List[str] = []
+        if dataset_version:
+            description_lines.append(f"Versão do dataset: {dataset_version}")
+        if row_count is not None:
+            description_lines.append(f"Total de linhas: {row_count}")
+        if min_data and max_data:
+            description_lines.append(f"Intervalo de dados: {min_data} → {max_data}")
+        elif min_data:
+            description_lines.append(f"Data mínima: {min_data}")
+        elif max_data:
+            description_lines.append(f"Data máxima: {max_data}")
+        if checksum:
+            description_lines.append(f"SHA256 do manifesto: {checksum}")
+
+        if description_lines:
+            description = "\n".join(description_lines)
+            metadata.setdefault("description", description)
+
+    for pair in extra_metadata:
+        if "=" not in pair:
+            raise ValueError(
+                f"Invalid metadata entry '{pair}'. Use the format key=value."
+            )
+        key, value = pair.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            raise ValueError("Metadata key cannot be empty.")
+        metadata[key] = value
+
+    return metadata
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+def _coerce_size(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    try:
+        return int(value)
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return None
+
+
+def _write_summary(metadata_output: Path | None, summary: Summary) -> None:
+    if not metadata_output:
+        return
+    metadata_output.write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def upload_dataset(
+    file_path: Path,
+    identifier: str,
+    *,
+    manifest: Mapping[str, Any] | None = None,
+    extra_metadata: Iterable[str] = (),
+    metadata_output: Path | None = None,
+    force: bool = False,
+    access_key: str | None = None,
+    secret_key: str | None = None,
+    get_item=internetarchive.get_item,
+    upload_func=internetarchive.upload,
+) -> Summary:
+    if not file_path.exists():
+        raise FileNotFoundError(f"Package not found: {file_path}")
+
+    manifest_dict: Dict[str, Any] | None = dict(manifest) if manifest else None
+    metadata = _build_metadata(manifest_dict, extra_metadata)
+
+    access_key = access_key or _require_env("IA_ACCESS_KEY")
+    secret_key = secret_key or _require_env("IA_SECRET_KEY")
+
+    local_size = file_path.stat().st_size
+    filename = file_path.name
+
+    summary: Summary = {
+        "identifier": identifier,
+        "file": filename,
+        "size": local_size,
+        "metadata": metadata,
+        "manifest": manifest_dict,
+        "uploaded": False,
+        "skipped": False,
+    }
+
+    if not force:
+        item = get_item(
+            identifier,
+            access_key=access_key,
+            secret_key=secret_key,
+        )
+        remote_file = item.get_file(filename)
+        remote_size = _coerce_size(getattr(remote_file, "size", None))
+        if getattr(remote_file, "exists", False) and remote_size == local_size:
+            summary.update(
+                {
+                    "skipped": True,
+                    "reason": "already_present",
+                    "remote_size": remote_size,
+                }
+            )
+            _write_summary(metadata_output, summary)
+            return summary
+
+    responses = upload_func(
+        identifier,
+        files=[str(file_path)],
+        metadata=metadata,
+        access_key=access_key,
+        secret_key=secret_key,
+        queue_derive=False,
+        verify=True,
+    )
+
+    errors = [
+        response
+        for response in responses
+        if getattr(response, "status_code", 200) >= 400
+    ]
+    if errors:
+        for response in errors:
+            status = getattr(response, "status_code", "unknown")
+            reason = getattr(response, "reason", "")
+            sys.stderr.write(
+                f"Upload failed with status {status} {reason}\n"
+            )
+        raise SystemExit(1)
+
+    summary["uploaded"] = True
+    _write_summary(metadata_output, summary)
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Upload a Baliza archive to the Internet Archive"
+    )
+    parser.add_argument(
+        "--file",
+        dest="file_path",
+        type=Path,
+        required=True,
+        help="Path to the tarball to upload",
+    )
+    parser.add_argument(
+        "--identifier",
+        required=True,
+        help="Internet Archive identifier for the item",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        help="Path to manifest.json to enrich metadata",
+    )
+    parser.add_argument(
+        "--metadata",
+        action="append",
+        default=[],
+        help="Extra metadata entries in key=value format",
+    )
+    parser.add_argument(
+        "--metadata-output",
+        type=Path,
+        help="Optional path to write a JSON summary of the upload",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force upload even if the file already exists on the Internet Archive",
+    )
+    args = parser.parse_args()
+
+    manifest = _load_manifest(args.manifest) if args.manifest else None
+
+    summary = upload_dataset(
+        args.file_path,
+        args.identifier,
+        manifest=manifest,
+        extra_metadata=args.metadata,
+        metadata_output=args.metadata_output,
+        force=args.force,
+    )
+
+    sys.stdout.write(json.dumps(summary, ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()

--- a/tests/unit/test_upload_internet_archive.py
+++ b/tests/unit/test_upload_internet_archive.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import upload_internet_archive
+
+
+class DummyFile:
+    def __init__(self, exists: bool, size: int | None):
+        self.exists = exists
+        self.size = size
+
+
+class DummyItem:
+    def __init__(self, file: DummyFile):
+        self._file = file
+
+    def get_file(self, name: str) -> DummyFile:
+        return self._file
+
+
+def test_upload_writes_summary_and_calls_upload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    package = tmp_path / "contratos-2024-01.tar.gz"
+    package.write_bytes(b"data")
+
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps({
+            "dataset_version": "2024-01",
+            "row_count": 10,
+            "min_data": "2024-01-01",
+            "max_data": "2024-01-31",
+        }),
+        encoding="utf-8",
+    )
+
+    summary_path = tmp_path / "summary.json"
+
+    calls: dict[str, int] = {"upload": 0}
+
+    def fake_upload(identifier: str, **kwargs):
+        calls["upload"] += 1
+        assert identifier == "baliza-contratos-2024-01"
+        assert kwargs["files"] == [str(package)]
+        return [SimpleNamespace(status_code=200)]
+
+    def fake_get_item(identifier: str, **kwargs):
+        assert identifier == "baliza-contratos-2024-01"
+        return DummyItem(DummyFile(exists=False, size=None))
+
+    summary = upload_internet_archive.upload_dataset(
+        package,
+        "baliza-contratos-2024-01",
+        manifest=json.loads(manifest_path.read_text(encoding="utf-8")),
+        metadata_output=summary_path,
+        get_item=fake_get_item,
+        upload_func=fake_upload,
+        access_key="key",
+        secret_key="secret",
+    )
+
+    assert calls["upload"] == 1
+    assert summary["uploaded"] is True
+    assert summary_path.exists()
+    stored = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert stored["metadata"]["mediatype"] == "data"
+    assert stored["manifest"]["dataset_version"] == "2024-01"
+
+
+def test_skip_when_same_file_exists(tmp_path: Path) -> None:
+    package = tmp_path / "contratos-2024-02.tar.gz"
+    data = b"another"
+    package.write_bytes(data)
+
+    summary_path = tmp_path / "summary.json"
+
+    dummy_file = DummyFile(exists=True, size=len(data))
+    dummy_item = DummyItem(dummy_file)
+
+    def fake_get_item(identifier: str, **kwargs):
+        return dummy_item
+
+    def fake_upload(*args, **kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("upload should not be called when file exists")
+
+    summary = upload_internet_archive.upload_dataset(
+        package,
+        "baliza-contratos-2024-02",
+        metadata_output=summary_path,
+        get_item=fake_get_item,
+        upload_func=fake_upload,
+        access_key="key",
+        secret_key="secret",
+    )
+
+    assert summary["skipped"] is True
+    assert summary["reason"] == "already_present"
+    stored = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert stored["skipped"] is True
+


### PR DESCRIPTION
## Summary
- update the Internet Archive upload helper to be resumable, emit structured summaries, and support artifact generation
- add unit tests covering the resumable upload logic and summary file output
- extend the monthly release workflow to archive the upload summary alongside the tarball for synchronization

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cebe58b9bc8325bfa849753acb2657