### PR TITLE
Add BDD test suite and URL query param support for detail views

### DIFF
--- a/web/features/agency-detail.feature
+++ b/web/features/agency-detail.feature
@@ -1,0 +1,31 @@
+Feature: Agency Detail View
+  The agency detail panel shows an órgão profile read from a URL query param (?cnpj=).
+
+  Scenario: Missing CNPJ shows EntityNotFound
+    Given the URL has no cnpj parameter
+    When the agency detail view mounts
+    Then I should see "ÓRGÃO não encontrada"
+
+  Scenario: Fetch pending shows skeleton
+    Given the URL has cnpj "00000000000191"
+    And the fetch is pending
+    When the agency detail view mounts
+    Then I should see an aria-busy element
+
+  Scenario: Fetch error shows AlertBanner
+    Given the URL has cnpj "00000000000191"
+    And the fetch throws "Órgão não localizado"
+    When the agency detail view mounts
+    Then I should see an alert banner with the error message
+
+  Scenario: Zero contracts shows EmptyState
+    Given the URL has cnpj "00000000000191"
+    And the PNCP API returns 0 contracts
+    When the agency detail view mounts
+    Then I should see "Nenhuma contratação recente"
+
+  Scenario: Contracts render as links
+    Given the URL has cnpj "00000000000191"
+    And the PNCP API returns a contract with id "00000000000191-1-000001-1"
+    When the agency detail view mounts
+    Then I should see a link to that contract

--- a/web/features/city-detail.feature
+++ b/web/features/city-detail.feature
@@ -1,0 +1,31 @@
+Feature: City Detail View
+  The city detail panel shows município contracts read from a URL query param (?ibge=).
+
+  Scenario: Missing IBGE shows EntityNotFound
+    Given the URL has no ibge parameter
+    When the city detail view mounts
+    Then I should see "MUNICÍPIO não encontrada"
+
+  Scenario: Fetch pending shows skeleton
+    Given the URL has ibge "1721000"
+    And the fetch is pending
+    When the city detail view mounts
+    Then I should see an aria-busy element
+
+  Scenario: Fetch error shows AlertBanner
+    Given the URL has ibge "1721000"
+    And the fetch throws "Município não localizado"
+    When the city detail view mounts
+    Then I should see an alert banner with the error message
+
+  Scenario: Zero contracts shows EmptyState
+    Given the URL has ibge "1721000"
+    And the PNCP API returns 0 contracts
+    When the city detail view mounts
+    Then I should see "Nenhuma contratação recente"
+
+  Scenario: Contract count rendered as stat card
+    Given the URL has ibge "1721000"
+    And the PNCP API returns 1 contract
+    When the city detail view mounts
+    Then I should see a stat card with value "1"

--- a/web/features/contract-detail.feature
+++ b/web/features/contract-detail.feature
@@ -1,0 +1,26 @@
+Feature: Contract Detail View
+  The contract detail panel shows a single contratação read from a URL query param (?id=).
+
+  Scenario: Missing ID shows EntityNotFound
+    Given the URL has no id parameter
+    When the contract detail view mounts
+    Then I should see "CONTRATAÇÃO não encontrada"
+
+  Scenario: Fetch pending shows skeleton
+    Given the URL has id "00000000000191-1-000001-1"
+    And the fetch is pending
+    When the contract detail view mounts
+    Then I should see an aria-busy element
+
+  Scenario: Fetch error shows AlertBanner
+    Given the URL has id "00000000000191-1-000001-1"
+    And the fetch throws "Contratação não localizada"
+    When the contract detail view mounts
+    Then I should see an alert banner with the error message
+
+  Scenario: Successful fetch renders both summary cards
+    Given the URL has id "00000000000191-1-000001-1"
+    And the PNCP API returns a valid contract payload
+    When the contract detail view mounts
+    Then I should see "Resumo Executivo"
+    And I should see "Itens da Licitação"

--- a/web/features/duckdb-explorer.feature
+++ b/web/features/duckdb-explorer.feature
@@ -29,3 +29,9 @@ Feature: DuckDB SQL Explorer
     And the user clicks a featured query chip
     Then the SQL textarea should contain the resolved parquet URL
     And the SQL textarea should not contain "IA_URL"
+
+  Scenario: Single quotes in resolved URL are escaped to prevent SQL injection
+    Given the IA manifest resolves to a URL containing a single quote
+    When the explorer mounts
+    And the user clicks a featured query chip
+    Then the SQL textarea should contain the URL with doubled single quotes

--- a/web/features/duckdb-explorer.feature
+++ b/web/features/duckdb-explorer.feature
@@ -1,0 +1,31 @@
+Feature: DuckDB SQL Explorer
+  The explorer lets analysts run SQL against Parquet files from Internet Archive.
+
+  Scenario: Initial state shows explore button and default query
+    When the explorer mounts
+    Then I should see "Explorar Dados"
+    And the SQL textarea should contain "SELECT"
+
+  Scenario: Featured query chip inserts SQL into textarea
+    When the explorer mounts
+    And the user clicks a featured query chip
+    Then the SQL textarea should contain the chip's SQL
+
+  Scenario: IA_URL placeholder shows warning and disables button
+    When the explorer mounts
+    And the user clicks a featured query chip that still contains "IA_URL"
+    Then I should see a placeholder warning
+    And the explore button should be disabled
+
+  Scenario: Valid SQL executes and renders results
+    Given DuckDB returns one row with column "n" equal to 1
+    When the explorer mounts
+    And the user clicks "Explorar Dados"
+    Then I should see a results table with "n" as a column header
+
+  Scenario: Resolved IA URL replaces IA_URL placeholder in featured query chips
+    Given the IA manifest resolves to "https://archive.org/download/baliza-pncp-2025-01/contratos-2025-01.parquet"
+    When the explorer mounts
+    And the user clicks a featured query chip
+    Then the SQL textarea should contain the resolved parquet URL
+    And the SQL textarea should not contain "IA_URL"

