### PR TITLE
Add internetarchive dependency for uploader tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pyyaml>=6.0",
     "httpx>=0.27.0",
     "xxhash>=3.4.1",
+    "internetarchive>=4.1.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add the internetarchive package to the main dependency list so the uploader module can import successfully during tests

## Testing
- pip install -e .[test]
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d146f26b4c8325a62ef6fdd382fd10