### PR TITLE
feat: Implement `baliza state show` command with BDD test

### DIFF
--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -318,6 +318,73 @@ def buffer_stats(
         raise typer.Exit(1) from None
 
 
+state_app = typer.Typer(help="Manage and inspect extraction state.")
+app.add_typer(state_app, name="state")
+
+
+@state_app.command("show")
+def state_show(
+    db_path: Path = typer.Option(
+        Path("baliza.duckdb"),
+        "--duckdb",
+        "-d",
+        help="Path to DuckDB database file",
+    ),
+) -> None:
+    """Show a summary of the current extraction state."""
+    try:
+        if not db_path.exists():
+            console.print("[yellow]No database found. Run extraction first.[/yellow]")
+            raise typer.Exit(0)
+
+        with duckdb.connect(str(db_path), read_only=True) as con:
+            # Get extraction history
+            try:
+                runs = con.execute(
+                    "SELECT status, COUNT(*) as count FROM baliza_state.extraction_runs GROUP BY status"
+                ).fetchall()
+            except duckdb.CatalogException:
+                runs = []
+
+            # Get coverage summary
+            try:
+                coverage = con.execute(
+                    "SELECT status, COUNT(*) as count FROM baliza_state.cobertura GROUP BY status"
+                ).fetchall()
+            except duckdb.CatalogException:
+                coverage = []
+
+        # Display Extraction History
+        console.print(Panel("[bold]Extraction History[/bold]", style="blue"))
+        if runs:
+            history_table = Table(show_header=True, header_style="bold magenta")
+            history_table.add_column("Status")
+            history_table.add_column("Count", justify="right")
+            for status, count in runs:
+                history_table.add_row(status, str(count))
+            console.print(history_table)
+        else:
+            console.print("No extraction history found.")
+
+        console.print()
+
+        # Display Coverage Summary
+        console.print(Panel("[bold]Coverage Summary[/bold]", style="blue"))
+        if coverage:
+            coverage_table = Table(show_header=True, header_style="bold magenta")
+            coverage_table.add_column("Status")
+            coverage_table.add_column("Window Count", justify="right")
+            for status, count in coverage:
+                coverage_table.add_row(status, str(count))
+            console.print(coverage_table)
+        else:
+            console.print("No coverage data found.")
+
+    except Exception as e:
+        console.print(f"[red]✗ Failed to get state: {e}")
+        raise typer.Exit(1) from None
+
+
 @app.command("status")
 def status(
     db_path: Path = typer.Option(

--- a/tests/features/state.feature
+++ b/tests/features/state.feature
@@ -1,0 +1,10 @@
+Feature: State Management
+  As a user of the Baliza CLI
+  I want to inspect the application's state
+  So that I can understand the data coverage and extraction history.
+
+  @tier1
+  Scenario: Show current application state
+    Given a pre-existing database with known state
+    When the user runs "baliza state show"
+    Then the output should summarize the database state

--- a/tests/step_defs/test_state.py
+++ b/tests/step_defs/test_state.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+import duckdb
+from pytest_bdd import scenario, given, when, then
+from typer.testing import CliRunner
+from baliza.cli_simple import app
+import pytest
+
+@pytest.fixture
+def db_path(tmp_path):
+    """Creates a temporary DuckDB database for testing."""
+    return tmp_path / "test.duckdb"
+
+@pytest.fixture
+def runner():
+    """Returns a Typer CliRunner."""
+    return CliRunner()
+
+@scenario('../features/state.feature', 'Show current application state')
+def test_show_current_application_state():
+    """Test the 'baliza state show' command."""
+    pass
+
+@given("a pre-existing database with known state", target_fixture="db_with_state")
+def db_with_state(db_path: Path):
+    """
+    Sets up a DuckDB database with a known state.
+    - Creates the necessary tables.
+    - Inserts mock data to represent extraction runs and coverage.
+    - Returns the path to the database file.
+    """
+    con = duckdb.connect(str(db_path))
+    con.execute("CREATE SCHEMA IF NOT EXISTS baliza_state;")
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS baliza_state.extraction_runs (
+            id VARCHAR,
+            status VARCHAR,
+            started_at TIMESTAMP,
+            ended_at TIMESTAMP
+        );
+    """)
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS baliza_state.cobertura (
+            data_inicio DATE,
+            data_fim DATE,
+            total_paginas_observado INTEGER,
+            status VARCHAR
+        );
+    """)
+
+    con.execute("INSERT INTO baliza_state.extraction_runs VALUES ('run1', 'completed', '2024-01-01 10:00:00', '2024-01-01 11:00:00');")
+    con.execute("INSERT INTO baliza_state.cobertura VALUES ('2024-01-01', '2024-01-02', 10, 'ok');")
+    con.execute("INSERT INTO baliza_state.cobertura VALUES ('2024-01-02', '2024-01-03', 5, 'incompleto');")
+    con.close()
+    return db_path
+
+@when('the user runs "baliza state show"', target_fixture="cli_result")
+def run_state_show_command(runner: CliRunner, db_with_state: Path):
+    """
+    Runs the 'baliza state show' command against the test database.
+    """
+    result = runner.invoke(app, ["state", "show", "--duckdb", str(db_with_state)])
+    return result
+
+@then("the output should summarize the database state")
+def check_output_summary(cli_result):
+    """
+    Asserts that the command output contains the expected state summary.
+    """
+    assert cli_result.exit_code == 0, f"CLI exited with an error. Stderr: {cli_result.stderr}"
+    output = cli_result.stdout
+    assert "Extraction History" in output
+    assert "Coverage Summary" in output
+    assert "completed" in output
+    assert "incompleto" in output
+    assert "ok" in output


### PR DESCRIPTION
This change adds a new `baliza state show` command and a corresponding BDD test. The command provides a summary of the data extraction history and coverage, improving the observability of the extraction process. The BDD test ensures the command's functionality and adherence to the project's testing standards.

---
*PR created automatically by Jules for task [13820214396137381523](https://jules.google.com/task/13820214396137381523) started by @franklinbaldo*