--- a/web/features/duckdb-explorer.feature
+++ b/web/features/duckdb-explorer.feature
@@ -35,3 +35,11 @@ Feature: DuckDB SQL Explorer
     When the explorer mounts
     And the user clicks a featured query chip
     Then the SQL textarea should contain the URL with doubled single quotes
+
+  Scenario: Active query is backfilled when IA URL resolves after a chip click
+    Given the IA manifest is slow to resolve to "https://archive.org/download/baliza-pncp-2025-01/contratos-2025-01.parquet"
+    When the explorer mounts
+    And the user clicks a featured query chip before the manifest resolves
+    And the manifest finishes resolving
+    Then the SQL textarea should contain the resolved parquet URL
+    And the explore button should be enabled

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,6 +26,7 @@
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/svelte": "^5.3.1",
+        "@types/papaparse": "^5.5.2",
         "@typescript-eslint/eslint-plugin": "^8.58.2",
         "@typescript-eslint/parser": "^8.58.2",
         "astro-eslint-parser": "^1.4.0",
@@ -2644,6 +2645,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/papaparse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.2.tgz",
+      "integrity": "sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/sax": {

--- a/web/package.json
+++ b/web/package.json
@@ -27,10 +27,11 @@
   },
   "devDependencies": {
     "@amiceli/vitest-cucumber": "^6.3.0",
+    "@eslint/js": "^10.0.1",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.3.1",
-    "@eslint/js": "^10.0.1",
+    "@types/papaparse": "^5.5.2",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",
     "astro-eslint-parser": "^1.4.0",
@@ -42,11 +43,11 @@
     "eslint-plugin-svelte": "^3.17.0",
     "globals": "^17.5.0",
     "jsdom": "^26.0.0",
-    "vitest": "^4.1.2",
     "prettier": "^3.8.3",
     "svelte-check": "^4.4.6",
     "svelte-eslint-parser": "^1.6.0",
     "typescript": "^5.7.3",
-    "typescript-eslint": "^8.58.2"
+    "typescript-eslint": "^8.58.2",
+    "vitest": "^4.1.2"
   }
 }

--- a/web/src/components/AgencyDetailView.svelte
+++ b/web/src/components/AgencyDetailView.svelte
@@ -9,7 +9,14 @@
 
   setQueryClientContext(getQueryClient());
 
