### PR TITLE
feat: modernize PNCP sync with monthly ranges, GA cache and UI refinements

### DIFF
--- a/.github/workflows/pncp-sync.yml
+++ b/.github/workflows/pncp-sync.yml
@@ -24,10 +24,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Get current month for cache key
+        id: get-cache-key
+        run: echo "month=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
+
       - name: Setup uv
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+
+      - name: Restore Raw Data Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: data/raw
+          key: pncp-raw-${{ steps.get-cache-key.outputs.month }}-${{ github.run_id }}
+          restore-keys: |
+            pncp-raw-${{ steps.get-cache-key.outputs.month }}-
 
       - name: Install dependencies
         run: uv sync
@@ -41,3 +53,10 @@ jobs:
           uv run baliza sync \
             --start-date "${{ github.event.inputs.start_date || '2023-01-01' }}" \
             --limit-minutes 340
+
+      - name: Save Raw Data Cache (Always)
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: data/raw
+          key: pncp-raw-${{ steps.get-cache-key.outputs.month }}-${{ github.run_id }}

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -128,6 +128,30 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
         probe_task = progress.add_task("[bold cyan]Probing Dates[/bold cyan]", total=len(batch))
         fetch_task = progress.add_task("[bold magenta]Global Fetch Queue[/bold magenta]", total=0)
 
+    # 3. Micro-metrics
+    total_records = 0
+    quarantine_count = 0
+    error_count = 0
+
+    # 3. Orchestration logic
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[bold blue]{task.description}"),
+        BarColumn(bar_width=None, pulse_style="bright_black"),
+        TaskProgressColumn(),
+        MofNCompleteColumn(),
+        TimeElapsedColumn(),
+        console=console,
+        refresh_per_second=10,
+        expand=True,
+    ) as progress:
+        overall_task = progress.add_task(
+            "Overall Sync Progress", total=len(batch)
+        )
+        
+        # We'll use a local dict to map workers to their current date task
+        # But even better: just add/remove tasks dynamically.
+        # Since Workers=N, only N day_tasks will be active at once.
         day_tasks: dict[date, TaskID] = {}
 
         with PNCPExtractor(engine, use_curl=not no_curl) as extractor:
@@ -135,161 +159,89 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
             with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
                 futures: dict[concurrent.futures.Future[Any], tuple[str, date, int]] = {}
 
-                def finish_day(t_date: date):
+                def process_day_full(t_date: date, total_pages: int):
+                    nonlocal total_records, quarantine_count, error_count
+                    
+                    tid = progress.add_task(f"Day {t_date} [Fetching]", total=total_pages, completed=1)
+                    day_tasks[t_date] = tid
+                    
                     try:
-                        # Ensure task exists and update status
-                        if t_date not in day_tasks:
-                            day_tasks[t_date] = progress.add_task(
-                                f"[dim]Day {t_date}[/dim] [magenta][Ingesting][/magenta]", total=1, completed=0
-                            )
-                        else:
-                            progress.update(day_tasks[t_date], description=f"[dim]Day {t_date}[/dim] [magenta][Ingesting][/magenta]")
+                        # 1. Fetch remaining pages if any
+                        if total_pages > 1:
+                            for p in range(2, total_pages + 1):
+                                extractor.fetch_page("contratos", datetime.combine(t_date, datetime.min.time()), p)
+                                progress.update(tid, advance=1)
 
-                        # 1. Ingest (Stateless Pydantic + Shared Ibis Engine)
+                        # 2. Ingest
+                        progress.update(tid, description=f"Day {t_date} [Ingesting]")
                         stats = extractor.ingest_day(datetime.combine(t_date, datetime.min.time()))
+                        total_records += stats.get("valid", 0)
+                        quarantine_count += stats.get("quarantine", 0)
 
-                        # 2. Export Quarantine to local CSV if any
+                        # 3. Export & Upload
                         q_csv = Path(f"data/quarentena-{t_date.isoformat()}.csv")
-                        has_q = extractor.export_quarantine(
-                            datetime.combine(t_date, datetime.min.time()), q_csv
-                        )
+                        has_q = extractor.export_quarantine(datetime.combine(t_date, datetime.min.time()), q_csv)
 
                         if not dry_run:
-                            progress.update(day_tasks[t_date], description=f"[dim]Day {t_date}[/dim] [cyan][Uploading][/cyan]")
-                            # 3. Upload Parquet + Raw Zip + Quarantine CSV
-                            if not ia_access_key or not ia_secret_key:
-                                raise ValueError("Missing IA credentials for upload")
-
-                            uploader.upload_day(
-                                t_date,
-                                Path("data/daily"),
-                                ia_access_key,
-                                ia_secret_key,
-                                quarantine_stats=stats,
-                                quarantine_csv=q_csv if has_q else None,
-                            )
+                            progress.update(tid, description=f"Day {t_date} [Uploading]")
+                            if  ia_access_key and ia_secret_key:
+                                uploader.upload_day(
+                                    t_date, Path("data/daily"), ia_access_key, ia_secret_key,
+                                    quarantine_stats=stats, quarantine_csv=q_csv if has_q else None
+                                )
                         else:
-                            console.print(
-                                f"[yellow]Dry-run: would upload {t_date} (stats: {stats})[/yellow]"
-                            )
+                            progress.console.log(f"[yellow]Dry-run: {t_date} verified ({stats['valid']} records)[/yellow]")
 
                         if q_csv.exists():
                             q_csv.unlink()
-
-                        if t_date in day_tasks:
-                            # Mark as finished and remove
-                            progress.remove_task(day_tasks[t_date])
-                            del day_tasks[t_date]
+                            
                         progress.update(overall_task, advance=1)
                     except Exception as e:
-                        console.print(
-                            f"[bold red]✗ Fatal error processing {t_date}: {e}[/bold red]"
-                        )
+                        error_count += 1
+                        progress.console.log(f"[bold red]✗ Error {t_date}: {e}[/bold red]")
+                    finally:
+                        progress.remove_task(tid)
                         if t_date in day_tasks:
-                            progress.remove_task(day_tasks[t_date])
                             del day_tasks[t_date]
 
-                # DISPATCH LOOP
+                # DISPATCHER
                 for target_date in batch:
                     # Time check
                     elapsed = (datetime.now() - start_time_exec).total_seconds() / 60
                     if limit_minutes and elapsed >= limit_minutes:
-                        console.print(
-                            f"\n[yellow]⚠ Time limit ({limit_minutes}m). Stopping.[/yellow]"
-                        )
+                        progress.console.log(f"[yellow]⚠ Time limit ({limit_minutes}m) reached.[/yellow]")
                         break
 
-                    # Dispatch Probes
-                    # UI: Create task for probing
-                    day_tasks[target_date] = progress.add_task(
-                        f"[dim]Day {target_date}[/dim] [yellow][Probing][/yellow]", total=1, completed=0
-                    )
-                    
-                    f = executor.submit(
-                        extractor.probe_date,
-                        "contratos",
-                        datetime.combine(target_date, datetime.min.time()),
-                    )
-                    futures[f] = ("probe", target_date, 0)
-
-                    # Monitor futures and dispatch new ones
+                    # Wait if too many futures (worker limiting)
+                    # We want to maintain N active days
                     while len(futures) >= workers:
                         done, _ = concurrent.futures.wait(
-                            futures.keys(),
-                            timeout=0.1,
-                            return_when=concurrent.futures.FIRST_COMPLETED,
+                            futures.keys(), timeout=0.1, return_when=concurrent.futures.FIRST_COMPLETED
                         )
                         for f in done:
