### PR TITLE
Add structured logging, deadline management, and resource health tracking

### DIFF
--- a/.github/workflows/continuous-extract.yml
+++ b/.github/workflows/continuous-extract.yml
@@ -118,7 +118,8 @@ jobs:
             --start ${{ steps.dates.outputs.start }} \
             --end ${{ steps.dates.outputs.end }} \
             --duckdb baliza.duckdb \
-            --dataset baliza_raw
+            --dataset baliza_raw \
+            --deadline-minutes 22
         env:
           # Rate limiting via environment
           BALIZA_PAGE_DELAY: ${{ env.SLEEP_BETWEEN_PAGES }}

--- a/.github/workflows/daily-export.yml
+++ b/.github/workflows/daily-export.yml
@@ -48,12 +48,12 @@ jobs:
         run: |
           # Always extract yesterday first (D-1 priority)
           YESTERDAY=$(date -d "-1 day" +%Y-%m-%d)
-          uv run baliza extract --start $YESTERDAY --end $YESTERDAY --duckdb baliza.duckdb --dataset baliza_raw
+          uv run baliza extract --start $YESTERDAY --end $YESTERDAY --duckdb baliza.duckdb --dataset baliza_raw --deadline-minutes 27
           # Then backfill recent days
           # --lookback-days removed in CLI refactor; use --start/--end instead
           DAY3=$(date -d "-3 days" +%Y-%m-%d)
           DAY2=$(date -d "-2 days" +%Y-%m-%d)
-          uv run baliza extract --start $DAY3 --end $DAY2 --duckdb baliza.duckdb --dataset baliza_raw
+          uv run baliza extract --start $DAY3 --end $DAY2 --duckdb baliza.duckdb --dataset baliza_raw --deadline-minutes 27
 
       - name: Export current month parquet snapshot
         run: |

--- a/.github/workflows/historical-backfill.yml
+++ b/.github/workflows/historical-backfill.yml
@@ -186,7 +186,8 @@ jobs:
                 --start "$DATE" \
                 --end "$DATE" \
                 --duckdb baliza.duckdb \