-  const { cnpj = "" } = $props();
+  const { cnpj: cnpjProp = "" }: { cnpj?: string } = $props();
+
+  const cnpj = $derived(
+    cnpjProp ||
+      (typeof window !== 'undefined'
+        ? new URLSearchParams(window.location.search).get('cnpj') ?? ''
+        : ''),
+  );
 
   const agencyQuery = createQuery(() => ({
     queryKey: QUERY_KEYS.orgao(cnpj),

--- a/web/src/components/CityDetailView.svelte
+++ b/web/src/components/CityDetailView.svelte
@@ -9,7 +9,14 @@
 
   setQueryClientContext(getQueryClient());
 
-  const { ibge = "" } = $props();
+  const { ibge: ibgeProp = "" }: { ibge?: string } = $props();
+
+  const ibge = $derived(
+    ibgeProp ||
+      (typeof window !== 'undefined'
+        ? new URLSearchParams(window.location.search).get('ibge') ?? ''
+        : ''),
+  );
 
   const cityQuery = createQuery(() => ({
     queryKey: QUERY_KEYS.municipio(ibge),

--- a/web/src/components/ContractDetailView.svelte
+++ b/web/src/components/ContractDetailView.svelte
@@ -8,7 +8,14 @@
 
   setQueryClientContext(getQueryClient());
 
-  const { id = "" } = $props();
+  const { id: idProp = "" }: { id?: string } = $props();
+
+  const id = $derived(
+    idProp ||
+      (typeof window !== 'undefined'
+        ? new URLSearchParams(window.location.search).get('id') ?? ''
+        : ''),
+  );
 
   const contractQuery = createQuery(() => ({
     queryKey: QUERY_KEYS.contratacao(id),

--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -29,6 +29,15 @@
     resolvedParquetUrl = await getLatestParquetUrl();
   });
 
+  $effect(() => {
+    if (resolvedParquetUrl && query.includes("'IA_URL'")) {
+      query = query.replaceAll(
+        "'IA_URL'",
+        `'${resolvedParquetUrl.replace(/'/g, "''")}'`,
+      );
+    }
+  });
+
   async function runQuery() {
     loading = true;
     error = null;

--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -1,14 +1,30 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { getDuckDB } from '../lib/duckdb';
   import { FEATURED_QUERIES } from '../lib/homepage-content';
+  import { getLatestParquetUrl } from '../lib/ia-manifest';
   import AlertBanner from './AlertBanner.svelte';
 
   let query = $state("SELECT * FROM contracts LIMIT 10");
   let results = $state<Record<string, unknown>[]>([]);
   let loading = $state(false);
   let error = $state<string | null>(null);
+  let resolvedParquetUrl = $state<string | null>(null);
+
+  const featuredQueries = $derived(
+    FEATURED_QUERIES.map((fq) => ({
+      ...fq,
+      sql: resolvedParquetUrl
+        ? fq.sql.replaceAll("'IA_URL'", `'${resolvedParquetUrl}'`)
+        : fq.sql,
+    })),
+  );
 
   const hasUnresolvedUrl = $derived(query.includes("'IA_URL'"));
+
+  onMount(async () => {
+    resolvedParquetUrl = await getLatestParquetUrl();
+  });
 
   async function runQuery() {
     loading = true;
@@ -38,7 +54,7 @@
 
   <div class="featured-queries" role="group" aria-label="Consultas prontas">
     <span class="featured-label">Consultas prontas:</span>
-    {#each FEATURED_QUERIES as fq (fq.label)}
+    {#each featuredQueries as fq (fq.label)}
       <button class="fq-chip" onclick={() => (query = fq.sql)}>
         {fq.label}
       </button>

--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -15,7 +15,10 @@
     FEATURED_QUERIES.map((fq) => ({
       ...fq,
       sql: resolvedParquetUrl
-        ? fq.sql.replaceAll("'IA_URL'", `'${resolvedParquetUrl}'`)
+        ? fq.sql.replaceAll(
+            "'IA_URL'",
+            `'${resolvedParquetUrl.replace(/'/g, "''")}'`,
+          )
         : fq.sql,
     })),
   );

--- a/web/src/components/__steps__/agency-detail.steps.ts
+++ b/web/src/components/__steps__/agency-detail.steps.ts
@@ -1,0 +1,162 @@
+import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber';
+import { screen, cleanup, waitFor } from '@testing-library/svelte/pure';
+import { vi, expect } from 'vitest';
+import { tick } from 'svelte';
+import { render } from './shared';
+import AgencyDetailViewRaw from '../AgencyDetailView.svelte';
+
+const AgencyDetailView = AgencyDetailViewRaw as unknown as Parameters<typeof render>[0];
+const feature = await loadFeature('features/agency-detail.feature');
+
+function setUrlQuery(qs: string) {
+  window.history.replaceState({}, '', qs ? `/?${qs}` : '/');
+}
+
+describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
+  BeforeEachScenario(async () => {
+    cleanup();
+    vi.restoreAllMocks();
+    setUrlQuery('');
+  });
+
+  Scenario('Missing CNPJ shows EntityNotFound', ({ Given, When, Then }) => {
+    Given('the URL has no cnpj parameter', () => {
+      setUrlQuery('');
+    });
+
+    When('the agency detail view mounts', async () => {
+      render(AgencyDetailView);
+      await tick();
+    });
+
+    Then('I should see "ÓRGÃO não encontrada"', async () => {
+      await waitFor(() =>
+        expect(screen.getByText('ÓRGÃO não encontrada')).toBeTruthy(),
+      );
+    });
+  });
+
+  Scenario('Fetch pending shows skeleton', ({ Given, And, When, Then }) => {
+    Given('the URL has cnpj "00000000000191"', () => {
+      setUrlQuery('cnpj=00000000000191');
+    });
+
+    And('the fetch is pending', () => {
+      global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    });
+
+    When('the agency detail view mounts', async () => {
+      render(AgencyDetailView);
+      await tick();
+    });
+
+    Then('I should see an aria-busy element', async () => {
+      await waitFor(() =>
+        expect(document.querySelector('[aria-busy="true"]')).toBeTruthy(),
+      );
+    });
+  });
+
+  Scenario('Fetch error shows AlertBanner', ({ Given, And, When, Then }) => {
+    Given('the URL has cnpj "00000000000191"', () => {
+      setUrlQuery('cnpj=00000000000191');
+    });
+
+    And('the fetch throws "Órgão não localizado"', () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(new Response('nope', { status: 404 }));
+    });
+
+    When('the agency detail view mounts', async () => {
+      render(AgencyDetailView);
+      await tick();
+    });
+
+    Then('I should see an alert banner with the error message', async () => {
+      await waitFor(
+        () => {
+          const alert = screen.getByRole('alert');
+          expect(alert.textContent).toMatch(/Órgão não localizado/);
+        },
+        { timeout: 2000 },
+      );
+    });
+  });
+
+  Scenario('Zero contracts shows EmptyState', ({ Given, And, When, Then }) => {
+    Given('the URL has cnpj "00000000000191"', () => {
+      setUrlQuery('cnpj=00000000000191');
+    });
+
+    And('the PNCP API returns 0 contracts', () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify({ data: [] }), { status: 200 }),
+        );
+    });
+
+    When('the agency detail view mounts', async () => {
+      render(AgencyDetailView);
+      await tick();
+    });
+
+    Then('I should see "Nenhuma contratação recente"', async () => {
+      await waitFor(
+        () =>
+          expect(screen.getByText('Nenhuma contratação recente')).toBeTruthy(),
+        { timeout: 2000 },
+      );
+    });
+  });
+
+  Scenario('Contracts render as links', ({ Given, And, When, Then }) => {
+    Given('the URL has cnpj "00000000000191"', () => {
+      setUrlQuery('cnpj=00000000000191');
+    });
+
+    And(
+      'the PNCP API returns a contract with id "00000000000191-1-000001-1"',
+      () => {
+        global.fetch = vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              data: [
+                {
+                  numeroControlePNCP: '00000000000191-1-000001-1',
+                  dataPublicacaoPncp: '2025-01-15T00:00:00',
+                  objetoContratacao: 'Aquisição de materiais de teste',
+                  valorTotalEstimado: 1000,
+                  orgaoEntidade: {
+                    razaoSocial: 'Órgão Teste',
+                    cnpj: '00000000000191',
+                  },
+                  unidadeOrgao: { nomeUnidade: 'Unidade' },
+                },
+              ],
+            }),
+            { status: 200 },
+          ),
+        );
+      },
+    );
+
+    When('the agency detail view mounts', async () => {
+      render(AgencyDetailView);
+      await tick();
+    });
+
+    Then('I should see a link to that contract', async () => {
+      await waitFor(
+        () => {
+          const link = document.querySelector(
+            'a[href*="00000000000191-1-000001-1"]',
+          );
+          expect(link).toBeTruthy();
+        },
+        { timeout: 2000 },
+      );
+    });
+  });
+});