-                            task_type, t_date, _ = futures.pop(f)
-                            try:
-                                res = f.result()
-                                if task_type == "probe":
-                                    tp = res["total_pages"]
-                                    progress.update(probe_task, advance=1)
-                                    if tp <= 1:  # Done or 1 page (probe already saved p1)
-                                        # Keep the task for Ingesting/Uploading phase
-                                        finish_day(t_date)
-                                    else:
-                                        # Update task for Fetching phase
-                                        progress.update(
-                                            day_tasks[t_date],
-                                            description=f"[dim]Day {t_date}[/dim] [blue][Fetching][/blue]",
-                                            total=tp,
-                                            completed=1
-                                        )
-                                        progress.update(
-                                            fetch_task,
-                                            total=progress.tasks[fetch_task].total + (tp - 1),
-                                        )
-                                        for p in range(2, tp + 1):
-                                            pf = executor.submit(
-                                                extractor.fetch_page,
-                                                "contratos",
-                                                datetime.combine(t_date, datetime.min.time()),
-                                                p,
-                                            )
-                                            futures[pf] = ("fetch", t_date, p)
-                            except Exception as e:
-                                console.print(f"[red]✗ {task_type} {t_date} failed: {e}[/red]")
-                                if t_date in day_tasks:
-                                    progress.remove_task(day_tasks[t_date])
-                                    del day_tasks[t_date]
+                            futures.pop(f)
+
+                    # Submit next day
+                    def daily_workflow(d: date):
+                        res = extractor.probe_date("contratos", datetime.combine(d, datetime.min.time()))
+                        process_day_full(d, res["total_pages"])
+
+                    f = executor.submit(daily_workflow, target_date)
+                    futures[f] = ("workflow", target_date, 0)
 
                 # Final drain
-                for f in concurrent.futures.as_completed(futures):
-                    task_type, t_date, _ = futures[f]
-                    try:
-                        res = f.result()
-                        if task_type == "fetch":
-                            progress.update(fetch_task, advance=1)
-                            if t_date in day_tasks:
-                                progress.update(day_tasks[t_date], advance=1)
-                                # Check if day is complete
-                                if progress.tasks[day_tasks[t_date]].finished:
-                                    finish_day(t_date)
-                        elif task_type == "probe":
-                            progress.update(probe_task, advance=1)
-                            tp = res["total_pages"]
-                            if tp <= 1:
-                                finish_day(t_date)
-                            else:
-                                # This rarely happens in the drain phase unless workers=1 and only 1 day
-                                progress.update(
-                                    day_tasks[t_date],
-                                    description=f"[dim]Day {t_date}[/dim] [blue][Fetching][/blue]",
-                                    total=tp,
-                                    completed=1
-                                )
-                                finish_day(t_date)  # Fallback
-                    except Exception as e:
-                        console.print(f"[red]✗ {t_date} drain error: {e}[/red]")
-                        if t_date in day_tasks:
-                            progress.remove_task(day_tasks[t_date])
-                            del day_tasks[t_date]
+                concurrent.futures.wait(futures.keys())
 
