### PR TITLE
Automate CI failure issue creation

### DIFF
--- a/.github/workflows/daily-export.yml
+++ b/.github/workflows/daily-export.yml
@@ -6,6 +6,11 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
 jobs:
   export:
     name: Run daily extraction and export
@@ -74,3 +79,82 @@ jobs:
         with:
           name: baliza-daily-${{ steps.partition.outputs.year }}-${{ steps.partition.outputs.month }}
           path: baliza-daily-${{ steps.partition.outputs.year }}-${{ steps.partition.outputs.month }}.tar.gz
+
+  report-failure:
+    name: Report workflow failure
+    if: ${{ failure() }}
+    needs: export
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open issue for failure
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const runId = context.runId;
+            const attempt = context.runAttempt;
+            const runUrl = `${context.payload.repository.html_url}/actions/runs/${runId}`;
+            const workflowName = context.workflow;
+            const identifier = `run_id:${runId}`;
+
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} "${identifier}" state:open type:issue`
+            });
+
+            if (search.data.total_count > 0) {
+              core.info('Existing issue found for this run, skipping creation.');
+              return;
+            }
+
+            const jobsResponse = await github.rest.actions.listJobsForWorkflowRunAttempt({
+              owner,
+              repo,
+              run_id: runId,
+              attempt_number: attempt,
+              per_page: 100
+            });
+
+            const failureDetails = [];
+            const failingConclusions = new Set(['failure', 'cancelled', 'timed_out']);
+            for (const job of jobsResponse.data.jobs) {
+              if (!failingConclusions.has(job.conclusion)) {
+                continue;
+              }
+
+              const stepLines = [];
+              for (const step of job.steps ?? []) {
+                if (failingConclusions.has(step.conclusion)) {
+                  stepLines.push(`    • ${step.name} (${step.conclusion})`);
+                }
+              }
+
+              if (stepLines.length > 0) {
+                failureDetails.push(`- ${job.name} (${job.conclusion})\n${stepLines.join('\n')}`);
+              } else {
+                failureDetails.push(`- ${job.name} (${job.conclusion})`);
+              }
+            }
+
+            const lines = [
+              '@codex há uma falha automática no workflow agendado.',
+              '',
+              `- **Workflow**: ${workflowName}`,
+              `- **Execução**: [#${context.runNumber}](${runUrl})`,
+              `- **Evento**: ${context.eventName}`,
+              `- **SHA**: ${context.sha}`,
+            ];
+
+            if (failureDetails.length > 0) {
+              lines.push('', 'Jobs com falha:', ...failureDetails);
+            }
+
+            lines.push('', `Identificador automático: ${identifier}`);
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: `🚨 Falha no workflow "${workflowName}" (run #${context.runNumber})`,
+              body: lines.join('\n'),
+              labels: ['ci-failure']
+            });

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -6,6 +6,11 @@ on:
     - cron: '0 4 1 * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
 jobs:
   release:
     name: Build and publish monthly dataset
@@ -145,3 +150,82 @@ jobs:
           asset_path: contratos-${{ steps.reference.outputs.reference }}.tar.gz
           asset_name: contratos-${{ steps.reference.outputs.reference }}.tar.gz
           asset_content_type: application/gzip
+
+  report-failure:
+    name: Report workflow failure
+    if: ${{ failure() }}
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open issue for failure
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const runId = context.runId;
+            const attempt = context.runAttempt;
+            const runUrl = `${context.payload.repository.html_url}/actions/runs/${runId}`;
+            const workflowName = context.workflow;
+            const identifier = `run_id:${runId}`;
+
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} "${identifier}" state:open type:issue`
+            });
+
+            if (search.data.total_count > 0) {
+              core.info('Existing issue found for this run, skipping creation.');
+              return;
+            }
+
+            const jobsResponse = await github.rest.actions.listJobsForWorkflowRunAttempt({
+              owner,
+              repo,
+              run_id: runId,
+              attempt_number: attempt,
+              per_page: 100
+            });
+
+            const failureDetails = [];
+            const failingConclusions = new Set(['failure', 'cancelled', 'timed_out']);
+            for (const job of jobsResponse.data.jobs) {
+              if (!failingConclusions.has(job.conclusion)) {
+                continue;
+              }
+
+              const stepLines = [];
+              for (const step of job.steps ?? []) {
+                if (failingConclusions.has(step.conclusion)) {
+                  stepLines.push(`    • ${step.name} (${step.conclusion})`);
+                }
+              }
+
+              if (stepLines.length > 0) {
+                failureDetails.push(`- ${job.name} (${job.conclusion})\n${stepLines.join('\n')}`);
+              } else {
+                failureDetails.push(`- ${job.name} (${job.conclusion})`);
+              }
+            }
+
+            const lines = [
+              '@codex há uma falha automática no workflow agendado.',
+              '',
+              `- **Workflow**: ${workflowName}`,
+              `- **Execução**: [#${context.runNumber}](${runUrl})`,
+              `- **Evento**: ${context.eventName}`,
+              `- **SHA**: ${context.sha}`,
+            ];
+
+            if (failureDetails.length > 0) {
+              lines.push('', 'Jobs com falha:', ...failureDetails);
+            }
+
+            lines.push('', `Identificador automático: ${identifier}`);
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: `🚨 Falha no workflow "${workflowName}" (run #${context.runNumber})`,
+              body: lines.join('\n'),
+              labels: ['ci-failure']
+            });


### PR DESCRIPTION
## Summary
- grant the scheduled workflows permission to read workflow runs and open issues
- add a failure-reporting job that files an issue mentioning @codex with contextual details whenever a run fails

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d142f819bc83259b7a9454d0c55dba