### PR TITLE
feat: import operational patterns from causaganha (structlog, deadline, circuit breaker)

### DIFF
--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,1 +1,0 @@
-"""Unit tests for baliza extractor checkpoint functionality."""

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -1,8 +1,10 @@
 from datetime import date
+
 import duckdb
 import pytest
 
 from baliza.extractor import PNCPExtractor
+
 
 @pytest.fixture
 def temp_db(tmp_path):

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -1,0 +1,101 @@
+from datetime import date
+import duckdb
+import pytest
+
+from baliza.extractor import PNCPExtractor
+
+@pytest.fixture
+def temp_db(tmp_path):
+    return tmp_path / "test.duckdb"
+
+@pytest.fixture
+def extractor(temp_db, monkeypatch):
+    monkeypatch.setenv("BALIZA_ALLOW_PRIVATE_NETWORKS", "1")
+    ext = PNCPExtractor(db_path=temp_db)
+    with duckdb.connect(str(temp_db)) as con:
+        ext._ensure_schema(con)
+    return ext
+
+def test_health_increments_on_empty_day(extractor, temp_db):
+    test_date = date(2023, 1, 1)
+
+    with duckdb.connect(str(temp_db)) as con:
+        extractor._update_resource_health(con, "contratos", test_date, rows_extracted=0)
+
+        health = con.execute(
+            "SELECT consecutive_empty_days, status FROM baliza_state.resource_health WHERE resource = 'contratos'"
+        ).fetchone()
+
+        assert health is not None
+        assert health[0] == 1
+        assert health[1] == "healthy"
+
+def test_health_resets_on_data(extractor, temp_db):
+    test_date_1 = date(2023, 1, 1)
+    test_date_2 = date(2023, 1, 2)
+
+    with duckdb.connect(str(temp_db)) as con:
+        # Increment once
+        extractor._update_resource_health(con, "contratos", test_date_1, rows_extracted=0)
+
+        health = con.execute(
+            "SELECT consecutive_empty_days FROM baliza_state.resource_health WHERE resource = 'contratos'"
+        ).fetchone()
+        assert health[0] == 1
+
+        # Reset on data
+        extractor._update_resource_health(con, "contratos", test_date_2, rows_extracted=100)
+
+        health_after = con.execute(
+            "SELECT consecutive_empty_days, status, last_nonempty_date FROM baliza_state.resource_health WHERE resource = 'contratos'"
+        ).fetchone()
+
+        assert health_after[0] == 0
+        assert health_after[1] == "healthy"
+        assert health_after[2] == test_date_2
+
+def test_warning_at_3_days(extractor, temp_db):
+    with duckdb.connect(str(temp_db)) as con:
+        for i in range(3):
+            test_date = date(2023, 1, 1 + i)
+            extractor._update_resource_health(con, "contratos", test_date, rows_extracted=0)
+
+        health = con.execute(
+            "SELECT consecutive_empty_days, status FROM baliza_state.resource_health WHERE resource = 'contratos'"
+        ).fetchone()
+
+        assert health[0] == 3
+        assert health[1] == "warning"
+
+def test_stalled_at_7_days(extractor, temp_db):
+    with duckdb.connect(str(temp_db)) as con:
+        for i in range(7):
+            test_date = date(2023, 1, 1 + i)
+            extractor._update_resource_health(con, "contratos", test_date, rows_extracted=0)
+
+        health = con.execute(
+            "SELECT consecutive_empty_days, status FROM baliza_state.resource_health WHERE resource = 'contratos'"
+        ).fetchone()
+
+        assert health[0] == 7
+        assert health[1] == "stalled"
+
+def test_last_nonempty_date_preserved(extractor, temp_db):
+    date_with_data = date(2023, 1, 1)
+    empty_date_1 = date(2023, 1, 2)
+    empty_date_2 = date(2023, 1, 3)
+
+    with duckdb.connect(str(temp_db)) as con:
+        # Initial run with data
+        extractor._update_resource_health(con, "contratos", date_with_data, rows_extracted=50)
+
+        # Followed by empties
+        extractor._update_resource_health(con, "contratos", empty_date_1, rows_extracted=0)
+        extractor._update_resource_health(con, "contratos", empty_date_2, rows_extracted=0)
+
+        health = con.execute(
+            "SELECT consecutive_empty_days, last_nonempty_date FROM baliza_state.resource_health WHERE resource = 'contratos'"
+        ).fetchone()
+
+        assert health[0] == 2
+        assert health[1] == date_with_data

