### PR TITLE
Enhance frontend UI and accessibility

### DIFF
--- a/web/src/components/ProjectAnatomy.astro
+++ b/web/src/components/ProjectAnatomy.astro
@@ -16,7 +16,7 @@ import { HOW_IT_WORKS_CARDS } from '../lib/homepage-content';
       <div class="cards-grid">
         {HOW_IT_WORKS_CARDS.map(card => (
           <div class="anatomy-card">
-            <span class="card-icon">{card.icon}</span>
+            <span class="card-icon" set:html={card.icon} />
             <h3 class="card-title">{card.title}</h3>
             <p class="card-text">{card.description}</p>
           </div>
@@ -59,8 +59,9 @@ import { HOW_IT_WORKS_CARDS } from '../lib/homepage-content';
   .anatomy-card {
     padding: var(--space-md);
     background: var(--color-base-200);
-    border-radius: var(--radius-box);
+    border-radius: var(--radius-sm);
     border: 1px solid var(--color-base-300);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.02);
     transition: transform 0.2s;
   }
   .anatomy-card:hover {

--- a/web/src/components/SearchHero.svelte
+++ b/web/src/components/SearchHero.svelte
@@ -121,7 +121,8 @@
   }
   input {
     flex: 1;
-    padding: var(--space-sm);
+    padding: var(--space-md);
+    font-size: var(--font-size-lg);
     border: 1px solid var(--color-base-300);
     border-radius: var(--radius-sm);
     background: var(--color-base-200);
@@ -136,11 +137,17 @@
   .search-btn {
     background: var(--color-primary);
     color: white;
-    padding: 0 var(--space-md);
+    padding: 0 var(--space-lg);
+    font-size: var(--font-size-lg);
     border: none;
     border-radius: var(--radius-sm);
     font-weight: 600;
     cursor: pointer;
+    transition: transform var(--transition-base), background-color var(--transition-base);
+  }
+  .search-btn:hover {
+    transform: scale(1.02);
+    background-color: var(--color-success);
   }
   .search-box.detected .input-group {
     border-color: var(--color-primary);
@@ -165,7 +172,7 @@
     margin-top: var(--space-sm);
     display: flex;
     flex-wrap: wrap;
-    gap: var(--space-xs);
+    gap: var(--space-sm);
     align-items: center;
     font-size: var(--font-size-xs);
     color: var(--color-secondary);

--- a/web/src/lib/homepage-content.ts
+++ b/web/src/lib/homepage-content.ts
@@ -12,17 +12,17 @@ export const HOW_IT_WORKS_CARDS = [
   {
     title: "1. Captura Stateless",
     description: "Extraímos dados do PNCP em tempo real, sem dependência de bancos de dados locais pesados.",
-    icon: "⚡",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-zap"><path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"/></svg>`,
   },
   {
     title: "2. Fé Pública Digital",
     description: "Cada dia de contratação é registrado no Internet Archive, garantindo que o passado não seja apagado.",
-    icon: "🏛️",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-landmark"><line x1="3" x2="21" y1="22" y2="22"/><line x1="6" x2="6" y1="18" y2="11"/><line x1="10" x2="10" y1="18" y2="11"/><line x1="14" x2="14" y1="18" y2="11"/><line x1="18" x2="18" y1="18" y2="11"/><polygon points="12 2 20 7 4 7"/></svg>`,
   },
   {
     title: "3. Exploração WASM",
     description: "Analise milhões de linhas direto no seu navegador usando o motor DuckDB. Sem servidores, sem rastro.",
-    icon: "🦆",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-code"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>`,
   },
 ];
 

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -81,6 +81,11 @@ html {
   background: var(--color-base-100);
 }
 
+*:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 h1, h2 { font-family: var(--font-serif); font-weight: 400; }
 h3, h4, h5, h6 { font-family: var(--font-sans); }
 
@@ -98,7 +103,7 @@ h3 { font-size: var(--font-size-xl); }
 
 .card:hover {
   border-color: var(--color-primary);
-  box-shadow: var(--shadow-glow);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05), var(--shadow-glow);
   transform: translateY(-2px);
 }
 


### PR DESCRIPTION
Improves the Baliza website acting as a UI expert, strictly adhering to the "Brazilian Modernism" and "Data-First" guidelines from `web/DESIGN.md`. 
1. Added global accessibility focus rings and deeper drop shadows on card hovers in `global.css`. 
2. Made the search box in `SearchHero.svelte` more prominent with larger paddings, fonts, and a new hover state on the search button.
3. Replaced emojis in `homepage-content.ts` with explicit Lucide SVG icons.
4. Refined the `.anatomy-card` in `ProjectAnatomy.astro` with sharper corners and subtle default shadows.

---
*PR created automatically by Jules for task [12694221442907608313](https://jules.google.com/task/12694221442907608313) started by @franklinbaldo*