### PR TITLE
Remove unused LocalIBGEResult interface from geo module

### DIFF
--- a/web/src/lib/geo.ts
+++ b/web/src/lib/geo.ts
@@ -15,18 +15,6 @@ export interface CityResult {
   state: string;
 }
 
-interface LocalIBGEResult {
-  id: number;
-  nome: string;
-  microrregiao: {
-    mesorregiao: {
-      UF: {
-        nome: string;
-      }
-    }
-  }
-}
-
 export async function getUserCoordinates(): Promise<GeoLocation> {
   return new Promise((resolve, reject) => {
     if (!navigator.geolocation) {


### PR DESCRIPTION
## Summary
Removed an unused interface definition from the geo utilities module to improve code cleanliness and reduce unnecessary type definitions.

## Changes
- Deleted the `LocalIBGEResult` interface that was not being referenced anywhere in the codebase
- This interface defined the structure for IBGE (Brazilian Institute of Geography and Statistics) API responses but was not actively used

## Details
The `LocalIBGEResult` interface included nested properties for Brazilian geographic data (id, nome, microrregiao, mesorregiao, UF) but had no corresponding usage in the module or its consumers. Removing it reduces code maintenance burden and clarifies the actual dependencies of the geo module.

https://claude.ai/code/session_01DzLkr7CahvBG2SFY9g7tPS