--- a/tests/unit/test_deadline.py
+++ b/tests/unit/test_deadline.py
@@ -1,0 +1,141 @@
+import os
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock
+
+import duckdb
+import pytest
+
+from baliza.extractor import PNCPExtractor, CheckpointData
+
+
+@pytest.fixture
+def temp_db(tmp_path):
+    db_path = tmp_path / "test.duckdb"
+    return db_path
+
+
+@pytest.fixture
+def fake_page_data():
+    return {
+        "totalPaginas": 5,
+        "data": [
+            {
+                "numeroControlePNCP": "123",
+                "anoCompra": 2023,
+                "sequencialCompra": 1,
+                "dataPublicacao": "2023-01-01T10:00:00"
+            }
+        ]
+    }
+
+
+def test_deadline_stops_extraction(temp_db, fake_page_data, monkeypatch):
+    monkeypatch.setenv("BALIZA_ALLOW_PRIVATE_NETWORKS", "1")
+    extractor = PNCPExtractor(db_path=temp_db)
+
+    with duckdb.connect(str(temp_db)) as con:
+        extractor._ensure_schema(con)
+
+    start_date = datetime(2023, 1, 1)
+    end_date = datetime(2023, 1, 1)
+
+    # Deadline is in the past, so it should stop immediately
+    deadline = datetime.now() - timedelta(minutes=5)
+
+    with patch("baliza.extractor._fetch_page", return_value=fake_page_data) as mock_fetch:
+        result = extractor._extract_range_task(
+            start_date=start_date,
+            end_date=end_date,
+            resource="contratos",
+            deadline=deadline
+        )
+
+        assert result["pages"] == 1 # Initial value is 1, loop breaks before fetching page 1
+        assert result["rows_extracted"] == 0
+        mock_fetch.assert_not_called()
+
+        # Verify coverage status is 'deadline'
+        with duckdb.connect(str(temp_db)) as con:
+            coverage = con.execute(
+                "SELECT status FROM baliza_state.coverage WHERE resource = 'contratos'"
+            ).fetchone()
+            assert coverage is not None
+            assert coverage[0] == "deadline"
+
+def test_no_deadline_completes_normally(temp_db, fake_page_data, monkeypatch):
+    monkeypatch.setenv("BALIZA_ALLOW_PRIVATE_NETWORKS", "1")
+    extractor = PNCPExtractor(db_path=temp_db)
+
+    with duckdb.connect(str(temp_db)) as con:
+        extractor._ensure_schema(con)
+
+    start_date = datetime(2023, 1, 1)
+    end_date = datetime(2023, 1, 1)
+
+    empty_page = {"totalPaginas": 1, "data": []}
+
+    with patch("baliza.extractor._fetch_page", side_effect=[fake_page_data, empty_page]) as mock_fetch:
+        result = extractor._extract_range_task(
+            start_date=start_date,
+            end_date=end_date,
+            resource="contratos",
+            deadline=None
+        )
+
+        assert result["pages"] >= 1
+        assert result["rows_extracted"] == 1
+
+        with duckdb.connect(str(temp_db)) as con:
+            # Verify status is 'complete'
+            coverage = con.execute(
+                "SELECT status FROM baliza_state.coverage WHERE resource = 'contratos'"
+            ).fetchone()
+            assert coverage is not None
+            assert coverage[0] == "complete"
+
+            # Verify checkpoint is cleared
+            checkpoint = con.execute(
+                "SELECT * FROM baliza_state.extraction_checkpoint"
+            ).fetchone()
+            assert checkpoint is None
+
+def test_deadline_preserves_checkpoint(temp_db, fake_page_data, monkeypatch):
+    monkeypatch.setenv("BALIZA_ALLOW_PRIVATE_NETWORKS", "1")
+    extractor = PNCPExtractor(db_path=temp_db)
+
+    with duckdb.connect(str(temp_db)) as con:
+        extractor._ensure_schema(con)
+
+    start_date = datetime(2023, 1, 1)
+    end_date = datetime(2023, 1, 1)
+
+    # We want it to do one page and then stop by deadline, OR stop immediately but we have a checkpoint beforehand
+    # The instruction says: "With expired deadline, verify `_clear_checkpoint` is NOT called (checkpoint row still exists in DuckDB)."
+    # Let's seed a checkpoint manually, then run with expired deadline.
+
+    with duckdb.connect(str(temp_db)) as con:
+        stats = {"current_page": 2, "total_pages": 5, "rows_extracted": 100}
+        extractor._save_checkpoint(con, "contratos", start_date, stats, datetime.now())
+
+        checkpoint_before = con.execute(
+            "SELECT current_page FROM baliza_state.extraction_checkpoint"
+        ).fetchone()
+        assert checkpoint_before[0] == 2
+
+    deadline = datetime.now() - timedelta(minutes=5)
+
+    with patch("baliza.extractor._fetch_page") as mock_fetch:
+        extractor._extract_range_task(
+            start_date=start_date,
+            end_date=end_date,
+            resource="contratos",
+            deadline=deadline
+        )
+
+        with duckdb.connect(str(temp_db)) as con:
+            checkpoint_after = con.execute(
+                "SELECT current_page FROM baliza_state.extraction_checkpoint"
+            ).fetchone()
+            # The checkpoint should still exist because it was stopped by deadline
+            assert checkpoint_after is not None
+            assert checkpoint_after[0] == 2

--- a/tests/unit/test_deadline.py
+++ b/tests/unit/test_deadline.py
@@ -1,11 +1,10 @@
-import os
 from datetime import datetime, timedelta
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import duckdb
 import pytest
 