-                --dataset baliza_raw 2>&1 | tee extract.log; then
+                --dataset baliza_raw \
+                --deadline-minutes 22 2>&1 | tee extract.log; then
 
               # Check if any records were extracted
               RECORDS=$(uv run python -c "

--- a/docs/CAUSAGANHA_COMPARISON.md
+++ b/docs/CAUSAGANHA_COMPARISON.md
@@ -1,306 +1,311 @@
-# Baliza vs CausaGanha Comparison
+# Baliza and CausaGanha: Operational Pipeline Comparison
 
-> Analysis comparing [baliza](https://github.com/franklinbaldo/baliza) with [causaganha](https://github.com/franklinbaldo/causaganha) to extract patterns and insights.
+> Honest comparison between two sister projects by the same author, focused on
+> their **data downloading and Internet Archive archiving pipelines**.
+>
+> Analytics features (ratings, AI, embeddings) are acknowledged as inspirational
+> but out of scope for this document.
+>
+> Last updated: 2026-04-03
 
-## Executive Summary
+## 1. Project Overview
 
-Both projects share a common technical DNA but serve different domains:
-- **Baliza**: Brazilian public procurement data (PNCP)
-- **CausaGanha**: Brazilian judicial decisions and lawyer ratings
+| | Baliza | CausaGanha |
+|---|--------|------------|
+| **Domain** | Brazilian public procurement (PNCP) | Brazilian judicial decisions (DJEN) |
+| **Data source** | 1 API (`pncp.gov.br/api/consulta/v1`) | 91 court websites via DJEN proxy |
+| **Collection unit** | JSON pages (500 records/page) | ZIP files (one per tribunal per day) |
+| **Output** | Parquet (contratos, orgaos, unidades) | Parquet (9 normalized tables) |
+| **Archive** | Internet Archive (S3 PUT) | Internet Archive (S3 PUT + `ia` CLI) |
+| **CLI** | `baliza` (Typer) | `causaganha` + `djen-backup` (Typer) |
+| **Repo** | [franklinbaldo/baliza](https://github.com/franklinbaldo/baliza) | [franklinbaldo/causaganha](https://github.com/franklinbaldo/causaganha) |
 
-CausaGanha has evolved several architectural patterns that could accelerate Baliza's development.
+Both projects share a mission of **Brazilian data transparency** and permanent
+preservation via Internet Archive.
 
 ---
 
-## Shared Technical Foundation
+## 2. Shared Technical Foundation
 
 | Aspect | Both Projects |
 |--------|---------------|
-| **Language** | Python 3.11+ |
-| **CLI Framework** | Typer |
-| **Package Manager** | uv |
-| **Database** | DuckDB |
-| **Data Format** | Parquet |
-| **Testing** | pytest-bdd (BDD) |
-| **Type Checking** | mypy (strict) |
-| **Linting** | ruff |
-| **HTTP Client** | httpx |
-| **Data Distribution** | Internet Archive |
-| **CI/CD** | GitHub Actions |
-| **Mission** | Brazilian data transparency |
+| Language | Python 3.11+ |
+| CLI framework | Typer |
+| Package manager | uv |
+| HTTP client | httpx (synchronous) |
+| Retry library | tenacity |
+| Database | DuckDB |
+| Data format | Apache Parquet (Zstd compression) |
+| Arrow integration | PyArrow |
+| Testing | pytest + pytest-bdd |
+| Type checking | mypy (strict) |
+| Linting | ruff |
+| CI/CD | GitHub Actions (scheduled workflows) |
+| Data distribution | Internet Archive |
 
 ---
 
-## Key Architectural Differences
+## 3. Side-by-Side Pipeline Comparison
 
-### 1. Sync vs Async Architecture
+### 3.1 Data Collection
 
-| Baliza | CausaGanha |
-|--------|------------|
-| Synchronous httpx | Async-first (asyncio everywhere) |
-| Sequential pagination | Concurrent request batching |
-| ~100 req/min | ~1000+ req/min |
+| Aspect | Baliza | CausaGanha |
+|--------|--------|------------|
+| **Concurrency model** | sync httpx + `ThreadPoolExecutor` | sync httpx + `ThreadPoolExecutor` |
+| **Worker count** | 4 (optimal for 1 rate-limited API) | 20 (needed for 91 independent courts) |
+| **Retry strategy** | tenacity: 5 attempts, exp backoff 1s-60s | tenacity + per-tribunal stall detection |
+| **Retryable errors** | HTTP 429, 5xx, connection, timeout | Same categories |
+| **Rate limiting** | API-imposed; 4 workers is the ceiling | Per-tribunal; 20 workers across 91 courts |
+| **SSRF protection** | IP validation, DNS rebinding prevention | Proxy-based (DJEN proxy service) |
+| **Response safety** | 10MB streaming size limit | ZIP file validation |
+| **Page/batch size** | 500 records per API page | 1 ZIP per tribunal per day |
 
-**CausaGanha Pattern:**
-```python
-async def fetch_all_courts(courts: list[str]) -> list[CourtData]:
-    tasks = [fetch_court_data(court) for court in courts]
-    return await asyncio.gather(*tasks)
-```
+**Key insight**: Both projects use the same concurrency model (synchronous httpx
+with thread pools). The difference in worker count reflects API constraints, not
+architectural choice. Baliza's PNCP API rate-limits aggressively beyond 4
+concurrent requests; causaganha targets 91 independent endpoints.
 
-### 2. Code Organization
+### 3.2 State Management
 
-| Baliza | CausaGanha |
-|--------|------------|
-| 3 source files | Multi-layer modular architecture |
-| `cli_simple.py`, `extractor.py`, `utils.py` | `api/`, `storage/`, `analysis/`, `pipeline/`, `scoring/` |
-| Simple, pragmatic | Scalable, maintainable |
+| Aspect | Baliza | CausaGanha |
+|--------|--------|------------|
+| **Checkpoint storage** | DuckDB tables (`baliza_state.*`) | JSON state files (`backfill-state.json`, `ia-state.json`) |
+| **Checkpoint granularity** | Per-page (500-record resolution) | Per-tribunal cursor + per-date completion |
+| **CI state persistence** | GitHub Actions artifacts (30-day retention) | GitHub Actions cache |
+| **Coverage tracking** | `baliza_state.coverage` table with status field | `state/completed.txt` + `state/unavailable.txt` |
+| **Stall detection** | Gap detection via `baliza verify` (reactive) | 60-day circuit breaker per tribunal (proactive) |
+| **Corruption recovery** | Manual | Auto-detect + rebuild from scratch |
 
-### 3. Data Processing
+**Tradeoffs**: Baliza's DuckDB state is transactionally consistent and
+queryable via SQL, which suits a single-API extractor well. CausaGanha's JSON
+files are simpler to inspect and version but lack transactional guarantees --
+appropriate when managing 91 independent sources where partial state loss is
+recoverable.
 
-| Baliza | CausaGanha |
-|--------|------------|
-| Raw DuckDB SQL | Ibis Framework |
-| Manual query optimization | Lazy evaluation, auto-optimization |
-| Adequate for current scale | 10-100x faster for complex analytics |
+### 3.3 Export and Archival
 
-### 4. Testing Scale
+| Aspect | Baliza | CausaGanha |
+|--------|--------|------------|
+| **Export tables** | 3 (contratos, orgaos, unidades) | 9 normalized (comunicacoes, textos, destinatarios, partes, advogados, ...) |
+| **Export memory** | O(1) streaming via `RecordBatchReader` | ThreadPoolExecutor for parallel table export |
+| **Compression** | Zstd level 3, Parquet v2.6 | Zstd compression |
+| **Partitioning** | `ano=YYYY/mes=MM/` (monthly exports) | Tribunal + year (`djen-{tribunal}-{year}`) |
+| **IA upload method** | Custom S3 PUT script (`upload_internet_archive.py`) | Integrated into collection pipeline |
+| **IA resumability** | HEAD check compares local vs remote file size | Checkpoint-based skip of already-uploaded items |
+| **IA metadata** | Manifest-driven: row count, date range, SHA256, subjects | Checksums alongside files |
+| **IA item naming** | `baliza-pncp-YYYY-MM-DD` (daily), `baliza-contratos-YYYY-MM` (monthly) | `djen-{tribunal}-{year}` |
+| **Metadata file** | `_metadata.json` per day + `manifest.json` with checksums | Per-item metadata |
 
-| Baliza | CausaGanha |
-|--------|------------|
-| 5 focused BDD scenarios | 459+ BDD scenarios |
-| Single tier | Prioritized P1-P5 hierarchy |
-| "Ship early, iterate" | Comprehensive coverage |
+**Key insight**: Baliza has a more mature IA upload pipeline with richer metadata
+(manifest-driven, SHA256 checksums, structured JSON summaries). CausaGanha
+uploads during collection for speed but with less metadata enrichment.
 
-### 5. AI/LLM Integration
+### 3.4 GitHub Actions Orchestration
 
-| Baliza | CausaGanha |
-|--------|------------|
-| None | Pydantic AI (provider-agnostic) |
-| N/A | Structured output extraction |
-| N/A | RAG + LLM hybrid analysis |
+| Aspect | Baliza | CausaGanha |
+|--------|--------|------------|
+| **Collection frequency** | Every 30 minutes | Every 20 minutes |
+| **Daily export** | 5 AM UTC | 6 AM UTC |
+| **Timeout handling** | `timeout-minutes: 25` (abrupt GHA kill) | Per-run deadline: 17 minutes (graceful shutdown) |
+| **Concurrency control** | Concurrency groups, `cancel-in-progress: false` | Same pattern |
+| **Failure alerting** | Auto-creates GitHub Issue with job details | Telegram bot (zero-ZIPs alert, low-coverage alert) |
+| **Backfill strategy** | Forward (oldest first), 5 days/batch | Backward (newest first), configurable |
+| **Workflow count** | 4 (continuous, daily, backfill, monthly) | 2 primary (collect-today, collect-zips) + deploy |
+| **Manual dispatch** | Date range, force flag | Date range, workers, tribunal filter, deadline, cache reset |
 
-### 6. Automation
+**Key insight**: CausaGanha's per-run deadline management is a significant
+operational advantage. Instead of relying on GitHub Actions to kill the process
+at 25 minutes (losing in-progress work), causaganha sets a 17-minute deadline
+and gracefully checkpoints before the GHA timeout. This is the single most
+impactful pattern to import.
 
-| Baliza | CausaGanha |
-|--------|------------|
-| Daily/monthly cron jobs | Jules system (23 AI personas) |
-| Manual development | Autonomous development (every 15 min) |
-| Human-driven PR review | Auto-merge on CI success |
+### 3.5 Observability
 
----
+| Aspect | Baliza | CausaGanha |
+|--------|--------|------------|
+| **Logging framework** | `logging` (stdlib) + `rich.Console` | `structlog` (structured JSON) |
+| **Log format** | Human-readable text | JSON key-value pairs (machine-parseable) |
+| **CI log parsing** | Grep through text output | Structured fields queryable by key |
+| **Alerting channel** | GitHub Issues (on workflow failure) | Telegram (proactive: zero-ZIPs, low coverage) |
+| **Health checks** | `baliza verify` (gap detection) | Coverage threshold checks (73/91 tribunals) |
+| **Metrics in CI** | `GITHUB_STEP_SUMMARY` with row counts | Same + collection/upload statistics |
 
-## Actionable Insights for Baliza
-
-### High Priority
-
-#### 1. Async-First Extraction (5-10x speedup)
-
-Migrate `extractor.py` to async httpx for concurrent API requests:
-
-```python
-# Before (sync)
-for page in range(total_pages):
-    response = self.client.get(url, params={"pagina": page})
-    process(response.json())
-
-# After (async)
-async def fetch_all_pages(self, total_pages: int) -> list[dict]:
-    async with httpx.AsyncClient() as client:
-        tasks = [
-            client.get(url, params={"pagina": page})
-            for page in range(total_pages)
-        ]
-        responses = await asyncio.gather(*tasks)
-        return [r.json() for r in responses]
-```
-
-**Estimated effort**: 4 hours
-**Impact**: 5-10x faster extraction
-
-#### 2. BDD Test Prioritization
-
-Expand from 5 tests to comprehensive coverage using priority tiers:
-
-```
-tests/features/
-├── P1_core/              # Must always pass
-│   ├── extraction.feature
-│   └── export.feature
-├── P2_operations/        # Should pass
-│   ├── verification.feature
-│   └── resilience.feature
-├── P3_advanced/          # Nice to have
-│   ├── incremental.feature
-│   └── performance.feature
-└── P4_quality/           # Monitoring
-    └── data_validation.feature
-```
-
-**Estimated effort**: 8 hours
-**Impact**: Comprehensive test coverage
-
-### Medium Priority
-
-#### 3. Structured Logging
-
-Add structlog for JSON-compatible, aggregatable logs:
-
-```python
-import structlog
-
-logger = structlog.get_logger()
-
-logger.info("extraction_complete",
-           contracts=1500,
-           duration_ms=3400,
-           start_date="2024-01-01",
-           end_date="2024-01-31")
-```
-
-**Benefits**:
-- Better debugging with context
-- Log aggregation compatibility
-- Structured data for analytics
-
-**Estimated effort**: 1 hour
-**Impact**: Better observability
-
-#### 4. Ibis Framework for Analytics
-
-Add Ibis for complex analytical queries in the `verify` command:
-
-```python
-import ibis
-
-con = ibis.duckdb.connect("baliza.duckdb")
-contratos = con.table("contratos")
-
-# Lazy evaluation - only fetches needed data
-coverage_gaps = (
-    contratos
-    .filter(contratos.dataPublicacao.between(start, end))
-    .group_by(contratos.dataPublicacao.truncate('day'))
-    .aggregate(count=contratos.count())
-    .filter(lambda t: t.count < expected_threshold)
-)
-```
-
-**Estimated effort**: 3 hours
-**Impact**: Faster analytics, cleaner code
-
-#### 5. Multi-Parquet Architecture
-
-Separate exports for better query performance:
-
-```
-data/
-├── contratos/              # Raw contract data
-│   └── ano=YYYY/mes=MM/
-├── orgaos/                 # Organization reference data
-│   └── orgaos.parquet
-└── agregados/              # Pre-computed statistics
-    └── resumo_mensal.parquet
-```
-
-**Benefits**:
-- 3-5x faster queries (smaller files)
-- Reprocessing flexibility
-- Better caching
-
-**Estimated effort**: 2 hours
-**Impact**: Query performance
-
-### Future Considerations
-
-#### 6. AI-Powered Anomaly Detection
-
-Use Pydantic AI for procurement anomaly analysis:
-
-```python
-from pydantic import BaseModel
-from pydantic_ai import Agent
-
-class ContractAnalysis(BaseModel):
-    anomaly_score: float
-    risk_factors: list[str]
-    price_deviation_pct: float
-    recommendation: str
-
-agent = Agent(model="gemini-2.5-flash")
-
-async def analyze_contract(contract: dict) -> ContractAnalysis:
-    return await agent.run(
-        f"Analyze this procurement contract for anomalies: {contract}",
-        result_type=ContractAnalysis
-    )
-```
-
-**Use cases**:
-- Price outlier detection
-- Suspicious vendor patterns
-- Contract splitting detection
-- Unusual timing patterns
-
-#### 7. Jules-Style Automation
-
-Consider autonomous AI personas for development:
-
-| Persona | Role |
-|---------|------|
-| 🔧 Refactor | Auto-fix linting, type errors |
-| 🛡️ Sentinel | Security vulnerability scanning |
-| 🧪 BDD Specialist | Test coverage expansion |
+**Key insight**: structlog gives causaganha machine-parseable logs with bound
+context (tribunal name, date, page number). Baliza mixes `logger.warning()`
+format strings with `console.print()` Rich formatting. The structlog pattern is
+a clear improvement for CI debugging and operational monitoring.
 
 ---
 
-## Implementation Roadmap
+## 4. Operational Patterns Worth Importing
 
-### Phase 0: GitHub Actions Patterns (COMPLETED)
+### Tier 1: High Impact, Low Risk
 
-- [x] **Concurrency control** - Prevent overlapping workflow runs
-- [x] **D-1 priority extraction** - Always extract yesterday first
-- [x] **State persistence via artifacts** - Resume from previous database state
-- [x] **High-frequency extraction workflow** - Every 30 minutes continuous extraction
-- [x] **Timeout protection** - Prevent runaway workflows
+#### 1. Structured Logging (structlog)
 
-### Phase 1: Quick Wins (Week 1)
+**What**: Replace stdlib `logging` + `console.print()` mix with `structlog` for
+JSON-structured, context-bound operational logging.
 
-- [ ] Add structlog for logging
-- [ ] Add pytest markers for test tiers (`@pytest.mark.tier0`, etc.)
-- [ ] Create separate Parquet for organizations
+**Where in causaganha**: Used throughout; configured as a core dependency in `pyproject.toml`.
 
-### Phase 2: Performance (Week 2-3)
+**Where in baliza**: `extractor.py` (line 38: `logger = logging.getLogger(__name__)`),
+`daily_exporter.py`, `cli_simple.py`. Keep `rich.Console` only for user-facing
+CLI output (panels, tables, progress bars).
 
-- [ ] Migrate extractor to async httpx
-- [ ] Add Ibis for analytical queries
-- [ ] Implement concurrent page fetching
+**Effort**: 1 day | **Risk**: Low (drop-in replacement)
 
-### Phase 3: Testing (Week 4)
+**Why it matters**: During 30-minute extraction runs in CI, structured logs with
+bound context (`resource=contratos`, `date=2026-04-01`, `page=7/23`) make
+debugging failures dramatically faster than grepping text output.
 
-- [ ] Expand BDD scenarios with P1-P5 hierarchy
-- [ ] Add integration tests for edge cases
-- [ ] Add performance benchmarks
+#### 2. Per-Run Deadline Management
 
-### Phase 4: Advanced (Future)
+**What**: Set an internal deadline (e.g., 22 minutes) that triggers graceful
+checkpoint and shutdown before the GitHub Actions `timeout-minutes: 25` kills
+the process abruptly.
 
-- [ ] AI-powered anomaly detection (optional)
-- [ ] Multi-parquet export architecture
-- [ ] Consider Jules-style automation
+**Where in causaganha**: `collect-zips.yml` uses a 17-minute deadline with the
+`--deadline` CLI flag. The CLI monitors elapsed time and stops accepting new
+work units when the deadline approaches.
+
+**Where in baliza**: `extractor.py` `_extract_range_task()` (line 482+) and
+`cli_simple.py` `extract` command. Add a `--deadline-minutes` CLI option that
+propagates to the extractor loop.
+
+**Effort**: 1 day | **Risk**: Low (additive, no behavior change without the flag)
+
+**Why it matters**: Currently, if a GHA timeout kills baliza mid-page-fetch, the
+checkpoint for that page is lost. With deadline management, extraction stops
+cleanly at the last completed page.
+
+#### 3. Stall / Circuit Breaker Detection
+
+**What**: Detect when a PNCP resource consistently returns zero results and
+surface this proactively, rather than silently continuing to poll.
+
+**Where in causaganha**: 60-day consecutive absence detection per tribunal.
+Tribunals that stop reporting are flagged as "stopped" and excluded from
+collection until manually reset.
+
+**Where in baliza**: Could be added to `extractor.py` and surfaced in `baliza
+verify` / `baliza status`. Track consecutive zero-result days per resource in
+`baliza_state` and warn when a threshold is hit (e.g., 7 days for PNCP, which
+is more stable than 91 courts).
+
+**Effort**: 1 day | **Risk**: Low
+
+**Why it matters**: If PNCP changes its API or a resource stops returning data,
+baliza currently runs extraction every 30 minutes indefinitely with zero results.
+A circuit breaker would surface this as an actionable alert instead of silent
+waste.
+
+### Tier 2: Medium Impact, Medium Risk
+
+#### 4. Richer GitHub Issue Alerting
+
+**What**: Enhance the existing failure-reporting GitHub Issues with coverage
+metrics, not just workflow failure details. Report zero-extraction days,
+coverage drops, or prolonged gaps.
+
+**Where in causaganha**: Smoke tests in `collect-zips.yml` check for zero ZIPs
+collected and coverage below 73/91 tribunals, triggering alerts.
+
+**Where in baliza**: Extend `daily-export.yml` and `historical-backfill.yml`
+failure jobs to include coverage statistics from `baliza verify`.
+
+**Effort**: 1 day | **Risk**: Low
+
+#### 5. Multi-Phase Pipeline Separation
+
+**What**: Explicitly separate the pipeline into collect -> transform -> export ->
+upload stages, each independently resumable.
+
+**Where in causaganha**: `scripts/pipeline/` has separate `collect.py`,
+`consolidate.py`, `convert.py` scripts, each independently runnable and
+checkpointed.
+
+**Where in baliza**: Currently, extraction and DuckDB insertion are tightly
+coupled in `extractor.py`. Export and upload are separate scripts. The main
+benefit would be making the extract step write raw JSON to a staging area before
+DuckDB insertion, enabling re-processing without re-downloading.
+
+**Effort**: 3 days | **Risk**: Medium (architectural change)
+
+#### 6. Per-Resource State Cursors
+
+**What**: When baliza expands beyond `contratos` to support `atas-registro-preco`,
+`termos-contrato`, etc., track state independently per resource with cursor-based
+progress tracking.
+
+**Where in causaganha**: Per-tribunal cursor tracking allows each of the 91
+courts to progress independently. If one court stalls, others continue.
+
+**Where in baliza**: `baliza_state.coverage` already supports per-resource
+tracking via the `resource` column. The gap is cursor-based progress (like "last
+successfully processed page for resource X on date Y") rather than
+window-based status.
+
+**Effort**: 2 days | **Risk**: Low (builds on existing schema)
+
+### Tier 3: Evaluate Later
+
+| Pattern | Notes |
+|---------|-------|
+| **Ibis for analytical queries** | Would clean up `verify` and `status` commands in `cli_simple.py`. Low urgency since current SQL works fine. |
+| **GHA cache vs artifacts** | CausaGanha uses GHA cache (faster restore) vs baliza's artifacts. Worth benchmarking the restore time difference for `baliza.duckdb`. |
+| **Backwards date processing** | CausaGanha backfills newest-first. Could be useful for baliza if recent data is more valuable. Add as a `--direction` flag to backfill. |
+| **Increased collection frequency** | 20 min vs 30 min. Depends on PNCP API tolerance and whether more frequent runs yield meaningfully fresher data. |
 
 ---
 
-## Conclusion
+## 5. Aspirational Only (Not Operational Patterns)
 
-CausaGanha provides a battle-tested blueprint for:
-1. **Async architecture** - Essential for API-heavy workloads
-2. **Structured testing** - Priority-based BDD hierarchy
-3. **Modern tooling** - Ibis, structlog, Pydantic AI
-4. **Automation** - AI-assisted development
+These causaganha features are **domain-specific or not pipeline patterns**.
+They are interesting but not candidates for import into baliza's data pipeline:
 
-The biggest immediate wins for Baliza are:
-1. **Async extraction** (5-10x speedup)
-2. **Structured logging** (better debugging)
-3. **Test tier expansion** (comprehensive coverage)
+| Feature | Why it's not operational |
+|---------|------------------------|
+| **Pydantic-AI analytics** | Judicial decision analysis; baliza is a data pipeline, not an analytics platform |
+| **OpenSkill rating system** | Lawyer performance rating; domain-specific to legal analytics |
+| **LanceDB vector embeddings** | Semantic search over judicial documents; no procurement use case |
+| **Jules automation (23 AI personas)** | Development tooling, not pipeline architecture |
+| **459+ BDD scenarios** | A scale metric, not a pattern. Baliza's tier system (`@tier0`-`@tier3`) already provides the infrastructure for test expansion. |
+| **Ibis for write-heavy paths** | CausaGanha uses Ibis for consolidation queries. Baliza's write-heavy extraction path is already optimized with raw DuckDB SQL + Arrow batch insertion. |
 
-These patterns can be adopted incrementally without disrupting Baliza's "ship early, iterate" philosophy.
+---
+
+## 6. Decision Log: What We Chose NOT to Import
+
+| Pattern | Reason for rejection |
+|---------|---------------------|
+| **Async httpx migration** | PNCP is 1 API that rate-limits at ~4 concurrent requests. `ThreadPoolExecutor(4)` already saturates the API. Async adds complexity without throughput gain. CausaGanha also uses sync httpx -- the old comparison doc's claim of "asyncio everywhere" was inaccurate. |
+| **JSON state files** | Baliza's DuckDB state tables are more robust for a single-API extractor: transactionally consistent, queryable via SQL, co-located with the data. JSON files make sense for causaganha's 91 independent sources where simplicity and inspectability matter more. |
+| **`internetarchive` library** | Baliza's direct S3 PUT is more controllable and already has resumability via HEAD check. The `ia` library adds a heavyweight dependency for functionality we already have. |
+| **20-worker parallelism** | PNCP would rate-limit us. 4 workers is the empirically optimal ceiling (benchmarked: 3.5s at 4 workers, 34s at 16 workers due to 429 errors). |
+| **Telegram alerting** | GitHub Issues provide sufficient alerting for baliza's single-API pipeline. Telegram adds operational overhead (bot management, token rotation) without proportional benefit for a pipeline with 1 data source. |
+| **Backwards backfill direction** | Baliza's forward (oldest-first) backfill ensures complete historical coverage. For PNCP procurement data, historical completeness matters more than recency of backfill. Can revisit if priorities change. |
+
+---
+
+## 7. Architectural Context
+
+The projects differ because they serve fundamentally different data landscapes:
+
+**CausaGanha** manages **91 independent, unreliable sources** (Brazilian courts).
+Each tribunal has different availability patterns, formats, and failure modes.
+This drives the need for per-source cursors, stall detection (60-day circuit
+breaker), high worker counts (20), and frequent collection (every 20 min).
+State lives in simple JSON files because per-tribunal state is independent and
+can be rebuilt from Internet Archive if lost.
+
+**Baliza** manages **1 well-structured API** (PNCP). The API is stable, has
+consistent pagination, and rate-limits aggressively. This drives a simpler
+architecture: fewer workers (4), DuckDB-based state (transactional
+consistency), and longer collection intervals (30 min). The complexity lives in
+data normalization (nested JSON to flat Parquet) and export quality (streaming
+O(1) memory, rich manifests with checksums).
+
+Neither approach is better -- they are appropriate responses to different
+constraints. The patterns worth importing are the **operational practices**
+(structured logging, deadline management, circuit breakers) that are valuable
+regardless of data source count.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "duckdb>=1.4.3",
     "pyarrow>=14.0.0",
     "tenacity>=8.2.0",
+    "structlog>=24.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -14,6 +14,7 @@ from rich.table import Table
 
 from .daily_exporter import DailyExporter
 from .extractor import PNCPExtractor
+from .logging import configure_logging
 from .utils import (
     escape_sql_literal,
     scrub_url_params,
@@ -21,8 +22,14 @@ from .utils import (
     validate_resource_path,
 )
 
-app = typer.Typer(help="Baliza - Simple PNCP extraction tool")
+app = typer.Typer()
 console = Console()
+
+
+@app.callback()
+def main() -> None:
+    """Baliza - Simple PNCP extraction tool."""
+    configure_logging()
 
 
 @app.command("extract")

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -205,6 +205,23 @@ def verify(
             else:
                 console.print(f"[green]✓ Complete coverage from {start} to {end}")
 
+            # Check resource health (circuit breaker)
+            try:
+                health = con.execute(
+                    "SELECT consecutive_empty_days, status "
+                    "FROM baliza_state.resource_health WHERE resource = ?",
+                    [resource],
+                ).fetchone()
+                if health and health[1] in ("warning", "stalled"):
+                    style = "red" if health[1] == "stalled" else "yellow"
+                    console.print(
+                        f"[{style}]⚠ Resource '{resource}': "
+                        f"{health[0]} consecutive empty days "
+                        f"(status: {health[1]})[/{style}]"
+                    )
+            except Exception:
+                pass  # Table may not exist in older databases
+
     except Exception as e:
         msg = scrub_url_params(str(e))
         console.print(f"[red]✗ Verify failed: {msg}")
@@ -412,6 +429,15 @@ def status(
             except Exception:
                 checkpoints = 0
 
+            # Resource health (circuit breaker)
+            try:
+                health_rows = con.execute(
+                    "SELECT resource, consecutive_empty_days, last_nonempty_date, status "
+                    "FROM baliza_state.resource_health"
+                ).fetchall()
+            except Exception:
+                health_rows = []
+
         # Display
         console.print(Panel("[bold]Baliza PNCP Status[/bold]", style="blue"))
         console.print()
@@ -430,7 +456,22 @@ def status(
 
         # Warnings
         if checkpoints > 0:
-            console.print(f"\n[yellow]⚠ {checkpoints} extraction(s) incomplete - will resume on next run[/yellow]")
+            console.print(
+                f"\n[yellow]⚠ {checkpoints} extraction(s) incomplete"
+                " - will resume on next run[/yellow]"
+            )
+
+        # Resource health warnings
+        for row in health_rows:
+            resource_name, empty_days, last_nonempty, health_status = row
+            if health_status in ("warning", "stalled"):
+                style = "red" if health_status == "stalled" else "yellow"
+                last = str(last_nonempty) if last_nonempty else "never"
+                console.print(
+                    f"[{style}]⚠ Resource '{resource_name}': "
+                    f"{empty_days} consecutive empty days "
+                    f"(status: {health_status}, last data: {last})[/{style}]"
+                )
 
     except Exception as e:
         msg = scrub_url_params(str(e))

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -70,6 +70,11 @@ def extract(  # noqa: PLR0913
         max=16,
         help="Number of concurrent workers (1-16)",
     ),
+    deadline_minutes: int | None = typer.Option(
+        None,
+        "--deadline-minutes",
+        help="Stop gracefully after N minutes (preserves checkpoint)",
+    ),
 ) -> None:
     """Extract data from PNCP API to DuckDB.
 
@@ -84,10 +89,17 @@ def extract(  # noqa: PLR0913
         start_date = datetime.strptime(start, "%Y-%m-%d")
         end_date = datetime.strptime(end, "%Y-%m-%d")
 
+        # Compute deadline if specified
+        deadline: datetime | None = None
+        if deadline_minutes is not None:
+            deadline = datetime.now() + timedelta(minutes=deadline_minutes)
+
         # Extract data
         start_time = time.time()
         with PNCPExtractor(db_path, dataset) as extractor:
-            result = extractor.extract(start_date, end_date, resource, workers=workers)
+            result = extractor.extract(
+                start_date, end_date, resource, workers=workers, deadline=deadline
+            )
         duration = time.time() - start_time
 
         # Create summary

--- a/src/baliza/extractor.py
+++ b/src/baliza/extractor.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import concurrent.futures
 import json
-import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, TypedDict
@@ -17,6 +16,7 @@ import duckdb
 import httpx
 import pyarrow as pa
 import pyarrow.compute as pc
+import structlog
 from rich.console import Console
 from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn, TextColumn
 from tenacity import (
@@ -35,7 +35,7 @@ from .utils import (
 )
 
 # Configure logger for retry logging
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 console = Console()
 
@@ -119,17 +119,37 @@ def _log_retry(retry_state: RetryCallState) -> None:
     if isinstance(exc, httpx.HTTPStatusError):
         status = exc.response.status_code
         logger.warning(
-            "Retry %d/5 after HTTP %d: %s",
-            attempt,
-            status,
-            scrub_url_params(str(exc.request.url)),
+            "retry_attempt",
+            attempt=attempt,
+            max_attempts=5,
+            kind="http_error",
+            status=status,
+            url=scrub_url_params(str(exc.request.url)),
         )
     elif isinstance(exc, httpx.ConnectError):
-        logger.warning("Retry %d/5 after connection error: %s", attempt, scrub_url_params(str(exc)))
+        logger.warning(
+            "retry_attempt",
+            attempt=attempt,
+            max_attempts=5,
+            kind="connection_error",
+            error=scrub_url_params(str(exc)),
+        )
     elif isinstance(exc, httpx.TimeoutException):
-        logger.warning("Retry %d/5 after timeout: %s", attempt, scrub_url_params(str(exc)))
+        logger.warning(
+            "retry_attempt",
+            attempt=attempt,
+            max_attempts=5,
+            kind="timeout",
+            error=scrub_url_params(str(exc)),
+        )
     else:
-        logger.warning("Retry %d/5 after error: %s", attempt, scrub_url_params(str(exc)))
+        logger.warning(
+            "retry_attempt",
+            attempt=attempt,
+            max_attempts=5,
+            kind="unknown",
+            error=scrub_url_params(str(exc)),
+        )
 
 
 @retry(

--- a/src/baliza/extractor.py
+++ b/src/baliza/extractor.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import json
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any, TypedDict
 
@@ -360,6 +360,17 @@ class PNCPExtractor:
                 total_rows INTEGER
             )
         """)
+        # Track resource health for stall/circuit breaker detection
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS baliza_state.resource_health (
+                resource VARCHAR PRIMARY KEY,
+                consecutive_empty_days INTEGER DEFAULT 0,
+                last_nonempty_date DATE,
+                last_checked_date DATE,
+                status VARCHAR DEFAULT 'healthy',
+                updated_at TIMESTAMP
+            )
+        """)
 
     def _get_checkpoint(
         self, con: duckdb.DuckDBPyConnection, resource: str, extraction_date: datetime
@@ -418,6 +429,60 @@ class PNCPExtractor:
         """,
             [resource, extraction_date.date()],
         )
+
+    # -- Circuit breaker / resource health tracking --
+
+    STALL_WARNING_THRESHOLD = 3
+    STALL_CRITICAL_THRESHOLD = 7
+
+    def _update_resource_health(
+        self,
+        con: duckdb.DuckDBPyConnection,
+        resource: str,
+        checked_date: date,
+        rows_extracted: int,
+    ) -> None:
+        """Update resource health tracking for stall detection."""
+        existing = con.execute(
+            "SELECT consecutive_empty_days FROM baliza_state.resource_health WHERE resource = ?",
+            [resource],
+        ).fetchone()
+
+        if rows_extracted == 0:
+            new_count = (existing[0] + 1) if existing else 1
+            if new_count >= self.STALL_CRITICAL_THRESHOLD:
+                new_status = "stalled"
+            elif new_count >= self.STALL_WARNING_THRESHOLD:
+                new_status = "warning"
+            else:
+                new_status = "healthy"
+
+            # Preserve last_nonempty_date from existing row
+            last_nonempty = con.execute(
+                "SELECT last_nonempty_date FROM baliza_state.resource_health WHERE resource = ?",
+                [resource],
+            ).fetchone()
+            last_nonempty_date = last_nonempty[0] if last_nonempty else None
+
+            con.execute(
+                """INSERT OR REPLACE INTO baliza_state.resource_health
+                VALUES (?, ?, ?, ?, ?, NOW())""",
+                [resource, new_count, last_nonempty_date, checked_date, new_status],
+            )
+
+            if new_status != "healthy":
+                logger.warning(
+                    "resource_health_degraded",
+                    resource=resource,
+                    consecutive_empty_days=new_count,
+                    status=new_status,
+                )
+        else:
+            con.execute(
+                """INSERT OR REPLACE INTO baliza_state.resource_health
+                VALUES (?, 0, ?, ?, 'healthy', NOW())""",
+                [resource, checked_date, checked_date],
+            )
 
     def _insert_page(self, con: duckdb.DuckDBPyConnection, rows: list[dict[str, Any]]) -> int:
         """Insert a single page of results immediately."""
@@ -618,6 +683,12 @@ class PNCPExtractor:
                 """,
                     [resource, start_date, end_date, status, page, total_rows],
                 )
+
+                # Update resource health (circuit breaker) for single-day extractions
+                if start_date.date() == end_date.date() and status == "complete":
+                    self._update_resource_health(
+                        con, resource, start_date.date(), total_rows
+                    )
         finally:
             if progress and task_id:
                 progress.remove_task(task_id)

--- a/src/baliza/extractor.py
+++ b/src/baliza/extractor.py
@@ -499,12 +499,13 @@ class PNCPExtractor:
 
         return len(values)
 
-    def _extract_range_task(
+    def _extract_range_task(  # noqa: PLR0912, PLR0915
         self,
         start_date: datetime,
         end_date: datetime,
         resource: str,
         progress: Progress | None = None,
+        deadline: datetime | None = None,
     ) -> dict[str, Any]:
         """Extract data for a date range (worker function)."""
         data_inicial = start_date.strftime("%Y%m%d")
@@ -549,6 +550,17 @@ class PNCPExtractor:
                 }
 
                 while True:
+                    # Check deadline before fetching next page
+                    if deadline is not None and datetime.now() >= deadline:
+                        logger.info(
+                            "deadline_reached",
+                            resource=resource,
+                            date=str(start_date.date()),
+                            pages_completed=page - 1,
+                            rows=total_rows,
+                        )
+                        break
+
                     # Call PNCP API with retry
                     params["pagina"] = page
 
@@ -588,16 +600,23 @@ class PNCPExtractor:
 
                     page += 1
 
-                # Clear checkpoint on successful completion
-                self._clear_checkpoint(con, resource, start_date)
+                # Determine completion status
+                stopped_by_deadline = (
+                    deadline is not None and datetime.now() >= deadline
+                )
+                status = "deadline" if stopped_by_deadline else "complete"
+
+                # Only clear checkpoint on true completion
+                if not stopped_by_deadline:
+                    self._clear_checkpoint(con, resource, start_date)
 
                 # Record coverage for this range
                 con.execute(
                     """
                     INSERT OR REPLACE INTO baliza_state.coverage
-                    VALUES (?, ?, ?, 'complete', ?, ?, NOW())
+                    VALUES (?, ?, ?, ?, ?, ?, NOW())
                 """,
-                    [resource, start_date, end_date, page, total_rows],
+                    [resource, start_date, end_date, status, page, total_rows],
                 )
         finally:
             if progress and task_id:
@@ -616,6 +635,7 @@ class PNCPExtractor:
         end_date: datetime,
         resource: str = "contratos",
         workers: int = 4,
+        deadline: datetime | None = None,
     ) -> dict[str, Any]:
         """Extract data from PNCP API for a date range.
 
@@ -626,6 +646,7 @@ class PNCPExtractor:
             end_date: End of date range
             resource: Resource type (default: contratos)
             workers: Number of concurrent workers (default: 4)
+            deadline: Stop gracefully after this time (default: None = no limit)
 
         Returns:
             Dict with extraction results (rows_extracted, pages, etc.)
@@ -656,7 +677,9 @@ class PNCPExtractor:
             if workers == 1:
                 # Sequential mode (matches original behavior)
                 try:
-                    result = self._extract_range_task(start_date, end_date, resource, progress)
+                    result = self._extract_range_task(
+                        start_date, end_date, resource, progress, deadline=deadline
+                    )
                     total_rows = result["rows_extracted"]
                     total_pages = result["pages"]
                 except Exception as e:
@@ -678,7 +701,8 @@ class PNCPExtractor:
                 with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
                     futures = {
                         executor.submit(
-                            self._extract_range_task, date, date, resource, progress
+                            self._extract_range_task, date, date, resource, progress,
+                            deadline
                         ): date
                         for date in dates
                     }

--- a/src/baliza/logging.py
+++ b/src/baliza/logging.py
@@ -1,0 +1,39 @@
+"""Structured logging configuration for Baliza.
+
+Uses structlog for machine-parseable, context-bound logging.
+Set BALIZA_LOG_FORMAT=json for JSON output (useful in CI).
+"""
+
+from __future__ import annotations
+
+import os
+
+import structlog
+
+
+def configure_logging() -> None:
+    """Configure structlog with console or JSON renderer.
+
+    Reads BALIZA_LOG_FORMAT env var:
+    - "json": JSONRenderer for CI/log aggregation
+    - "console" (default): ConsoleRenderer for human-readable output
+    """
+    log_format = os.environ.get("BALIZA_LOG_FORMAT", "console")
+
+    if log_format == "json":
+        renderer = structlog.processors.JSONRenderer()
+    else:
+        renderer = structlog.dev.ConsoleRenderer()
+
+    structlog.configure(
+        processors=[
+            structlog.stdlib.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.StackInfoRenderer(),
+            renderer,
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(0),
+        context_class=dict,
+        logger_factory=structlog.PrintLoggerFactory(),
+        cache_logger_on_first_use=True,
+    )


### PR DESCRIPTION
## Summary

This PR imports three operational patterns from CausaGanha to improve Baliza's observability, resilience, and graceful shutdown behavior:

1. **Structured logging** via `structlog` for machine-parseable, context-bound logs
2. **Per-run deadline management** to gracefully checkpoint before GitHub Actions timeout
3. **Resource health tracking** (circuit breaker) to detect and alert on stalled data sources

## Key Changes

### Structured Logging (structlog)
- Added `src/baliza/logging.py` with `configure_logging()` that supports both human-readable console output (default) and JSON output (via `BALIZA_LOG_FORMAT=json` env var)
- Replaced stdlib `logging` with `structlog` in `extractor.py` and `cli_simple.py`
- Converted all retry logging to structured key-value format (e.g., `logger.warning("retry_attempt", attempt=1, kind="http_error", status=429)`)
- Kept `rich.Console` for user-facing CLI output (panels, tables, progress bars)

### Deadline Management
- Added `deadline: datetime | None` parameter to `PNCPExtractor.extract()` and `_extract_range_task()`
- Added `--deadline-minutes` CLI option to `extract` command
- Extraction loop now checks deadline before fetching each page and gracefully stops, preserving checkpoint state
- Logs deadline-triggered stops with pages completed and rows extracted
- Prevents loss of in-progress work when GitHub Actions kills the process at `timeout-minutes: 25`

### Resource Health Tracking (Circuit Breaker)
- Added `baliza_state.resource_health` table to track consecutive empty-result days per resource
- Implemented `_update_resource_health()` method with configurable thresholds:
  - `STALL_WARNING_THRESHOLD = 3` days
  - `STALL_CRITICAL_THRESHOLD = 7` days
- Resource status transitions: `healthy` → `warning` → `stalled`
- Logs warnings when status degrades
- Integrated into `verify` and `status` commands to surface resource health issues
- Preserves `last_nonempty_date` to track when a resource last returned data

### Coverage Tracking Enhancement
- Modified `baliza_state.coverage` to record extraction status (`complete` vs `deadline`) instead of always marking as `complete`
- Allows distinguishing between full extractions and deadline-interrupted ones

## Implementation Details

- **Logging configuration**: Called once at CLI startup via `@app.callback()` in `cli_simple.py`
- **Deadline propagation**: Passed through extraction task chain; checked before each API request
- **Health updates**: Only triggered for single-day extractions marked as `complete` (not deadline-interrupted)
- **Backward compatibility**: All new features are optional; existing workflows unaffected
- **Dependencies**: Added `structlog>=24.0.0` to `pyproject.toml`

## Testing Considerations

- Existing BDD tests continue to pass (no behavior change without `--deadline-minutes` flag)
- New deadline behavior can be tested by setting a short deadline and verifying checkpoint preservation
- Resource health tracking can be verified by simulating zero-result days and checking status transitions

https://claude.ai/code/session_01G7CM67V8GMuFE5EzonApyp