--- a/web/src/components/__steps__/city-detail.steps.ts
+++ b/web/src/components/__steps__/city-detail.steps.ts
@@ -1,0 +1,155 @@
+import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber';
+import { screen, cleanup, waitFor } from '@testing-library/svelte/pure';
+import { vi, expect } from 'vitest';
+import { tick } from 'svelte';
+import { render } from './shared';
+import CityDetailViewRaw from '../CityDetailView.svelte';
+
+const CityDetailView = CityDetailViewRaw as unknown as Parameters<typeof render>[0];
+const feature = await loadFeature('features/city-detail.feature');
+
+function setUrlQuery(qs: string) {
+  window.history.replaceState({}, '', qs ? `/?${qs}` : '/');
+}
+
+describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
+  BeforeEachScenario(async () => {
+    cleanup();
+    vi.restoreAllMocks();
+    setUrlQuery('');
+  });
+
+  Scenario('Missing IBGE shows EntityNotFound', ({ Given, When, Then }) => {
+    Given('the URL has no ibge parameter', () => {
+      setUrlQuery('');
+    });
+
+    When('the city detail view mounts', async () => {
+      render(CityDetailView);
+      await tick();
+    });
+
+    Then('I should see "MUNICÍPIO não encontrada"', async () => {
+      await waitFor(() =>
+        expect(screen.getByText('MUNICÍPIO não encontrada')).toBeTruthy(),
+      );
+    });
+  });
+
+  Scenario('Fetch pending shows skeleton', ({ Given, And, When, Then }) => {
+    Given('the URL has ibge "1721000"', () => {
+      setUrlQuery('ibge=1721000');
+    });
+
+    And('the fetch is pending', () => {
+      global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    });
+
+    When('the city detail view mounts', async () => {
+      render(CityDetailView);
+      await tick();
+    });
+
+    Then('I should see an aria-busy element', async () => {
+      await waitFor(() =>
+        expect(document.querySelector('[aria-busy="true"]')).toBeTruthy(),
+      );
+    });
+  });
+
+  Scenario('Fetch error shows AlertBanner', ({ Given, And, When, Then }) => {
+    Given('the URL has ibge "1721000"', () => {
+      setUrlQuery('ibge=1721000');
+    });
+
+    And('the fetch throws "Município não localizado"', () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(new Response('nope', { status: 404 }));
+    });
+
+    When('the city detail view mounts', async () => {
+      render(CityDetailView);
+      await tick();
+    });
+
+    Then('I should see an alert banner with the error message', async () => {
+      await waitFor(
+        () => {
+          const alert = screen.getByRole('alert');
+          expect(alert.textContent).toMatch(/Município não localizado/);
+        },
+        { timeout: 2000 },
+      );
+    });
+  });
+
+  Scenario('Zero contracts shows EmptyState', ({ Given, And, When, Then }) => {
+    Given('the URL has ibge "1721000"', () => {
+      setUrlQuery('ibge=1721000');
+    });
+
+    And('the PNCP API returns 0 contracts', () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify({ data: [] }), { status: 200 }),
+        );
+    });
+
+    When('the city detail view mounts', async () => {
+      render(CityDetailView);
+      await tick();
+    });
+
+    Then('I should see "Nenhuma contratação recente"', async () => {
+      await waitFor(
+        () =>
+          expect(screen.getByText('Nenhuma contratação recente')).toBeTruthy(),
+        { timeout: 2000 },
+      );
+    });
+  });
+
+  Scenario('Contract count rendered as stat card', ({ Given, And, When, Then }) => {
+    Given('the URL has ibge "1721000"', () => {
+      setUrlQuery('ibge=1721000');
+    });
+
+    And('the PNCP API returns 1 contract', () => {
+      global.fetch = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                numeroControlePNCP: '99999999999999-1-000001-1',
+                dataPublicacaoPncp: '2025-01-15T00:00:00',
+                objetoContratacao: 'Teste',
+                valorTotalEstimado: 500,
+                orgaoEntidade: { razaoSocial: 'Órgão', cnpj: '99999999999999' },
+                unidadeOrgao: { nomeUnidade: 'Unidade' },
+                municipio: { nome: 'Palmas', uf: 'TO' },
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+    });
+
+    When('the city detail view mounts', async () => {
+      render(CityDetailView);
+      await tick();
+    });
+
+    Then('I should see a stat card with value "1"', async () => {
+      await waitFor(
+        () => {
+          expect(screen.getByText('Contratações Recentes')).toBeTruthy();
+          expect(screen.getByText('1')).toBeTruthy();
+        },
+        { timeout: 2000 },
+      );
+    });
+  });
+});

