### PR TITLE
docs: add Jules private repo test session results

### DIFF
--- a/docs/reports/jules-test-session-results.md
+++ b/docs/reports/jules-test-session-results.md
@@ -1,0 +1,93 @@
+# Jules Private Repo Access Test Report (New Session)
+
+Date: 2025-04-10
+Session: 4868697377064366900
+Repo: franklinbaldo/baliza (private)
+
+## Summary
+
+- ❌ GitHub CLI authenticated
+- ❌ Can list issues
+- ❌ Can list PRs
+- ✅ Can read repo files
+- ❌ GitHub token available
+- ❌ Can call GitHub API
+
+## Test Results
+
+### 1. Environment Variables
+
+```
+JULES_SESSION_ID=4868697377064366900
+GIT_TERMINAL_PROMPT=0
+```
+
+### 2. Git Config
+
+```
+user.name=google-labs-jules[bot]
+user.email=161369871+google-labs-jules[bot]@users.noreply.github.com
+core.hookspath=/dev/null
+core.repositoryformatversion=0
+core.filemode=true
+core.bare=false
+core.logallrefupdates=true
+submodule.active=.
+remote.origin.url=https://github.com/franklinbaldo/baliza
+remote.origin.fetch=+refs/heads/*:refs/remotes/origin/*
+branch.main.remote=origin
+branch.main.merge=refs/heads/main
+```
+
+### 3. Repo Files Access
+
+**Root listing:**
+```
+total 220
+drwxr-xr-x 9 jules root    4096 Apr 10 14:36 .
+drwxr-xr-x 1 root  root    4096 Apr 10 14:36 ..
+-rw-rw-r-- 1 jules jules    395 Apr 10 14:36 .dockerignore
+drwxrwxr-x 7 jules jules   4096 Apr 10 14:40 .git
+drwxrwxr-x 4 jules jules   4096 Apr 10 14:36 .github
+-rw-rw-r-- 1 jules jules    299 Apr 10 14:36 .gitignore
+drwxrwxr-x 2 jules jules   4096 Apr 10 14:36 .idx
+-rw-rw-r-- 1 jules jules    153 Apr 10 14:36 .pre-commit-config.yaml
+-rw-rw-r-- 1 jules jules     86 Apr 10 14:36 .repomixignore
+-rw-rw-r-- 1 jules jules    546 Apr 10 14:36 CHANGELOG.md
+-rw-rw-r-- 1 jules jules   7086 Apr 10 14:36 DASHBOARD_SPECS.md
+-rw-rw-r-- 1 jules jules   1157 Apr 10 14:36 Dockerfile
+-rw-rw-r-- 1 jules jules   1915 Apr 10 14:36 ISSUES_TRIAGE.md
+-rw-rw-r-- 1 jules jules   4456 Apr 10 14:36 PR_SUMMARY.md
+-rw-rw-r-- 1 jules jules   3579 Apr 10 14:36 README.md
+-rw-rw-r-- 1 jules jules   6781 Apr 10 14:36 ROADMAP.md
+-rw-rw-r-- 1 jules jules   5939 Apr 10 14:36 debug_api.py
+drwxrwxr-x 8 jules jules   4096 Apr 10 14:36 docs
+-rw-rw-r-- 1 jules jules     53 Apr 10 14:36 mypy.ini
+-rw-rw-r-- 1 jules jules   2435 Apr 10 14:36 pyproject.toml
+-rw-rw-r-- 1 jules jules    801 Apr 10 14:36 repomix.config.json
+drwxrwxr-x 2 jules jules   4096 Apr 10 14:36 scripts
+drwxrwxr-x 4 jules jules   4096 Apr 10 14:36 src
+-rw-rw-r-- 1 jules jules 274432 Apr 10 14:36 test_clean.duckdb
+drwxrwxr-x 8 jules jules   4096 Apr 10 14:36 tests
+```
+
+### 4. GitHub API Response
+```
+{
+  "message": "Bad credentials",
+  "documentation_url": "https://docs.github.com/rest",
+  "status": "401"
+}
+```
+
+### 5. GitHub CLI (gh)
+```
+-bash: gh: command not found
+```
+
+## Conclusions
+The previous conclusions hold true for this test session:
+1. Code Access: Yes. Jules can read repo files directly from the filesystem.
+2. Issue/PR Access: No. Jules cannot list or read issues and PRs via CLI or API.
+3. Authentication: No valid GITHUB_TOKEN is available in the environment.
+4. Limitations: Jules is restricted to file manipulation and cannot interact with GitHub project management features.


### PR DESCRIPTION
Added `docs/reports/jules-test-session-results.md` to document the environment variables, git config, and access capabilities for the current test session for Jules.

---
*PR created automatically by Jules for task [4868697377064366900](https://jules.google.com/task/4868697377064366900) started by @franklinbaldo*