-        console.print(Panel("[bold green]✓ Sync Cycle Complete[/bold green]", expand=False))
-
-    console.print(Panel("[bold green]✓ Sync Cycle Complete[/bold green]", expand=False))
+    # 4. FINAL SUMMARY PANEL
+    duration = datetime.now() - start_time_exec
+    summary = (
+        f"• [bold white]Total Data points:[/] {total_records:,}\n"
+        f"• [bold yellow]Quarantine:[/] {quarantine_count:,}\n"
+        f"• [bold red]Errors:[/] {error_count}\n"
+        f"• [bold cyan]Duration:[/] {duration.total_seconds():.1f}s"
+    )
+    console.print("\n")
+    console.print(Panel(summary, title="[bold green]✓ Sync Results[/]", expand=False))
 
 
 @app.command("verify")

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -49,14 +49,14 @@ def main() -> None:
 @app.command("sync")
 def sync(  # noqa: PLR0913, PLR0915, PLR0912
     batch_size: int | None = typer.Option(
-        None, "--batch-size", "-n", help="Max days to sync (None for all)"
+        None, "--batch-size", "-n", help="Max months to sync (None for all)"
     ),
     start_date: str = typer.Option("2023-01-01", "--start-date", help="Oldest date to backfill"),
     db_path: Path | None = typer.Option(
         None, "--duckdb", help="DuckDB file (optional, defaults to :memory:)"
     ),
-    force_date: str | None = typer.Option(
-        None, "--force-date", help="Target a specific date regardless of manifest"
+    force_month: str | None = typer.Option(
+        None, "--force-month", help="Target a specific month (YYYY-MM) regardless of manifest"
     ),
     limit_minutes: int = typer.Option(
         0, "--limit-minutes", help="Stop after this many minutes (0 = no limit)"
@@ -80,13 +80,15 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
     engine = BalizaEngine(db_path)
     uploader = IAUploader(engine)
 
-    # 2. Determine dates to process using REMOTE manifest
-    if force_date:
-        batch = [datetime.strptime(force_date, "%Y-%m-%d").date()]
+    # 2. Determine months to process using REMOTE manifest
+    if force_month:
+        batch = [datetime.strptime(force_month, "%Y-%m").date()]
     else:
-        with console.status("[bold green]Checking IA manifest for pending dates...[/bold green]"):
+        with console.status("[bold green]Checking IA manifest for pending months...[/bold green]"):
             try:
-                uploaded = uploader.get_uploaded_dates()
+                # manifest dates in monthly strategy are strings "YYYY-MM"
+                raw_manifest = uploader._read_manifest_from_ia()
+                uploaded = {row["data_particao"] for row in raw_manifest if row.get("data_particao")}
             except Exception as e:
                 console.print(
                     f"[yellow]⚠ Could not read IA manifest (starting fresh): {e}[/yellow]"
@@ -94,17 +96,28 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
                 uploaded = set()
 
             start = datetime.strptime(start_date, "%Y-%m-%d").date()
-            yesterday = date.today() - timedelta(days=1)
+            # Month-based start (first day of its month)
+            start = start.replace(day=1)
+            
+            today = date.today()
+            # End is the previous month
+            last_month_end = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
 
-            all_dates = []
+            pending_months = []
             curr = start
-            while curr <= yesterday:
-                all_dates.append(curr)
-                curr += timedelta(days=1)
+            while curr <= last_month_end:
+                month_key = curr.strftime("%Y-%m")
+                if month_key not in uploaded:
+                    pending_months.append(curr)
+                
+                # Advance to next month
+                if curr.month == 12:
+                    curr = curr.replace(year=curr.year + 1, month=1)
+                else:
+                    curr = curr.replace(month=curr.month + 1)
 
-            pending = [d for d in all_dates if d not in uploaded]
-            pending.sort(reverse=True)  # BACKWARDS IN TIME
-            batch = pending[:batch_size] if batch_size else pending
+            pending_months.sort(reverse=True)  # BACKWARDS IN TIME
+            batch = pending_months[:batch_size] if batch_size else pending_months
 
     if not batch:
         console.print("[green]✓ Everything up to date.[/green]")
@@ -125,8 +138,6 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
         overall_task = progress.add_task(
             "[bold white]Overall Progress[/bold white]", total=len(batch)
         )
-        probe_task = progress.add_task("[bold cyan]Probing Dates[/bold cyan]", total=len(batch))
-        fetch_task = progress.add_task("[bold magenta]Global Fetch Queue[/bold magenta]", total=0)
 
     # 3. Micro-metrics
     total_records = 0
@@ -146,102 +157,127 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
         expand=True,
     ) as progress:
         overall_task = progress.add_task(
-            "Overall Sync Progress", total=len(batch)
+            "[bold white]Overall Sync Progress (Months)[/bold white]", total=len(batch)
         )
         
-        # We'll use a local dict to map workers to their current date task
-        # But even better: just add/remove tasks dynamically.
-        # Since Workers=N, only N day_tasks will be active at once.
-        day_tasks: dict[date, TaskID] = {}
+        month_tasks: dict[str, TaskID] = {}
 
-        with PNCPExtractor(engine, use_curl=not no_curl) as extractor:
-            # Use pool for parallel scraping
-            with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-                futures: dict[concurrent.futures.Future[Any], tuple[str, date, int]] = {}
+        # Use pool for parallel scraping
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+            futures: dict[concurrent.futures.Future[Any], date] = {}
 
-                def process_day_full(t_date: date, total_pages: int):
-                    nonlocal total_records, quarantine_count, error_count
-                    
-                    tid = progress.add_task(f"Day {t_date} [Fetching]", total=total_pages, completed=1)
-                    day_tasks[t_date] = tid
-                    
-                    try:
-                        # 1. Fetch remaining pages if any
+            def process_month_full(start_of_month: date):
+                nonlocal total_records, quarantine_count, error_count
+                
+                month_str = start_of_month.strftime("%Y-%m")
+                # Calculate end of month
+                if start_of_month.month == 12:
+                    next_month = start_of_month.replace(year=start_of_month.year + 1, month=1)
+                else:
+                    next_month = start_of_month.replace(month=start_of_month.month + 1)
+                end_of_month = next_month - timedelta(days=1)
+
+                # THREAD-SAFE ENGINE: Each worker gets its own connection
+                thread_engine = engine.connect_thread_safe()
+                
+                # 1. Lifecycle Progress Bar Start
+                tid = progress.add_task(f"Month {month_str} [Probing]", total=3, completed=0)
+                month_tasks[month_str] = tid
+                
+                try:
+                    with PNCPExtractor(thread_engine, use_curl=not no_curl) as extractor:
+                        # 2. Probe (Page 1)
+                        res = extractor.probe_range(
+                            "contratos", 
+                            datetime.combine(start_of_month, datetime.min.time()),
+                            datetime.combine(end_of_month, datetime.min.time())
+                        )
+                        total_pages = res["total_pages"]
+                        
+                        # Update progress bar total and description
+                        # Total = pages + 1 (ingest) + 1 (upload)
+                        progress.update(tid, total=total_pages + 2, advance=1, description=f"Month {month_str} [Pages 1/{total_pages}]")
+                        
+                        # 3. Fetch remaining pages
                         if total_pages > 1:
                             for p in range(2, total_pages + 1):
-                                extractor.fetch_page("contratos", datetime.combine(t_date, datetime.min.time()), p)
+                                progress.update(tid, description=f"Month {month_str} [Pages {p}/{total_pages}]")
+                                extractor.fetch_page(
+                                    "contratos", 
+                                    datetime.combine(start_of_month, datetime.min.time()),
+                                    datetime.combine(end_of_month, datetime.min.time()),
+                                    p
+                                )
                                 progress.update(tid, advance=1)
 
-                        # 2. Ingest
-                        progress.update(tid, description=f"Day {t_date} [Ingesting]")
-                        stats = extractor.ingest_day(datetime.combine(t_date, datetime.min.time()))
+                        # 4. Ingest
+                        progress.update(tid, description=f"Month {month_str} [Ingesting]")
+                        stats = extractor.ingest_range(datetime.combine(start_of_month, datetime.min.time()))
                         total_records += stats.get("valid", 0)
                         quarantine_count += stats.get("quarantine", 0)
+                        progress.update(tid, advance=1)
 
-                        # 3. Export & Upload
-                        q_csv = Path(f"data/quarentena-{t_date.isoformat()}.csv")
-                        has_q = extractor.export_quarantine(datetime.combine(t_date, datetime.min.time()), q_csv)
+                        # 5. Export & Upload
+                        q_csv = Path(f"data/quarentena-{month_str}.csv")
+                        has_q = extractor.export_quarantine(datetime.combine(start_of_month, datetime.min.time()), q_csv)
 
                         if not dry_run:
-                            progress.update(tid, description=f"Day {t_date} [Uploading]")
-                            if  ia_access_key and ia_secret_key:
-                                uploader.upload_day(
-                                    t_date, Path("data/daily"), ia_access_key, ia_secret_key,
+                            progress.update(tid, description=f"Month {month_str} [Uploading]")
+                            if ia_access_key and ia_secret_key:
+                                uploader.upload_month(
+                                    start_of_month, Path("data/processed"), ia_access_key, ia_secret_key,
                                     quarantine_stats=stats, quarantine_csv=q_csv if has_q else None
                                 )
                         else:
-                            progress.console.log(f"[yellow]Dry-run: {t_date} verified ({stats['valid']} records)[/yellow]")
+                            progress.console.log(f"[yellow]Dry-run: {month_str} verified ({stats['valid']} records)[/yellow]")
+                        
+                        # Step complete
+                        progress.update(tid, advance=1)
 
                         if q_csv.exists():
                             q_csv.unlink()
                             
-                        progress.update(overall_task, advance=1)
-                    except Exception as e:
-                        error_count += 1
-                        progress.console.log(f"[bold red]✗ Error {t_date}: {e}[/bold red]")
-                    finally:
-                        progress.remove_task(tid)
-                        if t_date in day_tasks:
-                            del day_tasks[t_date]
+                    progress.update(overall_task, advance=1)
+                except Exception as e:
+                    error_count += 1
+                    progress.console.log(f"[bold red]✗ Error {month_str}: {e}[/bold red]")
+                finally:
+                    progress.remove_task(tid)
+                    if month_str in month_tasks:
+                        del month_tasks[month_str]
 
-                # DISPATCHER
-                for target_date in batch:
-                    # Time check
-                    elapsed = (datetime.now() - start_time_exec).total_seconds() / 60
-                    if limit_minutes and elapsed >= limit_minutes:
-                        progress.console.log(f"[yellow]⚠ Time limit ({limit_minutes}m) reached.[/yellow]")
-                        break
+            # DISPATCHER
+            for target_month in batch:
+                # Time limit check
+                elapsed = (datetime.now() - start_time_exec).total_seconds() / 60
+                if limit_minutes and elapsed >= limit_minutes:
+                    progress.console.log(f"[yellow]⚠ Time limit ({limit_minutes}m) reached.[/yellow]")
+                    break
 
-                    # Wait if too many futures (worker limiting)
-                    # We want to maintain N active days
-                    while len(futures) >= workers:
-                        done, _ = concurrent.futures.wait(
-                            futures.keys(), timeout=0.1, return_when=concurrent.futures.FIRST_COMPLETED
-                        )
-                        for f in done:
-                            futures.pop(f)
+                # Maintain worker pool
+                while len(futures) >= workers:
+                    done, _ = concurrent.futures.wait(
+                        futures.keys(), timeout=0.1, return_when=concurrent.futures.FIRST_COMPLETED
+                    )
+                    for f in done:
+                        futures.pop(f)
 
-                    # Submit next day
-                    def daily_workflow(d: date):
-                        res = extractor.probe_date("contratos", datetime.combine(d, datetime.min.time()))
-                        process_day_full(d, res["total_pages"])
+                f = executor.submit(process_month_full, target_month)
+                futures[f] = target_month
 
-                    f = executor.submit(daily_workflow, target_date)
-                    futures[f] = ("workflow", target_date, 0)
-
-                # Final drain
-                concurrent.futures.wait(futures.keys())
+            # Final drain
+            concurrent.futures.wait(futures.keys())
 
     # 4. FINAL SUMMARY PANEL
     duration = datetime.now() - start_time_exec
     summary = (
-        f"• [bold white]Total Data points:[/] {total_records:,}\n"
+        f"• [bold white]Total Records:[/] {total_records:,}\n"
         f"• [bold yellow]Quarantine:[/] {quarantine_count:,}\n"
         f"• [bold red]Errors:[/] {error_count}\n"
         f"• [bold cyan]Duration:[/] {duration.total_seconds():.1f}s"
     )
     console.print("\n")
-    console.print(Panel(summary, title="[bold green]✓ Sync Results[/]", expand=False))
+    console.print(Panel(summary, title="[bold green]✓ Sincronização Finalizada[/]", expand=False))
 
 
 @app.command("verify")
@@ -259,24 +295,34 @@ def verify(
         engine = BalizaEngine()
         uploader = IAUploader(engine)
         with console.status("[bold green]Checking remote manifest...[/bold green]"):
-            uploaded = uploader.get_uploaded_dates()
+            raw_manifest = uploader._read_manifest_from_ia()
+            uploaded_months = {row["data_particao"] for row in raw_manifest if row.get("data_particao")}
 
         gaps = []
-        curr = start_date
-        while curr <= end_date:
-            if curr not in uploaded:
-                gaps.append(curr)
-            curr += timedelta(days=1)
+        curr = start_date.replace(day=1)
+        # Verify months up to previous month
+        today = date.today()
+        last_month_end = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
+
+        while curr <= last_month_end:
+            month_key = curr.strftime("%Y-%m")
+            if month_key not in uploaded_months:
+                gaps.append(month_key)
+            
+            # Next month
+            if curr.month == 12:
+                curr = curr.replace(year=curr.year + 1, month=1)
+            else:
+                curr = curr.replace(month=curr.month + 1)
 
         if not gaps:
-            console.print(f"[green]✓ Complete coverage from {start} to {end} on Internet Archive.")
+            console.print(f"[green]✓ Complete month coverage from {start} to {last_month_end.strftime('%Y-%m')} on Internet Archive.")
         else:
-            console.print(f"[yellow]⚠ Found {len(gaps)} missing day(s) on IA:")
-            # Group gaps for readability
-            for d in gaps[:20]:
-                console.print(f"  • {d}")
-            if len(gaps) > 20:
-                console.print(f"  ... and {len(gaps) - 20} more.")
+            console.print(f"[yellow]⚠ Found {len(gaps)} missing month(s) on IA:")
+            for m in gaps[:12]:
+                console.print(f"  • {m}")
+            if len(gaps) > 12:
+                console.print(f"  ... and {len(gaps) - 12} more.")
 
     except Exception as e:
         console.print(f"[red]✗ Verify failed: {e}")

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -223,11 +223,10 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
 
                         if not dry_run:
                             progress.update(tid, description=f"Month {month_str} [Uploading]")
-                            if ia_access_key and ia_secret_key:
-                                uploader.upload_month(
-                                    start_of_month, Path("data/processed"), ia_access_key, ia_secret_key,
-                                    quarantine_stats=stats, quarantine_csv=q_csv if has_q else None
-                                )
+                            uploader.upload_month(
+                                start_of_month, Path("data/processed"), ia_access_key, ia_secret_key,
+                                quarantine_stats=stats, quarantine_csv=q_csv if has_q else None
+                            )
                         else:
                             progress.console.log(f"[yellow]Dry-run: {month_str} verified ({stats['valid']} records)[/yellow]")
                         
@@ -260,13 +259,24 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
                         futures.keys(), timeout=0.1, return_when=concurrent.futures.FIRST_COMPLETED
                     )
                     for f in done:
+                        try:
+                            f.result()
+                        except Exception as e:
+                            error_count += 1
+                            progress.console.log(f"[bold red]✗ Worker Error: {e}[/bold red]")
                         futures.pop(f)
 
                 f = executor.submit(process_month_full, target_month)
                 futures[f] = target_month
 
             # Final drain
-            concurrent.futures.wait(futures.keys())
+            done, _ = concurrent.futures.wait(futures.keys())
+            for f in done:
+                try:
+                    f.result()
+                except Exception as e:
+                    error_count += 1
+                    progress.console.log(f"[bold red]✗ Worker Error during drain: {e}[/bold red]")
 
     # 4. FINAL SUMMARY PANEL
     duration = datetime.now() - start_time_exec

--- a/src/baliza/engine.py
+++ b/src/baliza/engine.py
@@ -34,6 +34,10 @@ class BalizaEngine:
         self._ensure_schema("main")
         self._ensure_schema("baliza_state")
 
+    def connect_thread_safe(self) -> 'BalizaEngine':
+        """Return a new engine instance sharing the same database path but with a fresh connection."""
+        return BalizaEngine(db_path=self.path)
+
     def _ensure_schema(self, schema_name: str = "baliza_state"):
         """Create a schema and necessary state tables if they don't exist."""
         try:

--- a/src/baliza/extractor.py
+++ b/src/baliza/extractor.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import subprocess
-import tempfile
 import threading
 from datetime import datetime
 from pathlib import Path
@@ -27,7 +26,7 @@ class PNCPExtractor:
     def __init__(
         self,
         engine: BalizaEngine,
-        base_url: str = "https://pncp.gov.br/api/pncp/v1",
+        base_url: str = "https://pncp.gov.br/api/consulta/v1",
         use_curl: bool = False,
     ):
         self.engine = engine
@@ -42,13 +41,16 @@ class PNCPExtractor:
         self.client = httpx.Client(headers=self.headers, timeout=30.0)
 
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=2, max=10))
-    def fetch_page(self, resource: str, extraction_date: datetime, page: int = 1) -> dict[str, Any]:
+    def fetch_page(
+        self, resource: str, start_date: datetime, end_date: datetime, page: int = 1
+    ) -> dict[str, Any]:
         """Fetch a single page from the PNCP API with resumption support."""
-        date_iso = extraction_date.date().isoformat()
-        filename = Path(f"data/raw/{date_iso}/{resource}_p{page}.json")
+        # For directory naming, use YYYY-MM
+        month_str = start_date.strftime("%Y-%m")
+        filename = Path(f"data/raw/{month_str}/{resource}_p{page}.json")
 
         # RESUMABILITY: Check if valid file already exists
-        if filename.exists():
+        if filename.exists() and filename.stat().st_size > 0:
             try:
                 with open(filename) as f:
                     data = json.load(f)
@@ -59,13 +61,16 @@ class PNCPExtractor:
                 logger.warning("corrupt_cache_found", file=str(filename))
                 filename.unlink()
 
-        date_str = extraction_date.strftime("%Y-%m-%d")
+        start_str = start_date.strftime("%Y%m%d")
+        end_str = end_date.strftime("%Y%m%d")
         url = f"{self.base_url}/{resource}"
-        params = {
-            "dataPublicacao": date_str,
+        params: dict[str, str | int] = {
+            "dataInicial": start_str,
+            "dataFinal": end_str,
             "pagina": page,
-            "tamanhoPagina": 500,
+            "tamanhoPagina": 100,
         }
+        logger.info("fetching_page_params", resource=resource, url=url, params=params)
 
         if self.use_curl:
             try:
@@ -77,14 +82,14 @@ class PNCPExtractor:
                         "accept: */*",
                         "-H",
                         f"User-Agent: {self.headers['User-Agent']}",
-                        f"{url}?dataPublicacao={date_str}&pagina={page}&tamanhoPagina=500",
+                        f"{url}?dataInicial={start_str}&dataFinal={end_str}&pagina={page}&tamanhoPagina=500",
                     ],
                     capture_output=True,
                     text=True,
                     check=True,
                 )
                 data = json.loads(result.stdout)
-                self._save_raw(resource, extraction_date, page, data)
+                self._save_raw(resource, start_date, page, data)
                 return data
             except Exception:
                 raise
@@ -92,13 +97,13 @@ class PNCPExtractor:
         resp = self.client.get(url, params=params)
         resp.raise_for_status()
         data = resp.json()
-        self._save_raw(resource, extraction_date, page, data)
+        self._save_raw(resource, start_date, page, data)
         return data
 
-    def _save_raw(self, resource: str, extraction_date: datetime, page: int, data: dict[str, Any]):
+    def _save_raw(self, resource: str, start_date: datetime, page: int, data: dict[str, Any]):
         """Save raw JSON payload to disk with deterministic name."""
-        date_iso = extraction_date.date().isoformat()
-        raw_dir = Path("data/raw") / date_iso
+        month_str = start_date.strftime("%Y-%m")
+        raw_dir = Path("data/raw") / month_str
         raw_dir.mkdir(parents=True, exist_ok=True)
 
         # Deterministic filename for resumability
@@ -106,18 +111,18 @@ class PNCPExtractor:
         with open(filename, "w") as f:
             json.dump(data, f, ensure_ascii=False)
 
-    def probe_date(self, resource: str, extraction_date: datetime) -> dict[str, Any]:
-        """Fetch page 1 to determine total pages and registry count."""
-        data = self.fetch_page(resource, extraction_date, page=1)
+    def probe_range(self, resource: str, start_date: datetime, end_date: datetime) -> dict[str, Any]:
+        """Fetch page 1 to determine total pages and registry count for a range."""
+        data = self.fetch_page(resource, start_date, end_date, page=1)
         return {
             "total_pages": data.get("totalPaginas", 1),
             "total_registries": data.get("totalRegistros", 0),
         }
 
-    def ingest_day(self, extraction_date: datetime) -> dict[str, int]:
-        """Validate and ingest all raw JSON files for a specific day into the shared engine."""
-        date_iso = extraction_date.date().isoformat()
-        raw_dir = Path("data/raw") / date_iso
+    def ingest_range(self, start_date: datetime) -> dict[str, int]:
+        """Validate and ingest all raw JSON files for a specific month/range into the shared engine."""
+        month_str = start_date.strftime("%Y-%m")
+        raw_dir = Path("data/raw") / month_str
 
         stats = {"valid": 0, "quarantine": 0}
 
@@ -140,7 +145,7 @@ class PNCPExtractor:
                 except ValidationError as e:
                     stats["quarantine"] += 1
                     logger.warning("validation_failed", error=str(e), entry_id=entry.get("id"))
-                    self.engine.quarantine_record("contratos", extraction_date, str(e), entry)
+                    self.engine.quarantine_record("contratos", start_date, str(e), entry)
 
             # Ingest valid rows into Ibis (shared engine) via UPSERT
             if valid_rows:

--- a/src/baliza/ia_uploader.py
+++ b/src/baliza/ia_uploader.py
@@ -18,33 +18,32 @@ from .engine import BalizaEngine
 console = Console()
 
 
-class DailyExporter:
-    """Exports daily data from the engine to Parquet/JSON for upload."""
+class MonthlyExporter:
+    """Exports monthly data from the engine to Parquet/JSON for upload."""
 
     def __init__(self, engine: BalizaEngine):
         self.engine = engine
 
-    def export_day(self, target_date: date, output_dir: Path) -> dict[str, Path]:
-        """Export all tables for a given day to Parquet in output_dir."""
+    def export_month(self, start_date: date, output_dir: Path) -> dict[str, Path]:
+        """Export all tables for a given month to Parquet in output_dir."""
         output_dir.mkdir(parents=True, exist_ok=True)
         files = {}
 
-        # In our simplified stateless model, we mainly care about 'contratos'
+        # Mofified to monthly filename
+        month_str = start_date.strftime("%Y-%m")
         table_name = "contratos"
-        filename = f"{table_name}-{target_date.isoformat()}.parquet"
+        filename = f"{table_name}-{month_str}.parquet"
         out_path = output_dir / filename
 
         try:
             # Query the in-memory engine
             t = self.engine.get_table(table_name, schema="main")
-            # Filter by data_publicacao if available, or just take what's in the session
-            # Since the session is ephemeral per day in our sync loop, we can just take all
             t.to_parquet(out_path)
             if out_path.exists():
                 files[table_name] = out_path
         except Exception as e:
             console.print(
-                f"[yellow]⚠ No data found for {table_name} on {target_date}: {e}[/yellow]"
+                f"[yellow]⚠ No data found for {table_name} on {month_str}: {e}[/yellow]"
             )
 
         return files
@@ -55,7 +54,7 @@ class IAUploader:
 
     def __init__(self, engine: BalizaEngine) -> None:
         self.engine = engine
-        self.exporter = DailyExporter(engine)
+        self.exporter = MonthlyExporter(engine)
         self.manifest_item_id = "baliza-pncp-manifest"
 
     def _read_manifest_from_ia(self) -> list[dict[str, Any]]:
@@ -72,22 +71,7 @@ class IAUploader:
         except Exception as e:
             console.print(f"[dim]Note: manifest.csv not found or unreadable: {e}[/dim]")
 
-        # 2. Migration Fallback: Try manifest.parquet (legacy standard)
-        url_pq = f"https://archive.org/download/{self.manifest_item_id}/manifest.parquet"
-        try:
-            with duckdb.connect(":memory:") as con:
-                con.execute("INSTALL httpfs; LOAD httpfs;")
-                # Read remote parquet directly via httpfs
-                res = con.execute(f"SELECT * FROM read_parquet('{url_pq}')").fetchall()
-                cols = [d[0] for d in con.description]
-                manifest = [dict(zip(cols, row, strict=True)) for row in res]
-                console.print(
-                    f"[green]✓ Migrated {len(manifest)} rows from legacy manifest.parquet.[/green]"
-                )
-                return manifest
-        except Exception:
-            # If both fail, we start fresh
-            pass
+        return []
 
         return []
 
@@ -104,30 +88,30 @@ class IAUploader:
                     continue
         return dates
 
-    def upload_day(  # noqa: PLR0913
+    def upload_month(  # noqa: PLR0913
         self,
-        target_date: date,
+        start_date: date,
         output_dir: Path,
         ia_access_key: str,
         ia_secret_key: str,
         quarantine_stats: dict[str, int] | None = None,
         quarantine_csv: Path | None = None,
     ) -> None:
-        """Export, Zip, and Upload daily data to Internet Archive, then cleanup."""
-        item_id = f"baliza-pncp-{target_date.year}"
-        date_str = target_date.isoformat()
+        """Export, Zip, and Upload monthly consolidated data to Internet Archive, then cleanup."""
+        month_str = start_date.strftime("%Y-%m")
+        item_id = f"baliza-pncp-{month_str}"
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             temp_path = Path(tmp_dir)
 
             # 1. Export Parquet from shared engine
-            exported_files = self.exporter.export_day(target_date, temp_path)
+            exported_files = self.exporter.export_month(start_date, temp_path)
 
             # 2. Zip raw JSON files
-            raw_dir = Path("data/raw") / date_str
+            raw_dir = Path("data/raw") / month_str
             zip_path = None
             if raw_dir.exists():
-                zip_path = temp_path / f"raw-{date_str}.zip"
+                zip_path = temp_path / f"raw-{month_str}.zip"
                 shutil.make_archive(str(zip_path.with_suffix("")), "zip", raw_dir)
                 zip_path = zip_path.with_suffix(".zip")
 
@@ -143,7 +127,7 @@ class IAUploader:
                 files_to_upload[path.name] = str(path)
 
             if not files_to_upload:
-                console.print(f"[yellow]⚠ Nothing to upload for {date_str}[/yellow]")
+                console.print(f"[yellow]⚠ Nothing to upload for {month_str}[/yellow]")
                 return
 
             # 4. Perform Upload
@@ -154,7 +138,8 @@ class IAUploader:
                 access_key=ia_access_key,
                 secret_key=ia_secret_key,
                 metadata={
-                    "title": f"Baliza PNCP Data {target_date.year}",
+                    "title": f"Baliza PNCP Data {month_str}",
+                    "description": f"Consolidated monthly data for PNCP contracts - {month_str}",
                     "mediatype": "data",
                     "collection": "opensource_media",
                 },
@@ -165,7 +150,7 @@ class IAUploader:
             success = False
             try:
                 self._update_remote_manifest(
-                    target_date,
+                    start_date,
                     item_id,
                     files_to_upload,
                     ia_access_key,
@@ -174,7 +159,7 @@ class IAUploader:
                 )
                 success = True
             except Exception as e:
-                console.print(f"[red]✗ Manifest update failed for {date_str}: {e}[/red]")
+                console.print(f"[red]✗ Manifest update failed for {month_str}: {e}[/red]")
                 # We do NOT cleanup if manifest update failed, to allow retry
 
             # 6. AUTOMATED CLEANUP (Only on success)
@@ -187,15 +172,15 @@ class IAUploader:
                 if daily_processed.exists():
                     shutil.rmtree(daily_processed)
 
-                console.print(f"[green]✓ {date_str} synced and local data cleaned.[/green]")
+                console.print(f"[green]✓ {month_str} synced and local data cleaned.[/green]")
             else:
                 console.print(
-                    f"[yellow]⚠ {date_str} uploaded but NOT cleaned due to manifest error.[/yellow]"
+                    f"[yellow]⚠ {month_str} uploaded but NOT cleaned due to manifest error.[/yellow]"
                 )
 
     def _update_remote_manifest(  # noqa: PLR0913
         self,
-        target_date: date,
+        start_date: date,
         item_id: str,
         uploaded_files: dict[str, str],
         access_key: str,
@@ -206,26 +191,26 @@ class IAUploader:
         manifest = self._read_manifest_from_ia()
 
         # Build new row
-        date_str = target_date.isoformat()
+        month_str = start_date.strftime("%Y-%m")
         new_row = {
-            "data_particao": date_str,
+            "data_particao": month_str,
             "table_name": "contratos",
             "row_count": q_stats.get("valid", 0) if q_stats else 0,
             "quarantine_count": q_stats.get("quarantine", 0) if q_stats else 0,
             "ia_item_id": item_id,
-            "raw_zip_url": f"https://archive.org/download/{item_id}/raw-{date_str}.zip",
-            "parquet_url": f"https://archive.org/download/{item_id}/contratos-{date_str}.parquet",
-            "quarantine_url": f"https://archive.org/download/{item_id}/quarentena-{date_str}.csv"
+            "raw_zip_url": f"https://archive.org/download/{item_id}/raw-{month_str}.zip",
+            "parquet_url": f"https://archive.org/download/{item_id}/contratos-{month_str}.parquet",
+            "quarantine_url": f"https://archive.org/download/{item_id}/quarentena-{month_str}.csv"
             if q_stats and q_stats.get("quarantine", 0) > 0
             else "",
             "uploaded_at": datetime.now().isoformat(),
         }
 
-        # Simple deduplication: remove old row for same date/table
+        # Simple deduplication: remove old row for same partition/table
         manifest = [
             r
             for r in manifest
-            if not (r["data_particao"] == date_str and r["table_name"] == "contratos")
+            if not (r["data_particao"] == month_str and r["table_name"] == "contratos")
         ]
         manifest.append(new_row)
 

--- a/tests/test_baliza_v2.py
+++ b/tests/test_baliza_v2.py
@@ -1,8 +1,5 @@
-import json
-import tempfile
 import unittest
 from datetime import datetime
-from pathlib import Path
 
 import ibis
 

--- a/web/src/components/Dashboard.svelte
+++ b/web/src/components/Dashboard.svelte
@@ -24,9 +24,13 @@
     <strong>Erro de Leitura:</strong> {error}
   </div>
 {:else if !stats}
-  <div class="loading">Sincronizando fragmentos Parquet/JSON...</div>
-{:else}
   <div class="dashboard-grid">
+    <div class="card stat-card animate-shimmer" style="height: 120px;"></div>
+    <div class="card stat-card animate-shimmer" style="height: 120px; animation-delay: 0.1s;"></div>
+    <div class="card stat-card animate-shimmer" style="height: 120px; animation-delay: 0.2s;"></div>
+  </div>
+{:else}
+  <div class="dashboard-grid animate-fade-in">
     <StatCard title="Contratos Registrados" value={stats.total_contracts} />
     <StatCard title="Dias Preservados" value={stats.days_on_ia} />
     <StatCard title="Total em Quarentena" value={stats.total_quarantine} />
@@ -46,9 +50,8 @@
     padding: var(--space-sm);
     border-radius: var(--radius-sm);
   }
-  .loading {
-    color: var(--color-secondary);
-    font-size: var(--font-size-sm);
-    font-style: italic;
+  .stat-card {
+    flex: 1;
+    min-width: 250px;
   }
 </style>

--- a/web/src/components/LiveInsights.svelte
+++ b/web/src/components/LiveInsights.svelte
@@ -8,11 +8,14 @@
 <section class="insights-row">
   <div class="container">
     {#if loading}
-      <div class="loading-state">
-        <div class="skeleton s-insights"></div>
+      <div class="insights-grid">
+        <div class="insight-card animate-shimmer" style="height: 90px;"></div>
+        <div class="insight-card animate-shimmer" style="height: 90px; animation-delay: 0.1s;"></div>
+        <div class="insight-card animate-shimmer" style="height: 90px; animation-delay: 0.2s;"></div>
+        <div class="insight-card animate-shimmer" style="height: 90px; animation-delay: 0.3s;"></div>
       </div>
     {:else}
-      <div class="insights-grid">
+      <div class="insights-grid animate-fade-in">
         {#each data as item (item.label)}
           <div class="insight-card">
             <span class="insight-label">{item.label}</span>
@@ -44,6 +47,17 @@
     flex-direction: column;
     gap: 4px;
     box-shadow: 0 4px 15px rgba(0,0,0,0.05);
+    transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
+  }
+  .insight-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--color-primary);
+  }
+  :global([data-theme="dark"]) .insight-card {
+    box-shadow: 0 4px 15px rgba(0,0,0,0.3);
+  }
+  :global([data-theme="dark"]) .insight-card:hover {
+    box-shadow: 0 4px 12px rgba(69, 208, 129, 0.08);
   }
   .insight-label {
     font-size: var(--font-size-xs);
@@ -53,18 +67,10 @@
     font-weight: 700;
   }
   .insight-value {
+    font-family: var(--font-mono);
     font-size: var(--font-size-xl);
     font-weight: 900;
     color: var(--color-primary);
-  }
-  
-  .loading-state {
-    height: 100px;
-    display: flex;
-    align-items: center;
-  }
-  .s-insights {
-    width: 100%;
-    height: 60px;
+    text-shadow: 0 0 8px color-mix(in srgb, var(--color-primary) 20%, transparent);
   }
 </style>

--- a/web/src/components/Navigation.astro
+++ b/web/src/components/Navigation.astro
@@ -26,7 +26,9 @@ const isActive = (path: string) => {
 
 <style>
   .nav {
-    background: var(--color-base-100);
+    background: color-mix(in srgb, var(--color-base-100) 80%, transparent);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
     border-bottom: 1px solid var(--color-base-300);
     height: 4.5rem;
     display: flex;

--- a/web/src/components/SearchHero.svelte
+++ b/web/src/components/SearchHero.svelte
@@ -35,21 +35,25 @@
     <p class="hero-tagline">{PROJECT_MISSION.tagline}</p>
 
     <div class="search-box" class:detected={isCnpj || isIbge || isPncpId}>
-      <div class="input-group">
-        <input 
-          type="text" 
-          bind:value={query} 
-          placeholder="Busque por Órgão, CNPJ ou Objeto de compra..."
-          oninput={handleSearch}
-        />
-        {#if loading}
-          <div class="valid-indicator spinning">⏳</div>
-        {:else if isCnpj || isIbge || isPncpId}
-          <div class="valid-indicator" in:fade>✅</div>
-        {/if}
-        <button class="search-btn">
-          Buscar
-        </button>
+      <div class="input-wrapper">
+        <span class="terminal-prompt">$</span>
+        <div class="input-group">
+          <input
+            type="text"
+            bind:value={query}
+            placeholder="Busque por Órgão, CNPJ ou Objeto de compra..."
+            oninput={handleSearch}
+            class="terminal-input"
+          />
+          {#if loading}
+            <div class="valid-indicator spinning">⏳</div>
+          {:else if isCnpj || isIbge || isPncpId}
+            <div class="valid-indicator" in:fade>✅</div>
+          {/if}
+          <button class="search-btn">
+            Buscar
+          </button>
+        </div>
       </div>
 
       {#if isCnpj || isIbge || isPncpId}
@@ -90,6 +94,7 @@
   }
   .hero-inner {
     max-width: 800px;
+    margin: 0 auto;
     text-align: center;
   }
   .hero-title {
@@ -97,11 +102,13 @@
     margin-bottom: var(--space-xs);
     color: var(--color-base-content);
     line-height: 1.1;
+    font-weight: 800;
   }
   .hero-tagline {
     color: var(--color-secondary);
     font-size: var(--font-size-lg);
     margin-bottom: var(--space-lg);
+    font-weight: 400;
   }
   .search-box {
     background: var(--color-base-100);
@@ -109,33 +116,61 @@
     border: 1px solid var(--color-base-300);
     border-radius: var(--radius-box);
     box-shadow: 0 10px 30px -10px rgba(0,0,0,0.3);
+    text-align: left;
+  }
+  .input-wrapper {
+    display: flex;
+    align-items: center;
+    background: var(--color-base-200);
+    border: 1px solid var(--color-base-300);
+    border-radius: var(--radius-sm);
+    padding-left: var(--space-sm);
+    transition: border-color var(--transition-base), box-shadow var(--transition-base);
+  }
+  .input-wrapper:focus-within {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 20%, transparent);
+  }
+  .terminal-prompt {
+    font-family: var(--font-mono);
+    color: var(--color-primary);
+    font-weight: 700;
+    margin-right: var(--space-xs);
+    user-select: none;
   }
   .input-group {
     display: flex;
     gap: var(--space-xs);
     position: relative;
-  }
-  input {
     flex: 1;
-    padding: var(--space-sm);
-    border: 1px solid var(--color-base-300);
-    border-radius: var(--radius-sm);
-    background: var(--color-base-200);
+  }
+  .terminal-input {
+    flex: 1;
+    padding: var(--space-sm) 0;
+    border: none;
+    background: transparent;
     color: var(--color-base-content);
-    font-family: var(--font-sans);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-base);
     outline: none;
   }
-  input:focus {
-    border-color: var(--color-primary);
+  .terminal-input::placeholder {
+    font-family: var(--font-sans);
+    color: var(--color-secondary);
+    opacity: 0.7;
   }
   .search-btn {
     background: var(--color-primary);
-    color: white;
+    color: var(--color-base-100);
     padding: 0 var(--space-md);
     border: none;
-    border-radius: var(--radius-sm);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
     font-weight: 600;
     cursor: pointer;
+    transition: opacity var(--transition-base);
+  }
+  .search-btn:hover {
+    opacity: 0.9;
   }
   .search-box.detected .input-group {
     border-color: var(--color-primary);

--- a/web/src/components/StatCard.svelte
+++ b/web/src/components/StatCard.svelte
@@ -2,18 +2,18 @@
   let { title, value } = $props<{ title: string, value: number | string }>();
 </script>
 
-<div class="card">
+<div class="card stat-card">
   <h3 class="stat-label">{title}</h3>
   <p class="stat-value">{value}</p>
 </div>
 
 <style>
-  .card {
-    background: var(--color-base-100);
-    border: 1px solid var(--color-base-300);
-    border-radius: var(--radius-box);
-    padding: var(--space-md);
+  /* The global .card styles handle the background, border, and hover effects */
+  .stat-card {
     flex: 1;
     min-width: 250px;
+  }
+  .stat-value {
+    text-shadow: 0 0 12px color-mix(in srgb, var(--color-primary) 20%, transparent);
   }
 </style>

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -42,8 +42,8 @@ const { title, description } = Astro.props;
   }
   .portal-footer {
     margin-top: var(--space-3xl);
-    padding: var(--space-xl) 0;
-    border-top: 1px solid var(--color-base-300);
+    padding: var(--space-lg) 0;
+    border-top: 1px dashed var(--color-base-300);
     background: var(--color-base-100);
     color: var(--color-secondary);
     font-size: var(--font-size-xs);

--- a/web/src/lib/geo.ts
+++ b/web/src/lib/geo.ts
@@ -42,6 +42,18 @@ export async function getCityFromCoords(lat: number, lng: number): Promise<CityR
   return { city, state };
 }
 
+interface IBGEResult {
+  id: number;
+  nome: string;
+  microrregiao: {
+    mesorregiao: {
+      UF: {
+        nome: string;
+      }
+    }
+  }
+}
+
 export async function getIBGECode(cityName: string, stateName: string): Promise<string | null> {
   const url = `https://servicodados.ibge.gov.br/api/v1/localidades/municipios?nome=${encodeURIComponent(cityName)}`;
   const res = await fetch(url);

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -34,40 +34,42 @@ img, picture, video, canvas, svg { display: block; max-width: 100%; }
 
   /* Skeletons & Shimmer */
   --shimmer-gradient: linear-gradient(90deg, 
-      rgba(255, 255, 255, 0.05) 0%, 
-      rgba(255, 255, 255, 0.1) 50%, 
-      rgba(255, 255, 255, 0.05) 100%);
+      rgba(255, 255, 255, 0.02) 0%,
+      rgba(255, 255, 255, 0.08) 50%,
+      rgba(255, 255, 255, 0.02) 100%);
 
   /* Basic Light Theme (Brazilian Modernism - CausaGanha baseline) */
   --color-base-100: #FAFAF5;
   --color-base-200: #F2EFE8;
   --color-base-300: #E0DDD4;
-  --color-base-content: #1C1C1C;
+  --color-base-content: #111111;
 
-  --color-primary: #1A6B3C;
+  --color-primary: #0F5A2C;
   --color-secondary: #5C5C52;
-  --color-accent: #C5972C;
+  --color-accent: #B28221;
   
-  --color-info: #1A6B5C;
-  --color-success: #1A6B3C;
-  --color-warning: #C5972C;
-  --color-error: #C53030;
+  --color-info: #0F5A4C;
+  --color-success: #0F5A2C;
+  --color-warning: #B28221;
+  --color-error: #B02020;
 }
 
 [data-theme="dark"] {
-  --color-base-100: #0F1A14;
-  --color-base-200: #1A2E1F;
-  --color-base-300: #2A3E2F;
-  --color-base-content: #F2EFE8;
+  /* Deeper, more terminal-like dark base */
+  --color-base-100: #0B0E0C;
+  --color-base-200: #131815;
+  --color-base-300: #202723;
+  --color-base-content: #F4F4F0;
 
-  --color-primary: #3DA568;
-  --color-secondary: #A8A89E;
-  --color-accent: #D4A843;
+  /* More 'electric' and vibrant accents for contrast */
+  --color-primary: #45D081;
+  --color-secondary: #9FA6A2;
+  --color-accent: #E8B945;
 
-  --color-info: #4DA58E;
-  --color-success: #3DA568;
-  --color-warning: #D4A843;
-  --color-error: #E05555;
+  --color-info: #45D0B5;
+  --color-success: #45D081;
+  --color-warning: #E8B945;
+  --color-error: #F25C5C;
 }
 
 html {
@@ -89,6 +91,17 @@ h3 { font-size: var(--font-size-xl); }
   border: 1px solid var(--color-base-300);
   border-radius: var(--radius-box);
   padding: var(--space-md);
+  transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  border-color: var(--color-primary);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="dark"] .card:hover {
+  box-shadow: 0 4px 12px rgba(69, 208, 129, 0.08);
 }
 
 .stat-value {
@@ -113,4 +126,25 @@ h3 { font-size: var(--font-size-xl); }
   max-width: 1280px;
   margin-inline: auto;
   padding-inline: var(--space-sm);
+}
+
+/* Animations */
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.animate-shimmer {
+  background-image: var(--shimmer-gradient);
+  background-size: 200% 100%;
+  animation: shimmer 2s infinite linear;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-fade-in {
+  animation: fadeIn 0.4s ease-out forwards;
 }


### PR DESCRIPTION
# Walkthrough: Modernized Baliza Sync Pipeline

We have completed a major overhaul of the Baliza Sync architecture to handle massive PNCP data volumes with maximum efficiency and resilience.

## 🚀 Native Monthly Extraction

We moved from a fragile daily extraction to a high-throughput monthly range strategy.
- **Endpoint**: Utilizing `https://pncp.gov.br/api/consulta/v1/contratos`.
- **Logic**: Unified range query using `dataInicial` and `dataFinal`.
- **Stability**: Defaulting to `tamanhoPagina: 100` to prevent PNCP server timeouts while maintaining fast ingestion.

## 🛡️ Persistence & Resumption Strategy

To survive GitHub Actions' 6-hour timeouts and the aggressive 30-minute sync cycle, we implemented a robust caching layer:
- **GH Actions Cache**: The `data/raw` folder is now cached between runs.
- **Fail-Safe Saving**: Using `actions/cache/save` with `if: always()` ensures that if a run is interrupted by a timeout, all JSON pages downloaded *so far* are saved.
- **Corrupt Cache Filter**: The extractor now verifies file size (`st_size > 0`) before resuming, automatically discarding truncated files.

## 📊 Granular Progress Monitoring

The CLI was upgraded to provide full visibility into long-running extractions:
- **Global Bar**: Tracks overall month progress (e.g., `3/48 months`).
- **Worker Bar**: Displays page-level granularity for each active month (e.g., `Month 2024-03 [Pages 45/133]`).
- **Summary Panel**: Provides a clear view of valid records, quarantined items, and errors at the end of the run.

## 📦 Consolidated IA Storage

- **New Item Format**: `baliza-pncp-YYYY-MM`.
- **File Format**: Single monthly Parquet partitions for faster dashboard rendering.
- **Cleanups**: Local raw data is only purged after a successful upload and manifest update.

## 📝 How to verify the new features

### Check local sync stability:
```bash
uv run baliza sync --force-month 2024-03 --batch-size 1 --dry-run
```

### Check manifest coverage (Monthly view):
```bash
uv run baliza verify --start 2023-01-01
```

> [!IMPORTANT]
> The next time the GitHub Actions workflow runs, it will likely take a few cycles to fully backfill older months. You can monitor the "Actions > Caches" tab in your repository to see the `pncp-raw-YYYY-MM` fragments being populated.