--- a/web/src/components/__steps__/contract-detail.steps.ts
+++ b/web/src/components/__steps__/contract-detail.steps.ts
@@ -1,0 +1,127 @@
+import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber';
+import { screen, cleanup, waitFor } from '@testing-library/svelte/pure';
+import { vi, expect } from 'vitest';
+import { tick } from 'svelte';
+import { render } from './shared';
+import ContractDetailViewRaw from '../ContractDetailView.svelte';
+
+const ContractDetailView = ContractDetailViewRaw as unknown as Parameters<typeof render>[0];
+const feature = await loadFeature('features/contract-detail.feature');
+
+function setUrlQuery(qs: string) {
+  window.history.replaceState({}, '', qs ? `/?${qs}` : '/');
+}
+
+describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
+  BeforeEachScenario(async () => {
+    cleanup();
+    vi.restoreAllMocks();
+    setUrlQuery('');
+  });
+
+  Scenario('Missing ID shows EntityNotFound', ({ Given, When, Then }) => {
+    Given('the URL has no id parameter', () => {
+      setUrlQuery('');
+    });
+
+    When('the contract detail view mounts', async () => {
+      render(ContractDetailView);
+      await tick();
+    });
+
+    Then('I should see "CONTRATAÇÃO não encontrada"', async () => {
+      await waitFor(() =>
+        expect(screen.getByText('CONTRATAÇÃO não encontrada')).toBeTruthy(),
+      );
+    });
+  });
+
+  Scenario('Fetch pending shows skeleton', ({ Given, And, When, Then }) => {
+    Given('the URL has id "00000000000191-1-000001-1"', () => {
+      setUrlQuery('id=00000000000191-1-000001-1');
+    });
+
+    And('the fetch is pending', () => {
+      global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    });
+
+    When('the contract detail view mounts', async () => {
+      render(ContractDetailView);
+      await tick();
+    });
+
+    Then('I should see an aria-busy element', async () => {
+      await waitFor(() =>
+        expect(document.querySelector('[aria-busy="true"]')).toBeTruthy(),
+      );
+    });
+  });
+
+  Scenario('Fetch error shows AlertBanner', ({ Given, And, When, Then }) => {
+    Given('the URL has id "00000000000191-1-000001-1"', () => {
+      setUrlQuery('id=00000000000191-1-000001-1');
+    });
+
+    And('the fetch throws "Contratação não localizada"', () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(new Response('nope', { status: 404 }));
+    });
+
+    When('the contract detail view mounts', async () => {
+      render(ContractDetailView);
+      await tick();
+    });
+
+    Then('I should see an alert banner with the error message', async () => {
+      await waitFor(
+        () => {
+          const alert = screen.getByRole('alert');
+          expect(alert.textContent).toMatch(/Contratação não localizada/);
+        },
+        { timeout: 2000 },
+      );
+    });
+  });
+
+  Scenario('Successful fetch renders both summary cards', ({ Given, And, When, Then }) => {
+    Given('the URL has id "00000000000191-1-000001-1"', () => {
+      setUrlQuery('id=00000000000191-1-000001-1');
+    });
+
+    And('the PNCP API returns a valid contract payload', () => {
+      global.fetch = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            numeroControlePNCP: '00000000000191-1-000001-1',
+            dataPublicacaoPncp: '2025-01-15T00:00:00',
+            objetoContratacao: 'Aquisição de materiais',
+            valorTotalEstimado: 1000,
+            modalidadeNome: 'Pregão',
+            situacaoNome: 'Publicada',
+            orgaoEntidade: { razaoSocial: 'Órgão', cnpj: '00000000000191' },
+            unidadeOrgao: { nomeUnidade: 'Unidade' },
+            itens: [{ sequencialItem: 1, descricao: 'Item 1' }],
+          }),
+          { status: 200 },
+        ),
+      );
+    });
+
+    When('the contract detail view mounts', async () => {
+      render(ContractDetailView);
+      await tick();
+    });
+
+    Then('I should see "Resumo Executivo"', async () => {
+      await waitFor(
+        () => expect(screen.getByText('Resumo Executivo')).toBeTruthy(),
+        { timeout: 2000 },
+      );
+    });
+
+    And('I should see "Itens da Licitação"', () => {
+      expect(screen.getByText('Itens da Licitação')).toBeTruthy();
+    });
+  });
+});

--- a/web/src/components/__steps__/duckdb-explorer.steps.ts
+++ b/web/src/components/__steps__/duckdb-explorer.steps.ts
@@ -201,4 +201,59 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       );
     },
   );
+
+  Scenario(
+    'Active query is backfilled when IA URL resolves after a chip click',
+    ({ Given, When, And, Then }) => {
+      const resolvedUrl =
+        'https://archive.org/download/baliza-pncp-2025-01/contratos-2025-01.parquet';
+      let resolveManifest: (url: string | null) => void = () => {};
+
+      Given(
+        'the IA manifest is slow to resolve to "https://archive.org/download/baliza-pncp-2025-01/contratos-2025-01.parquet"',
+        () => {
+          vi.spyOn(iaManifestModule, 'getLatestParquetUrl').mockImplementation(
+            () =>
+              new Promise<string | null>((resolve) => {
+                resolveManifest = resolve;
+              }),
+          );
+        },
+      );
+
+      When('the explorer mounts', async () => {
+        render(DuckDBExplorer);
+        await tick();
+      });
+
+      And(
+        'the user clicks a featured query chip before the manifest resolves',
+        async () => {
+          const fq = FEATURED_QUERIES.find((q) => q.sql.includes("'IA_URL'"));
+          if (!fq) throw new Error('No featured query contains IA_URL');
+          await fireEvent.click(screen.getByText(fq.label));
+          await tick();
+          expect(getTextarea().value).toContain("'IA_URL'");
+        },
+      );
+
+      And('the manifest finishes resolving', async () => {
+        resolveManifest(resolvedUrl);
+        await tick();
+        await tick();
+      });
+
+      Then('the SQL textarea should contain the resolved parquet URL', async () => {
+        await waitFor(() => {
+          expect(getTextarea().value).toContain(resolvedUrl);
+          expect(getTextarea().value).not.toContain('IA_URL');
+        });
+      });
+
+      And('the explore button should be enabled', () => {
+        const btn = screen.getByText('Explorar Dados') as HTMLButtonElement;
+        expect(btn.disabled).toBe(false);
+      });
+    },
+  );
 });

--- a/web/src/components/__steps__/duckdb-explorer.steps.ts
+++ b/web/src/components/__steps__/duckdb-explorer.steps.ts
@@ -163,4 +163,42 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       });
     },
   );
+
+  Scenario(
+    'Single quotes in resolved URL are escaped to prevent SQL injection',
+    ({ Given, When, And, Then }) => {
+      const maliciousUrl = "https://example.com/evil'; DROP TABLE x; --";
+
+      Given('the IA manifest resolves to a URL containing a single quote', () => {
+        vi.spyOn(iaManifestModule, 'getLatestParquetUrl').mockResolvedValue(
+          maliciousUrl,
+        );
+      });
+
+      When('the explorer mounts', async () => {
+        render(DuckDBExplorer);
+        await tick();
+      });
+
+      And('the user clicks a featured query chip', async () => {
+        const fq = FEATURED_QUERIES.find((q) => q.sql.includes("'IA_URL'"));
+        if (!fq) throw new Error('No featured query contains IA_URL');
+        await waitFor(() => screen.getByText(fq.label));
+        await fireEvent.click(screen.getByText(fq.label));
+        await tick();
+      });
+
+      Then(
+        'the SQL textarea should contain the URL with doubled single quotes',
+        async () => {
+          await waitFor(() => {
+            expect(getTextarea().value).toContain(
+              maliciousUrl.replace(/'/g, "''"),
+            );
+            expect(getTextarea().value).not.toContain(`'${maliciousUrl}'`);
+          });
+        },
+      );
+    },
+  );
 });