-from baliza.extractor import PNCPExtractor, CheckpointData
+from baliza.extractor import PNCPExtractor
 
 
 @pytest.fixture
@@ -74,7 +73,7 @@ def test_no_deadline_completes_normally(temp_db, fake_page_data, monkeypatch):
 
     empty_page = {"totalPaginas": 1, "data": []}
 
-    with patch("baliza.extractor._fetch_page", side_effect=[fake_page_data, empty_page]) as mock_fetch:
+    with patch("baliza.extractor._fetch_page", side_effect=[fake_page_data, empty_page]):
         result = extractor._extract_range_task(
             start_date=start_date,
             end_date=end_date,
@@ -124,7 +123,7 @@ def test_deadline_preserves_checkpoint(temp_db, fake_page_data, monkeypatch):
 
     deadline = datetime.now() - timedelta(minutes=5)
 
-    with patch("baliza.extractor._fetch_page") as mock_fetch:
+    with patch("baliza.extractor._fetch_page"):
         extractor._extract_range_task(
             start_date=start_date,
             end_date=end_date,

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,43 @@
+import json
+import logging
+from unittest.mock import patch
+import structlog
+import pytest
+
+from baliza.logging import configure_logging
+
+def test_configure_logging_console(monkeypatch):
+    monkeypatch.setenv("BALIZA_LOG_FORMAT", "console")
+    configure_logging()
+
+    logger = structlog.get_logger()
+    assert logger is not None
+    # We just ensure it doesn't crash
+    logger.info("Test message console")
+
+def test_configure_logging_json(monkeypatch, capsys):
+    monkeypatch.setenv("BALIZA_LOG_FORMAT", "json")
+    configure_logging()
+
+    logger = structlog.get_logger()
+    logger.info("test_event", custom_key="custom_value")
+
+    captured = capsys.readouterr()
+    output_lines = [line for line in captured.out.split('\n') if line]
+
+    # Check that at least one output line is valid JSON with expected keys
+    found_valid_json = False
+    for line in output_lines:
+        try:
+            log_entry = json.loads(line)
+            if "event" in log_entry and log_entry["event"] == "test_event":
+                assert "timestamp" in log_entry
+                assert "level" in log_entry
+                assert log_entry["level"] == "info"
+                assert log_entry["custom_key"] == "custom_value"
+                found_valid_json = True
+                break
+        except json.JSONDecodeError:
+            continue
+
+    assert found_valid_json, f"Could not find valid JSON log output in {output_lines}"

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,10 +1,9 @@
 import json
-import logging
-from unittest.mock import patch
+
 import structlog
-import pytest
 
 from baliza.logging import configure_logging
+
 
 def test_configure_logging_console(monkeypatch):
     monkeypatch.setenv("BALIZA_LOG_FORMAT", "console")


### PR DESCRIPTION
## Summary

Imports 3 proven operational patterns from the sister project causaganha into baliza, plus a rewritten comparison document.

### Changes
- Comparison doc rewrite — docs/CAUSAGANHA_COMPARISON.md now focuses on operational pipeline patterns (download + archive), not aspirational features. Includes decision log for rejected patterns.
- structlog adoption — Replace stdlib logging with structlog for machine-parseable, context-bound logs. Set BALIZA_LOG_FORMAT=json for CI. Retry logging now uses structured key-value pairs.
- Per-run deadline management — New --deadline-minutes CLI option for baliza extract. Stops gracefully before GHA timeout, preserves checkpoint for resume. GHA workflows updated: 22 min for 25-min timeout, 27 min for 30-min timeout.
- Stall/circuit breaker detection — New baliza_state.resource_health table tracks consecutive empty extraction days per resource. Warning at 3 days, stalled at 7. Surfaced in baliza status and baliza verify.

## Files changed

| File | Change |
|------|--------|
| docs/CAUSAGANHA_COMPARISON.md | Full rewrite |
| pyproject.toml | Add structlog dependency |
| src/baliza/logging.py | NEW — structlog configuration |
| src/baliza/extractor.py | structlog, deadline check, resource_health |
| src/baliza/cli_simple.py | Typer callback, --deadline-minutes, health display |
| .github/workflows/continuous-extract.yml | --deadline-minutes 22 |
| .github/workflows/historical-backfill.yml | --deadline-minutes 22 |
| .github/workflows/daily-export.yml | --deadline-minutes 27 |
| tests/unit/test_deadline.py | NEW |
| tests/unit/test_circuit_breaker.py | NEW |
| tests/unit/test_logging.py | NEW |

## Test plan
- [x] unit tests pass for deadline, circuit breaker, structlog
- [ ] baliza extract --help shows --deadline-minutes option
- [ ] baliza status shows resource health warnings when applicable
- [ ] BALIZA_LOG_FORMAT=json produces valid JSON log output
- [ ] Existing BDD tests unaffected

---
*PR created automatically by Jules for task [18163705830465742827](https://jules.google.com/task/18163705830465742827) started by @franklinbaldo*