--- a/web/src/components/__steps__/duckdb-explorer.steps.ts
+++ b/web/src/components/__steps__/duckdb-explorer.steps.ts
@@ -1,0 +1,166 @@
+import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber';
+import { screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte/pure';
+import { vi, expect } from 'vitest';
+import { tick } from 'svelte';
+import { render } from './shared';
+import * as duckdbModule from '../../lib/duckdb';
+import * as iaManifestModule from '../../lib/ia-manifest';
+import DuckDBExplorerRaw from '../DuckDBExplorer.svelte';
+import { FEATURED_QUERIES } from '../../lib/homepage-content';
+
+const DuckDBExplorer = DuckDBExplorerRaw as unknown as Parameters<typeof render>[0];
+const feature = await loadFeature('features/duckdb-explorer.feature');
+
+function getTextarea(): HTMLTextAreaElement {
+  return screen.getByLabelText('Consulta SQL') as HTMLTextAreaElement;
+}
+
+function chipThatNeedsIaUrl() {
+  const fq = FEATURED_QUERIES.find((q) => q.sql.includes("'IA_URL'"));
+  if (!fq) throw new Error('No featured query with IA_URL placeholder');
+  return fq;
+}
+
+describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
+  BeforeEachScenario(async () => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  Scenario('Initial state shows explore button and default query', ({ When, Then, And }) => {
+    When('the explorer mounts', async () => {
+      render(DuckDBExplorer);
+      await tick();
+    });
+
+    Then('I should see "Explorar Dados"', () => {
+      expect(screen.getByText('Explorar Dados')).toBeTruthy();
+    });
+
+    And('the SQL textarea should contain "SELECT"', () => {
+      expect(getTextarea().value).toMatch(/SELECT/);
+    });
+  });
+
+  Scenario("Featured query chip inserts SQL into textarea", ({ When, And, Then }) => {
+    When('the explorer mounts', async () => {
+      render(DuckDBExplorer);
+      await tick();
+    });
+
+    let picked: { label: string; sql: string } | null = null;
+
+    And('the user clicks a featured query chip', async () => {
+      picked = FEATURED_QUERIES[0];
+      await fireEvent.click(screen.getByText(picked.label));
+      await tick();
+    });
+
+    Then("the SQL textarea should contain the chip's SQL", () => {
+      expect(picked).not.toBeNull();
+      expect(getTextarea().value).toBe(picked!.sql);
+    });
+  });
+
+  Scenario('IA_URL placeholder shows warning and disables button', ({ When, And, Then }) => {
+    When('the explorer mounts', async () => {
+      render(DuckDBExplorer);
+      await tick();
+    });
+
+    And('the user clicks a featured query chip that still contains "IA_URL"', async () => {
+      const fq = chipThatNeedsIaUrl();
+      await fireEvent.click(screen.getByText(fq.label));
+      await tick();
+    });
+
+    Then('I should see a placeholder warning', () => {
+      expect(screen.getByRole('note').textContent).toMatch(/IA_URL/);
+    });
+
+    And('the explore button should be disabled', () => {
+      const btn = screen.getByText('Explorar Dados') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+  });
+
+  Scenario('Valid SQL executes and renders results', ({ Given, When, And, Then }) => {
+    Given('DuckDB returns one row with column "n" equal to 1', () => {
+      vi.spyOn(duckdbModule, 'getDuckDB').mockResolvedValue({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        db: null as any,
+        conn: {
+          query: vi.fn().mockResolvedValue({
+            toArray: () => [{ toJSON: () => ({ n: 1 }) }],
+          }),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+      });
+    });
+
+    When('the explorer mounts', async () => {
+      render(DuckDBExplorer);
+      await tick();
+    });
+
+    And('the user clicks "Explorar Dados"', async () => {
+      const textarea = getTextarea();
+      await fireEvent.input(textarea, { target: { value: 'SELECT 1 AS n' } });
+      await tick();
+      await fireEvent.click(screen.getByText('Explorar Dados'));
+    });
+
+    Then('I should see a results table with "n" as a column header', async () => {
+      await waitFor(
+        () => {
+          const th = document.querySelector('th');
+          expect(th?.textContent).toBe('n');
+        },
+        { timeout: 2000 },
+      );
+    });
+  });
+
+  Scenario(
+    'Resolved IA URL replaces IA_URL placeholder in featured query chips',
+    ({ Given, When, And, Then }) => {
+      const resolvedUrl =
+        'https://archive.org/download/baliza-pncp-2025-01/contratos-2025-01.parquet';
+
+      Given(
+        'the IA manifest resolves to "https://archive.org/download/baliza-pncp-2025-01/contratos-2025-01.parquet"',
+        () => {
+          vi.spyOn(iaManifestModule, 'getLatestParquetUrl').mockResolvedValue(
+            resolvedUrl,
+          );
+        },
+      );
+
+      When('the explorer mounts', async () => {
+        render(DuckDBExplorer);
+        await tick();
+      });
+
+      And('the user clicks a featured query chip', async () => {
+        const fq = FEATURED_QUERIES.find((q) => q.sql.includes("'IA_URL'"));
+        if (!fq) throw new Error('No featured query contains IA_URL');
+        await waitFor(() => screen.getByText(fq.label));
+        await fireEvent.click(screen.getByText(fq.label));
+        await tick();
+      });
+
+      Then(
+        'the SQL textarea should contain the resolved parquet URL',
+        async () => {
+          await waitFor(() => {
+            expect(getTextarea().value).toContain(resolvedUrl);
+          });
+        },
+      );
+
+      And('the SQL textarea should not contain "IA_URL"', () => {
+        expect(getTextarea().value).not.toContain('IA_URL');
+      });
+    },
+  );
+});

--- a/web/src/components/__steps__/shared.ts
+++ b/web/src/components/__steps__/shared.ts
@@ -18,6 +18,12 @@ vi.mock('../../lib/duckdb', () => ({
   }),
 }));
 
+vi.mock('../../lib/ia-manifest', () => ({
+  getLatestParquetUrl: vi.fn().mockResolvedValue(null),
+  resetIaManifestCache: vi.fn(),
+  IA_MANIFEST_URL: 'https://archive.org/download/baliza-pncp-manifest/manifest.csv',
+}));
+
 export function render(
   component: Parameters<typeof tlRender>[0],
   props?: Parameters<typeof tlRender>[1],

--- a/web/src/lib/duckdb.ts
+++ b/web/src/lib/duckdb.ts
@@ -1,8 +1,24 @@
-import type { AsyncDuckDB, AsyncDuckDBConnection } from '@duckdb/duckdb-wasm';
+import type {
+  AsyncDuckDB,
+  AsyncDuckDBConnection,
+  DuckDBBundles,
+} from '@duckdb/duckdb-wasm';
+
+import duckdb_mvp_wasm from '@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url';
+import duckdb_mvp_worker from '@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url';
+import duckdb_eh_wasm from '@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url';
+import duckdb_eh_worker from '@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url';
 
 export let dbInstance: AsyncDuckDB | null = null;
 export let connInstance: AsyncDuckDBConnection | null = null;
 let initializationPromise: Promise<{ db: AsyncDuckDB; conn: AsyncDuckDBConnection }> | null = null;
+
+function getBundledBundles(): DuckDBBundles {
+  return {
+    mvp: { mainModule: duckdb_mvp_wasm, mainWorker: duckdb_mvp_worker },
+    eh: { mainModule: duckdb_eh_wasm, mainWorker: duckdb_eh_worker },
+  };
+}
 
 export async function getDuckDB(): Promise<{ db: AsyncDuckDB; conn: AsyncDuckDBConnection }> {
   if (dbInstance && connInstance) return { db: dbInstance, conn: connInstance };
@@ -11,8 +27,13 @@ export async function getDuckDB(): Promise<{ db: AsyncDuckDB; conn: AsyncDuckDBC
   initializationPromise = (async () => {
     try {
       const duckdb = await import('@duckdb/duckdb-wasm');
-      const JSDELIVR_BUNDLES = duckdb.getJsDelivrBundles();
-      const bundle = await duckdb.selectBundle(JSDELIVR_BUNDLES);
+
+      let bundle: Awaited<ReturnType<typeof duckdb.selectBundle>>;
+      try {
+        bundle = await duckdb.selectBundle(getBundledBundles());
+      } catch {
+        bundle = await duckdb.selectBundle(duckdb.getJsDelivrBundles());
+      }
 
       if (!bundle.mainWorker) throw new Error('DuckDB bundle selection failed');
 

--- a/web/src/lib/duckdb.ts
+++ b/web/src/lib/duckdb.ts
@@ -31,7 +31,11 @@ export async function getDuckDB(): Promise<{ db: AsyncDuckDB; conn: AsyncDuckDBC
       let bundle: Awaited<ReturnType<typeof duckdb.selectBundle>>;
       try {
         bundle = await duckdb.selectBundle(getBundledBundles());
-      } catch {
+      } catch (err) {
+        console.warn(
+          '[duckdb] bundled WASM selection failed, falling back to jsDelivr CDN:',
+          err,
+        );
         bundle = await duckdb.selectBundle(duckdb.getJsDelivrBundles());
       }
 

--- a/web/src/lib/ia-manifest.ts
+++ b/web/src/lib/ia-manifest.ts
@@ -1,30 +1,12 @@
+import Papa from 'papaparse';
+
 export const IA_MANIFEST_URL =
   'https://archive.org/download/baliza-pncp-manifest/manifest.csv';
 
 interface ManifestRow {
-  data_particao: string;
-  table_name: string;
-  parquet_url: string;
-}
-
-function parseManifestCsv(csv: string): ManifestRow[] {
-  const lines = csv.trim().split(/\r?\n/);
-  if (lines.length < 2) return [];
-  const header = lines[0].split(',');
-  const idx = {
-    data_particao: header.indexOf('data_particao'),
-    table_name: header.indexOf('table_name'),
-    parquet_url: header.indexOf('parquet_url'),
-  };
-  if (idx.data_particao < 0 || idx.parquet_url < 0) return [];
-  return lines.slice(1).map((line) => {
-    const cols = line.split(',');
-    return {
-      data_particao: cols[idx.data_particao] ?? '',
-      table_name: cols[idx.table_name] ?? '',
-      parquet_url: cols[idx.parquet_url] ?? '',
-    };
-  });
+  data_particao?: string;
+  table_name?: string;
+  parquet_url?: string;
 }
 
 let cached: Promise<string | null> | null = null;
@@ -39,12 +21,18 @@ export async function getLatestParquetUrl(): Promise<string | null> {
     try {
       const res = await fetch(IA_MANIFEST_URL);
       if (!res.ok) return null;
-      const rows = parseManifestCsv(await res.text()).filter(
+      const parsed = Papa.parse<ManifestRow>(await res.text(), {
+        header: true,
+        skipEmptyLines: true,
+      });
+      const rows = (parsed.data ?? []).filter(
         (r) => r.table_name === 'contratos' && r.parquet_url,
       );
       if (rows.length === 0) return null;
-      rows.sort((a, b) => b.data_particao.localeCompare(a.data_particao));
-      return rows[0].parquet_url;
+      rows.sort((a, b) =>
+        (b.data_particao ?? '').localeCompare(a.data_particao ?? ''),
+      );
+      return rows[0].parquet_url ?? null;
     } catch {
       return null;
     }

--- a/web/src/lib/ia-manifest.ts
+++ b/web/src/lib/ia-manifest.ts
@@ -1,0 +1,55 @@
+export const IA_MANIFEST_URL =
+  'https://archive.org/download/baliza-pncp-manifest/manifest.csv';
+
+interface ManifestRow {
+  data_particao: string;
+  table_name: string;
+  parquet_url: string;
+}
+
+function parseManifestCsv(csv: string): ManifestRow[] {
+  const lines = csv.trim().split(/\r?\n/);
+  if (lines.length < 2) return [];
+  const header = lines[0].split(',');
+  const idx = {
+    data_particao: header.indexOf('data_particao'),
+    table_name: header.indexOf('table_name'),
+    parquet_url: header.indexOf('parquet_url'),
+  };
+  if (idx.data_particao < 0 || idx.parquet_url < 0) return [];
+  return lines.slice(1).map((line) => {
+    const cols = line.split(',');
+    return {
+      data_particao: cols[idx.data_particao] ?? '',
+      table_name: cols[idx.table_name] ?? '',
+      parquet_url: cols[idx.parquet_url] ?? '',
+    };
+  });
+}
+
+let cached: Promise<string | null> | null = null;
+
+export function resetIaManifestCache() {
+  cached = null;
+}
+
+export async function getLatestParquetUrl(): Promise<string | null> {
+  if (cached) return cached;
+  cached = (async () => {
+    try {
+      const res = await fetch(IA_MANIFEST_URL);
+      if (!res.ok) return null;
+      const rows = parseManifestCsv(await res.text()).filter(
+        (r) => r.table_name === 'contratos' && r.parquet_url,
+      );
+      if (rows.length === 0) return null;
+      rows.sort((a, b) => b.data_particao.localeCompare(a.data_particao));
+      return rows[0].parquet_url;
+    } catch {
+      return null;
+    }
+  })();
+  const result = await cached;
+  if (result === null) cached = null;
+  return result;
+}

--- a/web/src/pages/contratacao.astro
+++ b/web/src/pages/contratacao.astro
@@ -1,11 +1,13 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import ContractDetailView from '../components/ContractDetailView.svelte';
+
+const id = Astro.url.searchParams.get('id') ?? '';
 ---
 
-<Layout 
-  title="Detalhamento de Contratação" 
+<Layout
+  title="Detalhamento de Contratação"
   description="Veja todos os detalhes interessantes desta contratação pública registrada no PNCP e preservada pelo Baliza."
 >
-  <ContractDetailView client:only="svelte" />
+  <ContractDetailView client:only="svelte" id={id} />
 </Layout>

--- a/web/src/pages/municipio.astro
+++ b/web/src/pages/municipio.astro
@@ -1,11 +1,13 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import CityDetailView from '../components/CityDetailView.svelte';
+
+const ibge = Astro.url.searchParams.get('ibge') ?? '';
 ---
 
-<Layout 
-  title="Painel do Município" 
+<Layout
+  title="Painel do Município"
   description="Consulte o histórico de contratações e o volume de dados preservados para este município."
 >
-  <CityDetailView client:only="svelte" />
+  <CityDetailView client:only="svelte" ibge={ibge} />
 </Layout>

--- a/web/src/pages/orgao.astro
+++ b/web/src/pages/orgao.astro
@@ -1,11 +1,13 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import AgencyDetailView from '../components/AgencyDetailView.svelte';
+
+const cnpj = Astro.url.searchParams.get('cnpj') ?? '';
 ---
 
-<Layout 
-  title="Painel do Órgão" 
+<Layout
+  title="Painel do Órgão"
   description="Consulte o perfil de compras e o histórico de contratações deste órgão público."
 >
-  <AgencyDetailView client:only="svelte" />
+  <AgencyDetailView client:only="svelte" cnpj={cnpj} />
 </Layout>


### PR DESCRIPTION
## Summary
This PR introduces comprehensive BDD (Behavior-Driven Development) test coverage using Cucumber-style feature files and step implementations, while also adding URL query parameter support to detail view components. Additionally, it includes a new Internet Archive manifest utility for resolving dynamic parquet URLs.

## Key Changes

### Test Infrastructure
- Added 4 feature files with Gherkin scenarios:
  - `duckdb-explorer.feature` - Tests SQL explorer functionality, featured queries, and IA_URL placeholder handling
  - `agency-detail.feature` - Tests agency/órgão detail view with CNPJ parameter
  - `city-detail.feature` - Tests city/município detail view with IBGE parameter
  - `contract-detail.feature` - Tests contract/contratação detail view with ID parameter

- Added corresponding step implementations:
  - `duckdb-explorer.steps.ts` - 5 scenarios covering query execution, featured queries, and placeholder resolution
  - `agency-detail.steps.ts` - 5 scenarios covering missing params, loading states, errors, and contract rendering
  - `city-detail.steps.ts` - 5 scenarios with similar coverage for city details
  - `contract-detail.steps.ts` - 4 scenarios for contract detail views

### Component Updates
- **DuckDBExplorer.svelte**: Added `onMount` hook to resolve IA parquet URLs and derive featured queries with resolved URLs
- **AgencyDetailView.svelte**: Added URL query parameter fallback (`?cnpj=`) alongside component props
- **CityDetailView.svelte**: Added URL query parameter fallback (`?ibge=`) alongside component props
- **ContractDetailView.svelte**: Added URL query parameter fallback (`?id=`) alongside component props

### New Utilities
- **ia-manifest.ts**: New module for fetching and parsing Internet Archive manifest CSV to resolve latest parquet URLs
  - `getLatestParquetUrl()` - Fetches manifest and returns latest contratos parquet URL
  - `resetIaManifestCache()` - Cache management for testing
  - Includes CSV parsing logic for manifest rows

### Page Updates
- **orgao.astro**, **municipio.astro**, **contratacao.astro**: Extract query parameters server-side and pass to components

### DuckDB Configuration
- **duckdb.ts**: Updated to use bundled WASM modules instead of CDN, with fallback logic for bundle selection

### Test Mocking
- Updated `shared.ts` to mock `ia-manifest` module for test isolation

## Notable Implementation Details
- Detail view components now support both prop-based and URL query parameter-based initialization, enabling direct linking
- Featured queries in DuckDB explorer dynamically resolve `'IA_URL'` placeholders to actual parquet URLs from Internet Archive
- Comprehensive error handling and loading states tested across all detail views
- BDD tests use `@amiceli/vitest-cucumber` for readable, maintainable test scenarios

https://claude.ai/code/session_01BHZUYpVGLNrBFqVYwnt1QG