### PR TITLE
Add Parquet fallback for detail views and free-text search to hero

### DIFF
--- a/web/FRONTEND.md
+++ b/web/FRONTEND.md
@@ -72,3 +72,21 @@ All components must use scoped `<style>` blocks referencing global CSS variables
 
 - **Do not** write inline `style="..."` with hardcoded values.
 - **Do not** duplicate hex codes.
+
+---
+
+## PNCP API boundaries
+
+Two distinct PNCP surfaces are consumed by the client:
+
+- **Consulta API** (`https://pncp.gov.br/api/consulta/v1/...`) — the structured
+  endpoints for agency / city / contract detail reads. These do **not** accept a
+  free-text keyword parameter.
+- **Portal search** (`https://pncp.gov.br/api/search?q=<term>&tipos_documento=edital&pagina=1`)
+  — the keyword-backed index used by the public portal's own search bar; used
+  by `SearchHero` for free-text queries and returns `{ items, total }`.
+
+When any consulta read fails, detail views fall back to the latest Internet
+Archive Parquet snapshot via `queryParquetFallback()`. Column identifiers are
+validated against `^[A-Za-z_][A-Za-z0-9_]*$` and every literal is escaped with
+the `'` → `''` pattern before it is embedded in the SQL string.

--- a/web/features/contract-detail.feature
+++ b/web/features/contract-detail.feature
@@ -18,9 +18,21 @@ Feature: Contract Detail View
     When the contract detail view mounts
     Then I should see an alert banner with the error message
 
-  Scenario: Successful fetch renders both summary cards
+  Scenario: Successful fetch renders all detail blocks
     Given the URL has id "00000000000191-1-000001-1"
     And the PNCP API returns a valid contract payload
     When the contract detail view mounts
-    Then I should see "Resumo Executivo"
-    And I should see "Itens da Licitação"
+    Then I should see the "Detalhes da Contratação" block
+    And I should see the "Órgão Responsável" block
+    And I should see the "Valores" block
+    And I should see the "Itens" block
+    And I should see the "Fontes e Metadados" block
+
+  Scenario: Successful fetch renders formatted currency and links
+    Given the URL has id "00000000000191-1-000001-1"
+    And the PNCP API returns a valid contract payload
+    When the contract detail view mounts
+    Then I should see the BRL-formatted valor "R$ 1.500,00"
+    And I should see a link to the agency page with cnpj "00000000000191"
+    And I should see a link to the municipality page with ibge "3550308"
+    And I should see an external link to the origin system

--- a/web/features/contract-detail.feature
+++ b/web/features/contract-detail.feature
@@ -36,3 +36,9 @@ Feature: Contract Detail View
     And I should see a link to the agency page with cnpj "00000000000191"
     And I should see a link to the municipality page with ibge "3550308"
     And I should see an external link to the origin system
+
+  Scenario: Slash-form id uses the year segment when calling PNCP
+    Given the URL has id "00000000000191-1-000001/2024"
+    And the PNCP API returns a valid contract payload
+    When the contract detail view mounts
+    Then the PNCP consulta URL should contain "/contratacoes/2024/000001"

--- a/web/features/detail-view-fallback.feature
+++ b/web/features/detail-view-fallback.feature
@@ -44,3 +44,10 @@ Feature: Detail view Parquet fallback
     And the Parquet fallback returns no rows for id "00000000000191-1-000001-1"
     When the contract detail view mounts for id "00000000000191-1-000001-1"
     Then I should see an error banner about arquivo histórico
+
+  Scenario: Contract view accepts slash-separated PNCP IDs and reaches the fallback
+    Given the PNCP API is unavailable for id "00000000000191-1-000001/2024"
+    And the Parquet fallback returns one row for id "00000000000191-1-000001/2024"
+    When the contract detail view mounts for id "00000000000191-1-000001/2024"
+    Then I should see an info banner about PNCP indisponível
+    And I should see the archived contract objeto

--- a/web/features/detail-view-fallback.feature
+++ b/web/features/detail-view-fallback.feature
@@ -1,0 +1,46 @@
+Feature: Detail view Parquet fallback
+  Detail views try the latest Internet Archive Parquet snapshot when PNCP is down.
+
+  Scenario: Agency view falls back to Parquet when PNCP fails
+    Given the PNCP API is unavailable for cnpj "00000000000191"
+    And the Parquet fallback returns one contract row for cnpj "00000000000191"
+    When the agency detail view mounts for cnpj "00000000000191"
+    Then I should see an info banner about PNCP indisponível
+    And I should see the archived contract from the Parquet snapshot
+
+  Scenario: Agency view shows combined error when both fail
+    Given the PNCP API is unavailable for cnpj "00000000000191"
+    And the Parquet fallback returns no rows for cnpj "00000000000191"
+    When the agency detail view mounts for cnpj "00000000000191"
+    Then I should see an error banner about arquivo histórico
+
+  Scenario: Agency view does not query Parquet when PNCP succeeds
+    Given the PNCP API returns one contract for cnpj "00000000000191"
+    When the agency detail view mounts for cnpj "00000000000191"
+    Then the Parquet fallback should not be called
+
+  Scenario: City view falls back to Parquet when PNCP fails
+    Given the PNCP API is unavailable for ibge "3550308"
+    And the Parquet fallback returns one contract row for ibge "3550308"
+    When the city detail view mounts for ibge "3550308"
+    Then I should see an info banner about PNCP indisponível
+    And I should see the archived contract from the Parquet snapshot
+
+  Scenario: City view shows combined error when both fail
+    Given the PNCP API is unavailable for ibge "3550308"
+    And the Parquet fallback returns no rows for ibge "3550308"
+    When the city detail view mounts for ibge "3550308"
+    Then I should see an error banner about arquivo histórico
+
+  Scenario: Contract view falls back to Parquet when PNCP fails
+    Given the PNCP API is unavailable for id "00000000000191-1-000001-1"
+    And the Parquet fallback returns one row for id "00000000000191-1-000001-1"
+    When the contract detail view mounts for id "00000000000191-1-000001-1"
+    Then I should see an info banner about PNCP indisponível
+    And I should see the archived contract objeto
+
+  Scenario: Contract view shows combined error when both fail
+    Given the PNCP API is unavailable for id "00000000000191-1-000001-1"
+    And the Parquet fallback returns no rows for id "00000000000191-1-000001-1"
+    When the contract detail view mounts for id "00000000000191-1-000001-1"
+    Then I should see an error banner about arquivo histórico

--- a/web/features/detail-view-fallback.feature
+++ b/web/features/detail-view-fallback.feature
@@ -51,3 +51,13 @@ Feature: Detail view Parquet fallback
     When the contract detail view mounts for id "00000000000191-1-000001/2024"
     Then I should see an info banner about PNCP indisponível
     And I should see the archived contract objeto
+
+  Scenario: Agency fallback uses the exported cnpj_orgao column and orders by recency
+    Given the PNCP API is unavailable for cnpj "00000000000191"
+    When the agency detail view mounts for cnpj "00000000000191"
+    Then the Parquet fallback should be called with column "cnpj_orgao" ordered by "data_publicacao_pncp"
+
+  Scenario: City fallback uses the exported codigo_ibge column and orders by recency
+    Given the PNCP API is unavailable for ibge "3550308"
+    When the city detail view mounts for ibge "3550308"
+    Then the Parquet fallback should be called with column "codigo_ibge" ordered by "data_publicacao_pncp"

--- a/web/features/search-hero.feature
+++ b/web/features/search-hero.feature
@@ -1,5 +1,6 @@
 Feature: Search Hero
-  The search input detects patterns and navigates to the right page.
+  The search input detects patterns and navigates to the right page, or
+  queries the PNCP search API for free text.
 
   Scenario: Detect CNPJ pattern and show correct jump link
     Given the user types "12345678000195" into the search box
@@ -27,3 +28,34 @@ Feature: Search Hero
   Scenario: Search input has accessible label
     When the search hero loads
     Then the input should have an accessible label
+
+  Scenario: Submitting a CNPJ navigates to the agency page
+    Given the user types "12345678000195" into the search box
+    When the user submits the search form
+    Then the browser should navigate to "/baliza/orgao?cnpj=12345678000195"
+
+  Scenario: Submitting an IBGE code navigates to the municipality page
+    Given the user types "3550308" into the search box
+    When the user submits the search form
+    Then the browser should navigate to "/baliza/municipio?ibge=3550308"
+
+  Scenario: Submitting a PNCP contract ID navigates to the contract page
+    Given the user types "12345678000195-1-000001-1" into the search box
+    When the user submits the search form
+    Then the browser should navigate to "/baliza/contratacao?id=12345678000195-1-000001-1"
+
+  Scenario: Free text triggers a PNCP search and renders results listbox
+    Given the PNCP search API returns two results for "hospital"
+    When the user types "hospital" into the search box
+    Then I should see a results listbox with at least one link
+    And the first result should link to a contratação page
+
+  Scenario: PNCP search failure shows an alert banner
+    Given the PNCP search API fails for "hospital"
+    When the user types "hospital" into the search box
+    Then I should see an alert banner about the search error
+
+  Scenario: PNCP search zero results shows an empty state
+    Given the PNCP search API returns zero results for "xyzneverexists"
+    When the user types "xyzneverexists" into the search box
+    Then I should see an empty state for the search

--- a/web/features/search-hero.feature
+++ b/web/features/search-hero.feature
@@ -44,6 +44,11 @@ Feature: Search Hero
     When the user submits the search form
     Then the browser should navigate to "/baliza/contratacao?id=12345678000195-1-000001-1"
 
+  Scenario: Submitting a slash-separated PNCP contract ID also navigates
+    Given the user types "12345678000195-1-000001/2024" into the search box
+    When the user submits the search form
+    Then the browser should navigate to "/baliza/contratacao?id=12345678000195-1-000001/2024"
+
   Scenario: Free text triggers a PNCP search and renders results listbox
     Given the PNCP search API returns two results for "hospital"
     When the user types "hospital" into the search box

--- a/web/src/components/AgencyDetailView.svelte
+++ b/web/src/components/AgencyDetailView.svelte
@@ -3,6 +3,7 @@
   import { getQueryClient } from '../lib/queryClient';
   import { QUERY_KEYS } from '../lib/queryKeys';
   import type { PNCPContract } from '../lib/types';
+  import { queryParquetFallback } from '../lib/parquetFallback';
   import EntityNotFound from './EntityNotFound.svelte';
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
@@ -18,17 +19,61 @@
         : ''),
   );
 
+  interface AgencyView {
+    name: string;
+    cnpj: string;
+    contracts: PNCPContract[];
+    archived?: { dataParticao: string | null };
+  }
+
+  function archivedRowToContract(row: Record<string, unknown>): PNCPContract {
+    return {
+      numeroControlePNCP: String(row.numero_controle_pncp ?? ''),
+      dataPublicacaoPncp: String(row.data_publicacao_pncp ?? ''),
+      objetoContratacao: String(row.objeto_contratacao ?? row.objeto_compra ?? ''),
+      valorTotalEstimado: Number(row.valor_total_estimado ?? 0),
+      orgaoEntidade: {
+        razaoSocial: String(row.orgao_razao_social ?? 'Órgão Arquivado'),
+        cnpj: String(row.orgao_cnpj ?? ''),
+      },
+      unidadeOrgao: {
+        nomeUnidade: String(row.unidade_nome_unidade ?? ''),
+      },
+    };
+  }
+
   const agencyQuery = createQuery(() => ({
     queryKey: QUERY_KEYS.orgao(cnpj),
-    queryFn: async () => {
+    queryFn: async (): Promise<AgencyView | null> => {
       if (!cnpj) return null;
       const url = `https://pncp.gov.br/api/consulta/v1/contratacoes/publicacao?cnpjOrgao=${cnpj}&tamanhoPagina=10`;
-      const res = await fetch(url);
-      if (!res.ok) throw new Error("Órgão não localizado ou sem publicações no PNCP.");
-      const pncpData = (await res.json()) as { data: PNCPContract[] };
-      const contracts = pncpData.data || [];
-      const agencyName = contracts[0]?.orgaoEntidade?.razaoSocial || "Órgão Público";
-      return { name: agencyName, cnpj, contracts };
+      try {
+        const res = await fetch(url);
+        if (!res.ok) throw new Error("Órgão não localizado ou sem publicações no PNCP.");
+        const pncpData = (await res.json()) as { data: PNCPContract[] };
+        const contracts = pncpData.data || [];
+        const agencyName = contracts[0]?.orgaoEntidade?.razaoSocial || "Órgão Público";
+        return { name: agencyName, cnpj, contracts };
+      } catch (pncpErr) {
+        const archived = await queryParquetFallback<Record<string, unknown>>(
+          'orgao_cnpj',
+          cnpj,
+          10,
+        );
+        if (!archived) {
+          throw new Error(
+            "PNCP indisponível e arquivo histórico sem registro para este identificador.",
+          );
+        }
+        const contracts = archived.rows.map(archivedRowToContract);
+        const agencyName = contracts[0]?.orgaoEntidade?.razaoSocial || "Órgão Arquivado";
+        return {
+          name: agencyName,
+          cnpj,
+          contracts,
+          archived: { dataParticao: archived.dataParticao },
+        };
+      }
     },
     enabled: !!cnpj,
   }));
@@ -57,12 +102,19 @@
       </div>
     </div>
   {:else if data}
+    {#if data.archived}
+      <AlertBanner
+        title="Dados arquivados"
+        message={`PNCP indisponível — exibindo dados arquivados (última consolidação: ${data.archived.dataParticao ?? 'desconhecida'}).`}
+        level="info"
+      />
+    {/if}
     <header class="hub-header">
       <span class="type-badge">🏛️ ÓRGÃO / ENTIDADE</span>
       <h1>{data.name}</h1>
       <div class="meta-row">
         <span>CNPJ: {data.cnpj}</span>
-        <span>Fonte: PNCP V1</span>
+        <span>Fonte: {data.archived ? 'Arquivo Parquet (IA)' : 'PNCP V1'}</span>
       </div>
     </header>
 

--- a/web/src/components/AgencyDetailView.svelte
+++ b/web/src/components/AgencyDetailView.svelte
@@ -30,14 +30,14 @@
     return {
       numeroControlePNCP: String(row.numero_controle_pncp ?? ''),
       dataPublicacaoPncp: String(row.data_publicacao_pncp ?? ''),
-      objetoContratacao: String(row.objeto_contratacao ?? row.objeto_compra ?? ''),
-      valorTotalEstimado: Number(row.valor_total_estimado ?? 0),
+      objetoContratacao: String(row.objeto_contrato ?? ''),
+      valorTotalEstimado: Number(row.valor_global ?? row.valor_inicial ?? 0),
       orgaoEntidade: {
-        razaoSocial: String(row.orgao_razao_social ?? 'Órgão Arquivado'),
-        cnpj: String(row.orgao_cnpj ?? ''),
+        razaoSocial: String(row.razao_social_orgao ?? 'Órgão Arquivado'),
+        cnpj: String(row.cnpj_orgao ?? ''),
       },
       unidadeOrgao: {
-        nomeUnidade: String(row.unidade_nome_unidade ?? ''),
+        nomeUnidade: String(row.nome_unidade ?? ''),
       },
     };
   }
@@ -56,9 +56,10 @@
         return { name: agencyName, cnpj, contracts };
       } catch (pncpErr) {
         const archived = await queryParquetFallback<Record<string, unknown>>(
-          'orgao_cnpj',
+          'cnpj_orgao',
           cnpj,
           10,
+          'data_publicacao_pncp',
         );
         if (!archived) {
           throw new Error(

--- a/web/src/components/AgencyDetailView.svelte
+++ b/web/src/components/AgencyDetailView.svelte
@@ -63,6 +63,7 @@
         if (!archived) {
           throw new Error(
             "PNCP indisponível e arquivo histórico sem registro para este identificador.",
+            { cause: pncpErr },
           );
         }
         const contracts = archived.rows.map(archivedRowToContract);

--- a/web/src/components/CityDetailView.svelte
+++ b/web/src/components/CityDetailView.svelte
@@ -60,7 +60,7 @@
         const cityName = contracts[0]?.municipio?.nomeMunicipio || contracts[0]?.unidadeOrgao?.municipioNome || "Município";
         const uf = contracts[0]?.unidadeOrgao?.ufSigla || "";
         return { name: cityName, uf, ibge, contracts };
-      } catch {
+      } catch (pncpErr) {
         const archived = await queryParquetFallback<Record<string, unknown>>(
           'codigo_municipio_ibge',
           ibge,
@@ -69,6 +69,7 @@
         if (!archived) {
           throw new Error(
             "PNCP indisponível e arquivo histórico sem registro para este identificador.",
+            { cause: pncpErr },
           );
         }
         const contracts = archived.rows.map(archivedRowToContract);

--- a/web/src/components/CityDetailView.svelte
+++ b/web/src/components/CityDetailView.svelte
@@ -32,17 +32,17 @@
     return {
       numeroControlePNCP: String(row.numero_controle_pncp ?? ''),
       dataPublicacaoPncp: String(row.data_publicacao_pncp ?? ''),
-      objetoContratacao: String(row.objeto_contratacao ?? row.objeto_compra ?? ''),
-      valorTotalEstimado: Number(row.valor_total_estimado ?? 0),
+      objetoContratacao: String(row.objeto_contrato ?? ''),
+      valorTotalEstimado: Number(row.valor_global ?? row.valor_inicial ?? 0),
       orgaoEntidade: {
-        razaoSocial: String(row.orgao_razao_social ?? ''),
-        cnpj: String(row.orgao_cnpj ?? ''),
+        razaoSocial: String(row.razao_social_orgao ?? ''),
+        cnpj: String(row.cnpj_orgao ?? ''),
       },
       unidadeOrgao: {
-        nomeUnidade: String(row.unidade_nome_unidade ?? ''),
+        nomeUnidade: String(row.nome_unidade ?? ''),
         municipioNome: String(row.municipio_nome ?? ''),
         ufSigla: String(row.uf_sigla ?? ''),
-        codigoMunicipioIbge: String(row.codigo_municipio_ibge ?? ''),
+        codigoMunicipioIbge: String(row.codigo_ibge ?? ''),
       },
     };
   }
@@ -62,9 +62,10 @@
         return { name: cityName, uf, ibge, contracts };
       } catch (pncpErr) {
         const archived = await queryParquetFallback<Record<string, unknown>>(
-          'codigo_municipio_ibge',
+          'codigo_ibge',
           ibge,
           10,
+          'data_publicacao_pncp',
         );
         if (!archived) {
           throw new Error(

--- a/web/src/components/CityDetailView.svelte
+++ b/web/src/components/CityDetailView.svelte
@@ -2,6 +2,8 @@
   import { createQuery, setQueryClientContext } from '@tanstack/svelte-query';
   import { getQueryClient } from '../lib/queryClient';
   import { QUERY_KEYS } from '../lib/queryKeys';
+  import type { PNCPContract } from '../lib/types';
+  import { queryParquetFallback } from '../lib/parquetFallback';
   import EntityNotFound from './EntityNotFound.svelte';
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
@@ -18,18 +20,69 @@
         : ''),
   );
 
+  interface CityView {
+    name: string;
+    uf: string;
+    ibge: string;
+    contracts: PNCPContract[];
+    archived?: { dataParticao: string | null };
+  }
+
+  function archivedRowToContract(row: Record<string, unknown>): PNCPContract {
+    return {
+      numeroControlePNCP: String(row.numero_controle_pncp ?? ''),
+      dataPublicacaoPncp: String(row.data_publicacao_pncp ?? ''),
+      objetoContratacao: String(row.objeto_contratacao ?? row.objeto_compra ?? ''),
+      valorTotalEstimado: Number(row.valor_total_estimado ?? 0),
+      orgaoEntidade: {
+        razaoSocial: String(row.orgao_razao_social ?? ''),
+        cnpj: String(row.orgao_cnpj ?? ''),
+      },
+      unidadeOrgao: {
+        nomeUnidade: String(row.unidade_nome_unidade ?? ''),
+        municipioNome: String(row.municipio_nome ?? ''),
+        ufSigla: String(row.uf_sigla ?? ''),
+        codigoMunicipioIbge: String(row.codigo_municipio_ibge ?? ''),
+      },
+    };
+  }
+
   const cityQuery = createQuery(() => ({
     queryKey: QUERY_KEYS.municipio(ibge),
-    queryFn: async () => {
+    queryFn: async (): Promise<CityView | null> => {
       if (!ibge) return null;
       const url = `https://pncp.gov.br/api/consulta/v1/contratacoes/publicacao?codigoMunicipioIbge=${ibge}&tamanhoPagina=10`;
-      const res = await fetch(url);
-      if (!res.ok) throw new Error("Município não localizado ou sem publicações no PNCP.");
-      const json = await res.json();
-      const contracts = json.data || [];
-      const cityName = contracts[0]?.municipio?.nome || "Município";
-      const uf = contracts[0]?.municipio?.uf || "";
-      return { name: cityName, uf, ibge, contracts };
+      try {
+        const res = await fetch(url);
+        if (!res.ok) throw new Error("Município não localizado ou sem publicações no PNCP.");
+        const json = await res.json();
+        const contracts = (json.data || []) as PNCPContract[];
+        const cityName = contracts[0]?.municipio?.nomeMunicipio || contracts[0]?.unidadeOrgao?.municipioNome || "Município";
+        const uf = contracts[0]?.unidadeOrgao?.ufSigla || "";
+        return { name: cityName, uf, ibge, contracts };
+      } catch {
+        const archived = await queryParquetFallback<Record<string, unknown>>(
+          'codigo_municipio_ibge',
+          ibge,
+          10,
+        );
+        if (!archived) {
+          throw new Error(
+            "PNCP indisponível e arquivo histórico sem registro para este identificador.",
+          );
+        }
+        const contracts = archived.rows.map(archivedRowToContract);
+        const first = archived.rows[0] as Record<string, unknown> | undefined;
+        const cityName = String(first?.municipio_nome ?? 'Município');
+        const uf = String(first?.uf_sigla ?? '');
+        return {
+          name: cityName,
+          uf,
+          ibge,
+          contracts,
+          archived: { dataParticao: archived.dataParticao },
+        };
+      }
     },
     enabled: !!ibge,
   }));
@@ -59,12 +112,19 @@
       </div>
     </div>
   {:else if data}
+    {#if data.archived}
+      <AlertBanner
+        title="Dados arquivados"
+        message={`PNCP indisponível — exibindo dados arquivados (última consolidação: ${data.archived.dataParticao ?? 'desconhecida'}).`}
+        level="info"
+      />
+    {/if}
     <header class="hub-header">
       <span class="type-badge">🏙️ MUNICÍPIO</span>
       <h1>{data.name} / {data.uf}</h1>
       <div class="meta-row">
         <span>Cód. IBGE: {data.ibge}</span>
-        <span>Fonte: PNCP V1</span>
+        <span>Fonte: {data.archived ? 'Arquivo Parquet (IA)' : 'PNCP V1'}</span>
       </div>
     </header>
 

--- a/web/src/components/ContractDetailView.svelte
+++ b/web/src/components/ContractDetailView.svelte
@@ -51,7 +51,7 @@
     queryKey: QUERY_KEYS.contratacao(id),
     queryFn: async (): Promise<ContractView | null> => {
       if (!id) return null;
-      const parts = id.split("-");
+      const parts = id.split(/[-/]/);
       if (parts.length < 4) throw new Error("ID de contrato inválido. Formato esperado: CNPJ-ANO-SEQ-TIPO.");
       const cnpj = parts[0];
       const ano = parts[1];

--- a/web/src/components/ContractDetailView.svelte
+++ b/web/src/components/ContractDetailView.svelte
@@ -70,6 +70,7 @@
         if (!archived || archived.rows.length === 0) {
           throw new Error(
             "PNCP indisponível e arquivo histórico sem registro para este identificador.",
+            { cause: pncpErr },
           );
         }
         const view = archivedRowToContract(archived.rows[0], id);

--- a/web/src/components/ContractDetailView.svelte
+++ b/web/src/components/ContractDetailView.svelte
@@ -26,23 +26,20 @@
     return {
       numeroControlePNCP: String(row.numero_controle_pncp ?? id),
       dataPublicacaoPncp: String(row.data_publicacao_pncp ?? ''),
-      objetoContratacao: String(row.objeto_contratacao ?? row.objeto_compra ?? ''),
-      valorTotalEstimado: Number(row.valor_total_estimado ?? 0),
-      valorTotalHomologado:
-        row.valor_total_homologado != null ? Number(row.valor_total_homologado) : undefined,
+      objetoContratacao: String(row.objeto_contrato ?? ''),
+      valorTotalEstimado: Number(row.valor_global ?? row.valor_inicial ?? 0),
       modalidadeNome: row.modalidade_nome ? String(row.modalidade_nome) : undefined,
-      situacaoNome: row.situacao_nome ? String(row.situacao_nome) : undefined,
+      linkSistemaOrigem: row.link_sistema_origem ? String(row.link_sistema_origem) : undefined,
+      usuarioNome: row.usuario_nome ? String(row.usuario_nome) : undefined,
       orgaoEntidade: {
-        razaoSocial: String(row.orgao_razao_social ?? ''),
-        cnpj: String(row.orgao_cnpj ?? ''),
+        razaoSocial: String(row.razao_social_orgao ?? ''),
+        cnpj: String(row.cnpj_orgao ?? ''),
       },
       unidadeOrgao: {
-        nomeUnidade: String(row.unidade_nome_unidade ?? ''),
+        nomeUnidade: String(row.nome_unidade ?? ''),
         municipioNome: row.municipio_nome ? String(row.municipio_nome) : undefined,
         ufSigla: row.uf_sigla ? String(row.uf_sigla) : undefined,
-        codigoMunicipioIbge: row.codigo_municipio_ibge
-          ? String(row.codigo_municipio_ibge)
-          : undefined,
+        codigoMunicipioIbge: row.codigo_ibge ? String(row.codigo_ibge) : undefined,
       },
     };
   }

--- a/web/src/components/ContractDetailView.svelte
+++ b/web/src/components/ContractDetailView.svelte
@@ -37,6 +37,17 @@
   const data = $derived(contractQuery.data);
   const loading = $derived(contractQuery.isFetching);
   const error = $derived(contractQuery.error instanceof Error ? contractQuery.error : null);
+
+  function formatBRL(v: number | null | undefined): string {
+    if (v == null) return '—';
+    return v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+  }
+
+  function formatDate(iso: string | null | undefined): string {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    return isNaN(d.getTime()) ? '—' : d.toLocaleDateString('pt-BR');
+  }
 </script>
 
 <div class="contract-view container">
@@ -47,6 +58,8 @@
       <div class="skeleton skeleton-title"></div>
       <div class="skeleton skeleton-meta"></div>
       <div class="skeleton-grid">
+        <div class="skeleton skeleton-card"></div>
+        <div class="skeleton skeleton-card"></div>
         <div class="skeleton skeleton-card"></div>
         <div class="skeleton skeleton-card"></div>
       </div>
@@ -63,28 +76,107 @@
       <span class="type-badge">📄 CONTRATAÇÃO PÚBLICA</span>
       <h1>{data.objetoContratacao}</h1>
       <div class="meta-row">
-        <span class="meta-item">ID: {id}</span>
-        <span class="meta-item">📅 {new Date(data.dataPublicacaoPncp).toLocaleDateString('pt-BR')}</span>
+        <span class="meta-item">ID: {data.numeroControlePNCP || id}</span>
+        <span class="meta-item">📅 {formatDate(data.dataPublicacaoPncp)}</span>
       </div>
     </header>
 
     <div class="grid-details">
       <section class="card">
-        <h3>Resumo Executivo</h3>
+        <h3>Detalhes da Contratação</h3>
         <dl class="data-list">
-          <div role="listitem"><dt>Modalidade</dt><dd>{data.modalidadeNome || 'Não informada'}</dd></div>
-          <div role="listitem"><dt>Situação</dt><dd>{data.situacaoNome || 'Desconhecida'}</dd></div>
-          <div role="listitem"><dt>CNPJ Comprador</dt><dd>{data.orgaoEntidade?.cnpj}</dd></div>
+          <div role="listitem"><dt>Objeto</dt><dd>{data.objetoContratacao || '—'}</dd></div>
+          <div role="listitem"><dt>Nº Controle PNCP</dt><dd>{data.numeroControlePNCP || '—'}</dd></div>
+          <div role="listitem"><dt>Modalidade</dt><dd>{data.modalidadeNome || '—'}</dd></div>
+          <div role="listitem"><dt>Situação</dt><dd>{data.situacaoNome || '—'}</dd></div>
+          <div role="listitem"><dt>Publicação</dt><dd>{formatDate(data.dataPublicacaoPncp)}</dd></div>
+          <div role="listitem"><dt>Abertura de Propostas</dt><dd>{formatDate(data.dataAberturaProposta)}</dd></div>
+          <div role="listitem"><dt>Encerramento de Propostas</dt><dd>{formatDate(data.dataEncerramentoProposta)}</dd></div>
         </dl>
       </section>
 
       <section class="card">
-        <h3>Itens da Licitação</h3>
-        <ul class="item-list">
-          {#each data.itens || [] as item (item.sequencialItem)}
-            <li>{item.descricao}</li>
-          {/each}
-        </ul>
+        <h3>Órgão Responsável</h3>
+        <dl class="data-list">
+          <div role="listitem">
+            <dt>Razão Social</dt>
+            <dd>
+              {#if data.orgaoEntidade?.cnpj}
+                <a href={`/baliza/orgao?cnpj=${data.orgaoEntidade.cnpj}`} class="inline-link">
+                  {data.orgaoEntidade.razaoSocial || '—'}
+                </a>
+              {:else}
+                {data.orgaoEntidade?.razaoSocial || '—'}
+              {/if}
+            </dd>
+          </div>
+          <div role="listitem"><dt>CNPJ</dt><dd>{data.orgaoEntidade?.cnpj || '—'}</dd></div>
+          <div role="listitem"><dt>Unidade</dt><dd>{data.unidadeOrgao?.nomeUnidade || '—'}</dd></div>
+          <div role="listitem">
+            <dt>Município</dt>
+            <dd>
+              {#if data.unidadeOrgao?.codigoMunicipioIbge}
+                <a href={`/baliza/municipio?ibge=${data.unidadeOrgao.codigoMunicipioIbge}`} class="inline-link">
+                  {data.unidadeOrgao?.municipioNome || '—'}{data.unidadeOrgao?.ufSigla ? ` / ${data.unidadeOrgao.ufSigla}` : ''}
+                </a>
+              {:else}
+                {data.unidadeOrgao?.municipioNome || '—'}{data.unidadeOrgao?.ufSigla ? ` / ${data.unidadeOrgao.ufSigla}` : ''}
+              {/if}
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="card">
+        <h3>Valores</h3>
+        <dl class="data-list">
+          <div role="listitem"><dt>Valor Estimado</dt><dd>{formatBRL(data.valorTotalEstimado)}</dd></div>
+          {#if data.valorTotalHomologado != null}
+            <div role="listitem"><dt>Valor Homologado</dt><dd>{formatBRL(data.valorTotalHomologado)}</dd></div>
+          {/if}
+        </dl>
+      </section>
+
+      <section class="card">
+        <h3>Itens</h3>
+        {#if data.itens && data.itens.length > 0}
+          <ul class="item-list">
+            {#each data.itens as item (item.sequencialItem)}
+              <li class="item-row">
+                <div class="item-header">
+                  <span class="item-seq">#{item.sequencialItem}</span>
+                  <span class="item-desc">{item.descricao}</span>
+                </div>
+                <div class="item-meta">
+                  <span>Qtd: {item.quantidade ?? '—'} {item.unidadeMedida ?? ''}</span>
+                  <span class="item-valor">Unit.: {formatBRL(item.valorUnitarioEstimado)}</span>
+                </div>
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="muted">Sem itens publicados para esta contratação.</p>
+        {/if}
+      </section>
+
+      <section class="card meta-card">
+        <h3>Fontes e Metadados</h3>
+        <dl class="data-list">
+          <div role="listitem"><dt>Modo de Disputa</dt><dd>{data.modoDisputaNome || '—'}</dd></div>
+          <div role="listitem"><dt>Publicado por</dt><dd>{data.usuarioNome || '—'}</dd></div>
+          <div role="listitem">
+            <dt>Sistema de Origem</dt>
+            <dd>
+              {#if data.linkSistemaOrigem}
+                <a href={data.linkSistemaOrigem} target="_blank" rel="noopener noreferrer" class="inline-link">
+                  Abrir sistema externo ↗
+                </a>
+              {:else}
+                —
+              {/if}
+            </dd>
+          </div>
+        </dl>
       </section>
     </div>
   {/if}
@@ -107,14 +199,34 @@
   h1 { font-size: var(--font-size-xl); margin-top: var(--space-sm); line-height: 1.3; }
   .meta-row { display: flex; gap: var(--space-md); color: var(--color-secondary); font-size: var(--font-size-sm); margin-top: 8px; }
 
-  .grid-details { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: var(--space-lg); }
+  .grid-details { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: var(--space-lg); }
   .card { background: var(--color-base-100); border: 1px solid var(--color-base-300); padding: var(--space-md); border-radius: var(--radius-sm); }
   .card h3 { margin-top: 0; font-size: var(--font-size-lg); border-bottom: 1px solid var(--color-base-200); padding-bottom: 8px; margin-bottom: var(--space-md); }
 
-  .data-list div { display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid var(--color-base-200); }
-  .data-list dt { font-weight: 700; color: var(--color-secondary); font-size: var(--font-size-sm); }
-  .data-list dd { font-family: var(--font-mono); font-size: var(--font-size-sm); color: var(--color-primary); }
+  .meta-card { grid-column: 1 / -1; }
 
-  .item-list { list-style: none; padding: 0; }
-  .item-list li { padding: 8px 0; border-bottom: 1px solid var(--color-base-200); font-size: var(--font-size-sm); }
+  .data-list div { display: flex; justify-content: space-between; gap: var(--space-sm); padding: 8px 0; border-bottom: 1px solid var(--color-base-200); }
+  .data-list dt { font-weight: 700; color: var(--color-secondary); font-size: var(--font-size-sm); flex-shrink: 0; }
+  .data-list dd {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+    color: var(--color-primary);
+    text-align: right;
+    margin: 0;
+    max-width: 65%;
+    overflow-wrap: anywhere;
+  }
+
+  .inline-link { color: var(--color-primary); text-decoration: underline; }
+  .inline-link:hover { text-decoration: none; }
+
+  .item-list { list-style: none; padding: 0; margin: 0; display: grid; gap: var(--space-sm); }
+  .item-row { padding: 8px 0; border-bottom: 1px solid var(--color-base-200); }
+  .item-header { display: flex; gap: var(--space-sm); align-items: baseline; }
+  .item-seq { font-family: var(--font-mono); color: var(--color-secondary); font-size: var(--font-size-xs); }
+  .item-desc { font-size: var(--font-size-sm); }
+  .item-meta { display: flex; justify-content: space-between; margin-top: 4px; font-family: var(--font-mono); font-size: var(--font-size-xs); color: var(--color-secondary); }
+  .item-valor { color: var(--color-primary); font-weight: 700; }
+
+  .muted { color: var(--color-secondary); font-size: var(--font-size-sm); font-style: italic; margin: 0; }
 </style>

--- a/web/src/components/ContractDetailView.svelte
+++ b/web/src/components/ContractDetailView.svelte
@@ -54,8 +54,8 @@
       const parts = id.split(/[-/]/);
       if (parts.length < 4) throw new Error("ID de contrato inválido. Formato esperado: CNPJ-ANO-SEQ-TIPO.");
       const cnpj = parts[0];
-      const ano = parts[1];
       const sequencial = parts[2];
+      const ano = parts[3];
       const url = `https://pncp.gov.br/api/consulta/v1/orgaos/${cnpj}/contratacoes/${ano}/${sequencial}`;
       try {
         const res = await fetch(url);

--- a/web/src/components/ContractDetailView.svelte
+++ b/web/src/components/ContractDetailView.svelte
@@ -3,6 +3,7 @@
   import { getQueryClient } from '../lib/queryClient';
   import { QUERY_KEYS } from '../lib/queryKeys';
   import type { PNCPContract } from '../lib/types';
+  import { queryParquetFallback } from '../lib/parquetFallback';
   import EntityNotFound from './EntityNotFound.svelte';
   import AlertBanner from './AlertBanner.svelte';
 
@@ -17,9 +18,38 @@
         : ''),
   );
 
+  interface ContractView extends PNCPContract {
+    archived?: { dataParticao: string | null };
+  }
+
+  function archivedRowToContract(row: Record<string, unknown>, id: string): ContractView {
+    return {
+      numeroControlePNCP: String(row.numero_controle_pncp ?? id),
+      dataPublicacaoPncp: String(row.data_publicacao_pncp ?? ''),
+      objetoContratacao: String(row.objeto_contratacao ?? row.objeto_compra ?? ''),
+      valorTotalEstimado: Number(row.valor_total_estimado ?? 0),
+      valorTotalHomologado:
+        row.valor_total_homologado != null ? Number(row.valor_total_homologado) : undefined,
+      modalidadeNome: row.modalidade_nome ? String(row.modalidade_nome) : undefined,
+      situacaoNome: row.situacao_nome ? String(row.situacao_nome) : undefined,
+      orgaoEntidade: {
+        razaoSocial: String(row.orgao_razao_social ?? ''),
+        cnpj: String(row.orgao_cnpj ?? ''),
+      },
+      unidadeOrgao: {
+        nomeUnidade: String(row.unidade_nome_unidade ?? ''),
+        municipioNome: row.municipio_nome ? String(row.municipio_nome) : undefined,
+        ufSigla: row.uf_sigla ? String(row.uf_sigla) : undefined,
+        codigoMunicipioIbge: row.codigo_municipio_ibge
+          ? String(row.codigo_municipio_ibge)
+          : undefined,
+      },
+    };
+  }
+
   const contractQuery = createQuery(() => ({
     queryKey: QUERY_KEYS.contratacao(id),
-    queryFn: async () => {
+    queryFn: async (): Promise<ContractView | null> => {
       if (!id) return null;
       const parts = id.split("-");
       if (parts.length < 4) throw new Error("ID de contrato inválido. Formato esperado: CNPJ-ANO-SEQ-TIPO.");
@@ -27,9 +57,25 @@
       const ano = parts[1];
       const sequencial = parts[2];
       const url = `https://pncp.gov.br/api/consulta/v1/orgaos/${cnpj}/contratacoes/${ano}/${sequencial}`;
-      const res = await fetch(url);
-      if (!res.ok) throw new Error("Contratação não localizada no PNCP.");
-      return (await res.json()) as PNCPContract;
+      try {
+        const res = await fetch(url);
+        if (!res.ok) throw new Error("Contratação não localizada no PNCP.");
+        return (await res.json()) as ContractView;
+      } catch (pncpErr) {
+        const archived = await queryParquetFallback<Record<string, unknown>>(
+          'numero_controle_pncp',
+          id,
+          1,
+        );
+        if (!archived || archived.rows.length === 0) {
+          throw new Error(
+            "PNCP indisponível e arquivo histórico sem registro para este identificador.",
+          );
+        }
+        const view = archivedRowToContract(archived.rows[0], id);
+        view.archived = { dataParticao: archived.dataParticao };
+        return view;
+      }
     },
     enabled: !!id,
   }));
@@ -72,6 +118,13 @@
       </div>
     </div>
   {:else if data}
+    {#if data.archived}
+      <AlertBanner
+        title="Dados arquivados"
+        message={`PNCP indisponível — exibindo dados arquivados (última consolidação: ${data.archived.dataParticao ?? 'desconhecida'}).`}
+        level="info"
+      />
+    {/if}
     <header class="hub-header">
       <span class="type-badge">📄 CONTRATAÇÃO PÚBLICA</span>
       <h1>{data.objetoContratacao}</h1>

--- a/web/src/components/SearchHero.svelte
+++ b/web/src/components/SearchHero.svelte
@@ -1,21 +1,129 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import { PROJECT_MISSION, SEARCH_HINTS } from '../lib/homepage-content';
   import EmptyState from './EmptyState.svelte';
+  import AlertBanner from './AlertBanner.svelte';
+
+  // PNCP's public consulta API (Swagger: https://pncp.gov.br/api/consulta/swagger-ui/index.html)
+  // has no free-text parameter for /v1/contratacoes/publicacao. The portal's user-facing
+  // search is backed by /api/search which does support keyword queries, so we use it here.
+  // Endpoint: https://pncp.gov.br/api/search?q=<query>&tipos_documento=edital&pagina=1
+  // Response envelope: { items: [...], total: number }
+  const SEARCH_ENDPOINT = 'https://pncp.gov.br/api/search';
+  const DEBOUNCE_MS = 300;
+
+  interface SearchItem {
+    numero_controle_pncp?: string;
+    title?: string;
+    description?: string;
+    orgao_nome?: string;
+    data_publicacao_pncp?: string;
+    valor_global?: number | null;
+  }
 
   let query = $state('');
-  let loading = $state(false);
-
   const cleanQuery = $derived(query.trim());
-  const isCnpj    = $derived(/^\d{14}$/.test(cleanQuery.replace(/\D/g, '')));
-  const isIbge    = $derived(/^\d{7}$/.test(cleanQuery));
-  const isPncpId  = $derived(/\d{14}[-/]\d{1}[-/]\d{6}[-/]\d{4}/.test(cleanQuery));
-  const hasPattern = $derived(isCnpj || isIbge || isPncpId);
-  const showEmpty  = $derived(cleanQuery.length >= 3 && !loading && !hasPattern);
+  const digitsOnly = $derived(cleanQuery.replace(/\D/g, ''));
+  const isCnpj   = $derived(/^\d{14}$/.test(digitsOnly) && /^\d{14}$/.test(cleanQuery));
+  const isIbge   = $derived(/^\d{7}$/.test(cleanQuery));
+  const isPncpId = $derived(/^\d{14}-\d+-\d{6}-\d+$/.test(cleanQuery));
+  const isPncpIdLoose = $derived(/\d{14}[-/]\d+[-/]\d{6}[-/]\d+/.test(cleanQuery));
+  const hasPattern = $derived(isCnpj || isIbge || isPncpIdLoose);
 
-  function handleSearch() {
-    if (cleanQuery.length < 3) return;
-    loading = true;
-    setTimeout(() => { loading = false; }, 200);
+  function navigateFor(value: string): string | null {
+    if (/^\d{14}$/.test(value)) return `/baliza/orgao?cnpj=${value}`;
+    if (/^\d{7}$/.test(value))  return `/baliza/municipio?ibge=${value}`;
+    if (/^\d{14}-\d+-\d{6}-\d+$/.test(value)) return `/baliza/contratacao?id=${value}`;
+    return null;
+  }
+
+  let results = $state<SearchItem[]>([]);
+  let searching = $state(false);
+  let searchError = $state<string | null>(null);
+  let didSearch = $state(false);
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let searchToken = 0;
+
+  function truncate(s: string, n: number) {
+    if (!s) return '';
+    return s.length > n ? s.slice(0, n - 1) + '…' : s;
+  }
+
+  function formatBRL(v: number | null | undefined) {
+    if (v == null) return '—';
+    return v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+  }
+
+  function formatDate(iso: string | undefined) {
+    if (!iso) return '';
+    const d = new Date(iso);
+    return isNaN(d.getTime()) ? '' : d.toLocaleDateString('pt-BR');
+  }
+
+  async function runSearch(term: string) {
+    const token = ++searchToken;
+    searching = true;
+    searchError = null;
+    try {
+      const url = `${SEARCH_ENDPOINT}?q=${encodeURIComponent(term)}&tipos_documento=edital&pagina=1`;
+      const res = await fetch(url);
+      if (!res.ok) throw new Error('Falha ao consultar o PNCP. Tente novamente em instantes.');
+      const json = (await res.json()) as { items?: SearchItem[] };
+      if (token !== searchToken) return;
+      results = (json.items || []).slice(0, 10);
+      didSearch = true;
+    } catch (err) {
+      if (token !== searchToken) return;
+      results = [];
+      didSearch = true;
+      searchError = err instanceof Error ? err.message : 'Erro na busca PNCP.';
+    } finally {
+      if (token === searchToken) searching = false;
+    }
+  }
+
+  function isShapeMatch(term: string) {
+    return (
+      /^\d{14}$/.test(term) ||
+      /^\d{7}$/.test(term) ||
+      /\d{14}[-/]\d+[-/]\d{6}[-/]\d+/.test(term)
+    );
+  }
+
+  function scheduleSearch(term: string) {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    if (term.length < 3 || isShapeMatch(term)) {
+      results = [];
+      searchError = null;
+      didSearch = false;
+      searching = false;
+      return;
+    }
+    debounceTimer = setTimeout(() => runSearch(term), DEBOUNCE_MS);
+  }
+
+  onDestroy(() => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    searchToken++;
+  });
+
+  function handleInput(e: Event) {
+    const term = (e.target as HTMLInputElement).value.trim();
+    query = (e.target as HTMLInputElement).value;
+    scheduleSearch(term);
+  }
+
+  function handleSubmit(e: Event) {
+    e.preventDefault();
+    const target = navigateFor(cleanQuery);
+    if (target && typeof window !== 'undefined') {
+      window.location.assign(target);
+      return;
+    }
+    if (cleanQuery.length >= 3 && !hasPattern) {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      runSearch(cleanQuery);
+    }
   }
 </script>
 
@@ -24,7 +132,7 @@
     <h1 class="hero-title">{PROJECT_MISSION.title}</h1>
     <p class="hero-tagline">{PROJECT_MISSION.tagline}</p>
 
-    <div class="search-box" class:detected={hasPattern}>
+    <form class="search-form search-box" class:detected={hasPattern} onsubmit={handleSubmit}>
       <div class="input-wrapper">
         <label class="input-label" for="search-input">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="search-icon" aria-hidden="true">
@@ -35,23 +143,23 @@
             type="text"
             bind:value={query}
             placeholder="CNPJ, código IBGE, ID PNCP ou objeto..."
-            oninput={handleSearch}
+            oninput={handleInput}
             autocomplete="off"
             spellcheck={false}
             aria-label="Buscar contratos públicos"
           />
           {#if query}
-            <button type="button" class="clear-btn" onclick={() => (query = '')} aria-label="Limpar busca">×</button>
+            <button type="button" class="clear-btn" onclick={() => { query = ''; scheduleSearch(''); }} aria-label="Limpar busca">×</button>
           {/if}
         </label>
 
-        {#if loading}
+        {#if searching}
           <div class="valid-indicator cg-pulse" aria-hidden="true">⏳</div>
         {:else if hasPattern}
           <div class="valid-indicator" aria-hidden="true">✅</div>
         {/if}
 
-        <button class="search-btn btn btn-primary" disabled={loading}>Buscar</button>
+        <button type="submit" class="search-btn btn btn-primary" disabled={searching}>Buscar</button>
       </div>
 
       {#if hasPattern}
@@ -65,30 +173,53 @@
             <a href={`/baliza/municipio?ibge=${cleanQuery}`} class="jump-link">
               Explorar Município <span class="badge badge-sm badge-info">{cleanQuery}</span>
             </a>
-          {:else if isPncpId}
+          {:else if isPncpIdLoose}
             <a href={`/baliza/contratacao?id=${cleanQuery}`} class="jump-link">
               Ver Contratação <span class="badge badge-sm badge-info">#{cleanQuery}</span>
             </a>
           {/if}
         </div>
-      {:else if showEmpty}
-        <div>
+      {:else if cleanQuery.length >= 3}
+        {#if searching}
+          <ul class="results-list skeleton-results" aria-busy="true" aria-label="Carregando resultados">
+            {#each [1, 2, 3] as _, i (i)}
+              <li class="skeleton skeleton-row"></li>
+            {/each}
+          </ul>
+        {:else if searchError}
+          <AlertBanner title="Busca PNCP indisponível" message={searchError} level="error" />
+        {:else if didSearch && results.length === 0}
           <EmptyState
-            title="Nenhum padrão detectado"
-            message="Use um CNPJ (14 dígitos), código IBGE (7 dígitos) ou identificador PNCP para ir direto ao resultado."
+            title="Nenhum resultado"
+            message="A busca PNCP não encontrou contratações para este termo."
           />
-        </div>
+        {:else if results.length > 0}
+          <ul class="results-list" role="listbox" aria-label="Resultados da busca PNCP">
+            {#each results as item (item.numero_controle_pncp)}
+              <li role="option" aria-selected="false">
+                <a href={`/baliza/contratacao?id=${item.numero_controle_pncp}`} class="result-link">
+                  <div class="result-objeto">{truncate(item.description || item.title || '', 120)}</div>
+                  <div class="result-meta">
+                    <span class="result-orgao">{item.orgao_nome || ''}</span>
+                    <span class="result-date">{formatDate(item.data_publicacao_pncp)}</span>
+                    <span class="result-valor">{formatBRL(item.valor_global)}</span>
+                  </div>
+                </a>
+              </li>
+            {/each}
+          </ul>
+        {/if}
       {/if}
 
       <div class="hints" role="status" aria-live="polite">
         <span class="hints-label">Sugestões:</span>
         {#each SEARCH_HINTS as hint (hint)}
-          <button class="hint-chip" onclick={() => (query = hint)}>
+          <button type="button" class="hint-chip" onclick={() => { query = hint; scheduleSearch(hint); }}>
             {hint}
           </button>
         {/each}
       </div>
-    </div>
+    </form>
   </div>
 </section>
 
@@ -127,6 +258,8 @@
     border-radius: var(--radius-box);
     box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.3);
   }
+
+  .search-form { display: block; }
 
   .input-wrapper {
     display: flex;
@@ -229,6 +362,47 @@
   }
 
   .jump-link:hover { text-decoration: underline; }
+
+  .results-list {
+    list-style: none;
+    padding: 0;
+    margin: var(--space-md) 0 0;
+    display: grid;
+    gap: var(--space-xs);
+    text-align: left;
+  }
+
+  .result-link {
+    display: block;
+    padding: var(--space-sm);
+    background: var(--color-base-200);
+    border: 1px solid var(--color-base-300);
+    border-radius: var(--radius-sm);
+    color: inherit;
+    text-decoration: none;
+    transition: border-color var(--transition-base);
+  }
+
+  .result-link:hover { border-color: var(--color-primary); }
+
+  .result-objeto {
+    font-size: var(--font-size-sm);
+    color: var(--color-base-content);
+    margin-bottom: 4px;
+  }
+
+  .result-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    font-size: var(--font-size-xs);
+    font-family: var(--font-mono);
+    color: var(--color-secondary);
+  }
+
+  .result-valor { color: var(--color-primary); font-weight: 700; }
+
+  .skeleton-row { height: 3.5rem; border-radius: var(--radius-sm); }
 
   .hints {
     margin-top: var(--space-sm);

--- a/web/src/components/SearchHero.svelte
+++ b/web/src/components/SearchHero.svelte
@@ -26,14 +26,15 @@
   const digitsOnly = $derived(cleanQuery.replace(/\D/g, ''));
   const isCnpj   = $derived(/^\d{14}$/.test(digitsOnly) && /^\d{14}$/.test(cleanQuery));
   const isIbge   = $derived(/^\d{7}$/.test(cleanQuery));
-  const isPncpId = $derived(/^\d{14}-\d+-\d{6}-\d+$/.test(cleanQuery));
   const isPncpIdLoose = $derived(/\d{14}[-/]\d+[-/]\d{6}[-/]\d+/.test(cleanQuery));
   const hasPattern = $derived(isCnpj || isIbge || isPncpIdLoose);
 
   function navigateFor(value: string): string | null {
     if (/^\d{14}$/.test(value)) return `/baliza/orgao?cnpj=${value}`;
     if (/^\d{7}$/.test(value))  return `/baliza/municipio?ibge=${value}`;
-    if (/^\d{14}-\d+-\d{6}-\d+$/.test(value)) return `/baliza/contratacao?id=${value}`;
+    // Accept both separators used in the wild — PNCP URLs canonically use
+    // "<cnpj>-<seq>-<ano>/<num>" but the textual ID form uses hyphens only.
+    if (/^\d{14}[-/]\d+[-/]\d{6}[-/]\d+$/.test(value)) return `/baliza/contratacao?id=${value}`;
     return null;
   }
 

--- a/web/src/components/__steps__/agency-detail.steps.ts
+++ b/web/src/components/__steps__/agency-detail.steps.ts
@@ -77,7 +77,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await waitFor(
         () => {
           const alert = screen.getByRole('alert');
-          expect(alert.textContent).toMatch(/Órgão não localizado/);
+          expect(alert.textContent).toMatch(/PNCP indisponível/);
         },
         { timeout: 2000 },
       );

--- a/web/src/components/__steps__/city-detail.steps.ts
+++ b/web/src/components/__steps__/city-detail.steps.ts
@@ -77,7 +77,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await waitFor(
         () => {
           const alert = screen.getByRole('alert');
-          expect(alert.textContent).toMatch(/Município não localizado/);
+          expect(alert.textContent).toMatch(/PNCP indisponível/);
         },
         { timeout: 2000 },
       );

--- a/web/src/components/__steps__/contract-detail.steps.ts
+++ b/web/src/components/__steps__/contract-detail.steps.ts
@@ -118,7 +118,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await waitFor(
         () => {
           const alert = screen.getByRole('alert');
-          expect(alert.textContent).toMatch(/Contratação não localizada/);
+          expect(alert.textContent).toMatch(/PNCP indisponível/);
         },
         { timeout: 2000 },
       );

--- a/web/src/components/__steps__/contract-detail.steps.ts
+++ b/web/src/components/__steps__/contract-detail.steps.ts
@@ -12,6 +12,47 @@ function setUrlQuery(qs: string) {
   window.history.replaceState({}, '', qs ? `/?${qs}` : '/');
 }
 
+const RICH_PAYLOAD = {
+  numeroControlePNCP: '00000000000191-1-000001-1',
+  dataPublicacaoPncp: '2025-01-15T00:00:00',
+  dataAberturaProposta: '2025-01-20T09:00:00',
+  dataEncerramentoProposta: '2025-02-05T17:00:00',
+  objetoContratacao: 'Aquisição de materiais de expediente',
+  valorTotalEstimado: 1500,
+  valorTotalHomologado: 1450,
+  modalidadeNome: 'Pregão Eletrônico',
+  modoDisputaNome: 'Aberto',
+  situacaoNome: 'Publicada',
+  orgaoEntidade: {
+    razaoSocial: 'Prefeitura Municipal',
+    cnpj: '00000000000191',
+  },
+  unidadeOrgao: {
+    nomeUnidade: 'Departamento de Compras',
+    municipioNome: 'São Paulo',
+    ufSigla: 'SP',
+    codigoMunicipioIbge: '3550308',
+  },
+  linkSistemaOrigem: 'https://origem.exemplo.gov.br/compras/1',
+  usuarioNome: 'Sistema PNCP',
+  itens: [
+    {
+      sequencialItem: 1,
+      descricao: 'Caneta esferográfica azul',
+      quantidade: 100,
+      unidadeMedida: 'UN',
+      valorUnitarioEstimado: 2.5,
+    },
+    {
+      sequencialItem: 2,
+      descricao: 'Papel A4 75g',
+      quantidade: 50,
+      unidadeMedida: 'RS',
+      valorUnitarioEstimado: 25,
+    },
+  ],
+};
+
 describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
   BeforeEachScenario(async () => {
     cleanup();
@@ -84,27 +125,14 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
   });
 
-  Scenario('Successful fetch renders both summary cards', ({ Given, And, When, Then }) => {
+  Scenario('Successful fetch renders all detail blocks', ({ Given, And, When, Then }) => {
     Given('the URL has id "00000000000191-1-000001-1"', () => {
       setUrlQuery('id=00000000000191-1-000001-1');
     });
 
     And('the PNCP API returns a valid contract payload', () => {
-      global.fetch = vi.fn().mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            numeroControlePNCP: '00000000000191-1-000001-1',
-            dataPublicacaoPncp: '2025-01-15T00:00:00',
-            objetoContratacao: 'Aquisição de materiais',
-            valorTotalEstimado: 1000,
-            modalidadeNome: 'Pregão',
-            situacaoNome: 'Publicada',
-            orgaoEntidade: { razaoSocial: 'Órgão', cnpj: '00000000000191' },
-            unidadeOrgao: { nomeUnidade: 'Unidade' },
-            itens: [{ sequencialItem: 1, descricao: 'Item 1' }],
-          }),
-          { status: 200 },
-        ),
+      global.fetch = vi.fn().mockImplementation(async () =>
+        new Response(JSON.stringify(RICH_PAYLOAD), { status: 200 }),
       );
     });
 
@@ -113,15 +141,78 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await tick();
     });
 
-    Then('I should see "Resumo Executivo"', async () => {
+    Then('I should see the "Detalhes da Contratação" block', async () => {
       await waitFor(
-        () => expect(screen.getByText('Resumo Executivo')).toBeTruthy(),
+        () => expect(screen.getByText('Detalhes da Contratação')).toBeTruthy(),
         { timeout: 2000 },
       );
     });
 
-    And('I should see "Itens da Licitação"', () => {
-      expect(screen.getByText('Itens da Licitação')).toBeTruthy();
+    And('I should see the "Órgão Responsável" block', () => {
+      expect(screen.getByText('Órgão Responsável')).toBeTruthy();
+    });
+
+    And('I should see the "Valores" block', () => {
+      expect(screen.getByText('Valores')).toBeTruthy();
+    });
+
+    And('I should see the "Itens" block', () => {
+      expect(screen.getByText('Itens')).toBeTruthy();
+    });
+
+    And('I should see the "Fontes e Metadados" block', () => {
+      expect(screen.getByText('Fontes e Metadados')).toBeTruthy();
+    });
+  });
+
+  Scenario('Successful fetch renders formatted currency and links', ({ Given, And, When, Then }) => {
+    Given('the URL has id "00000000000191-1-000001-1"', () => {
+      setUrlQuery('id=00000000000191-1-000001-1');
+    });
+
+    And('the PNCP API returns a valid contract payload', () => {
+      global.fetch = vi.fn().mockImplementation(async () =>
+        new Response(JSON.stringify(RICH_PAYLOAD), { status: 200 }),
+      );
+    });
+
+    When('the contract detail view mounts', async () => {
+      render(ContractDetailView);
+      await tick();
+    });
+
+    Then('I should see the BRL-formatted valor "R$ 1.500,00"', async () => {
+      await waitFor(
+        () => {
+          const matches = Array.from(document.querySelectorAll('dd')).map(
+            (el) => el.textContent?.replace(/\s+/g, ' ').trim() ?? '',
+          );
+          expect(matches.some((t) => /R\$\s*1\.500,00/.test(t))).toBe(true);
+        },
+        { timeout: 2000 },
+      );
+    });
+
+    And('I should see a link to the agency page with cnpj "00000000000191"', () => {
+      const link = document.querySelector(
+        'a[href="/baliza/orgao?cnpj=00000000000191"]',
+      );
+      expect(link).toBeTruthy();
+    });
+
+    And('I should see a link to the municipality page with ibge "3550308"', () => {
+      const link = document.querySelector(
+        'a[href="/baliza/municipio?ibge=3550308"]',
+      );
+      expect(link).toBeTruthy();
+    });
+
+    And('I should see an external link to the origin system', () => {
+      const link = document.querySelector(
+        'a[href="https://origem.exemplo.gov.br/compras/1"]',
+      ) as HTMLAnchorElement | null;
+      expect(link).toBeTruthy();
+      expect(link?.getAttribute('rel')).toMatch(/noopener/);
     });
   });
 });

--- a/web/src/components/__steps__/contract-detail.steps.ts
+++ b/web/src/components/__steps__/contract-detail.steps.ts
@@ -215,4 +215,32 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       expect(link?.getAttribute('rel')).toMatch(/noopener/);
     });
   });
+
+  Scenario('Slash-form id uses the year segment when calling PNCP', ({ Given, And, When, Then }) => {
+    Given('the URL has id "00000000000191-1-000001/2024"', () => {
+      setUrlQuery('id=00000000000191-1-000001%2F2024');
+    });
+
+    And('the PNCP API returns a valid contract payload', () => {
+      global.fetch = vi.fn().mockImplementation(async () =>
+        new Response(JSON.stringify(RICH_PAYLOAD), { status: 200 }),
+      );
+    });
+
+    When('the contract detail view mounts', async () => {
+      render(ContractDetailView);
+      await tick();
+    });
+
+    Then('the PNCP consulta URL should contain "/contratacoes/2024/000001"', async () => {
+      await waitFor(
+        () => {
+          const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+          const calls = fetchMock.mock.calls.map((args: unknown[]) => String(args[0]));
+          expect(calls.some((u: string) => u.includes('/contratacoes/2024/000001'))).toBe(true);
+        },
+        { timeout: 2000 },
+      );
+    });
+  });
 });

--- a/web/src/components/__steps__/detail-view-fallback.steps.ts
+++ b/web/src/components/__steps__/detail-view-fallback.steps.ts
@@ -1,0 +1,275 @@
+import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber';
+import { screen, cleanup, waitFor } from '@testing-library/svelte/pure';
+import { vi, expect } from 'vitest';
+import { tick } from 'svelte';
+import { render } from './shared';
+import { queryParquetFallback } from '../../lib/parquetFallback';
+import AgencyDetailViewRaw from '../AgencyDetailView.svelte';
+import CityDetailViewRaw from '../CityDetailView.svelte';
+import ContractDetailViewRaw from '../ContractDetailView.svelte';
+
+const AgencyDetailView = AgencyDetailViewRaw as unknown as Parameters<typeof render>[0];
+const CityDetailView = CityDetailViewRaw as unknown as Parameters<typeof render>[0];
+const ContractDetailView = ContractDetailViewRaw as unknown as Parameters<typeof render>[0];
+
+const feature = await loadFeature('features/detail-view-fallback.feature');
+
+const fallbackMock = vi.mocked(queryParquetFallback);
+
+function setUrlQuery(qs: string) {
+  window.history.replaceState({}, '', qs ? `/?${qs}` : '/');
+}
+
+const ARCHIVED_AGENCY_ROW = {
+  numero_controle_pncp: '00000000000191-1-000001/2024',
+  objeto_contratacao: 'Aquisição arquivada – órgão',
+  data_publicacao_pncp: '2024-01-15T00:00:00',
+  valor_total_estimado: 9999,
+  orgao_cnpj: '00000000000191',
+  orgao_razao_social: 'Órgão Arquivado',
+};
+
+const ARCHIVED_CITY_ROW = {
+  numero_controle_pncp: '00000000000191-1-000002/2024',
+  objeto_contratacao: 'Aquisição arquivada – município',
+  data_publicacao_pncp: '2024-02-20T00:00:00',
+  valor_total_estimado: 5555,
+  municipio_nome: 'São Paulo',
+  uf_sigla: 'SP',
+  codigo_municipio_ibge: '3550308',
+};
+
+const ARCHIVED_CONTRACT_ROW = {
+  numero_controle_pncp: '00000000000191-1-000001-1',
+  objeto_contratacao: 'Aquisição arquivada – contratação',
+  data_publicacao_pncp: '2024-03-01T00:00:00',
+  valor_total_estimado: 7777,
+  modalidade_nome: 'Pregão Eletrônico',
+  situacao_nome: 'Publicada',
+  orgao_cnpj: '00000000000191',
+  orgao_razao_social: 'Órgão Arquivado',
+};
+
+describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
+  BeforeEachScenario(async () => {
+    cleanup();
+    vi.restoreAllMocks();
+    fallbackMock.mockReset();
+    fallbackMock.mockResolvedValue(null);
+    setUrlQuery('');
+  });
+
+  Scenario('Agency view falls back to Parquet when PNCP fails', ({ Given, And, When, Then }) => {
+    Given('the PNCP API is unavailable for cnpj "00000000000191"', () => {
+      global.fetch = vi.fn().mockResolvedValue(new Response('boom', { status: 503 }));
+    });
+
+    And('the Parquet fallback returns one contract row for cnpj "00000000000191"', () => {
+      fallbackMock.mockResolvedValue({
+        rows: [ARCHIVED_AGENCY_ROW],
+        dataParticao: '2024-12-01',
+      });
+    });
+
+    When('the agency detail view mounts for cnpj "00000000000191"', async () => {
+      setUrlQuery('cnpj=00000000000191');
+      render(AgencyDetailView);
+      await tick();
+    });
+
+    Then('I should see an info banner about PNCP indisponível', async () => {
+      await waitFor(
+        () => {
+          const alert = screen.getByRole('alert');
+          expect(alert.textContent).toMatch(/PNCP indisponível/i);
+        },
+        { timeout: 2000 },
+      );
+    });
+
+    And('I should see the archived contract from the Parquet snapshot', () => {
+      expect(screen.getByText(/Aquisição arquivada – órgão/)).toBeTruthy();
+    });
+  });
+
+  Scenario('Agency view shows combined error when both fail', ({ Given, And, When, Then }) => {
+    Given('the PNCP API is unavailable for cnpj "00000000000191"', () => {
+      global.fetch = vi.fn().mockResolvedValue(new Response('boom', { status: 503 }));
+    });
+
+    And('the Parquet fallback returns no rows for cnpj "00000000000191"', () => {
+      fallbackMock.mockResolvedValue(null);
+    });
+
+    When('the agency detail view mounts for cnpj "00000000000191"', async () => {
+      setUrlQuery('cnpj=00000000000191');
+      render(AgencyDetailView);
+      await tick();
+    });
+
+    Then('I should see an error banner about arquivo histórico', async () => {
+      await waitFor(
+        () => {
+          const alert = screen.getByRole('alert');
+          expect(alert.textContent).toMatch(/arquivo histórico/i);
+        },
+        { timeout: 2000 },
+      );
+    });
+  });
+
+  Scenario('Agency view does not query Parquet when PNCP succeeds', ({ Given, When, Then }) => {
+    Given('the PNCP API returns one contract for cnpj "00000000000191"', () => {
+      global.fetch = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                numeroControlePNCP: '00000000000191-1-000001/2024',
+                dataPublicacaoPncp: '2024-06-01T00:00:00',
+                objetoContratacao: 'Contrato PNCP ao vivo',
+                valorTotalEstimado: 10000,
+                orgaoEntidade: { razaoSocial: 'Órgão Vivo', cnpj: '00000000000191' },
+                unidadeOrgao: { nomeUnidade: 'Unidade' },
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+    });
+
+    When('the agency detail view mounts for cnpj "00000000000191"', async () => {
+      setUrlQuery('cnpj=00000000000191');
+      render(AgencyDetailView);
+      await tick();
+    });
+
+    Then('the Parquet fallback should not be called', async () => {
+      await waitFor(
+        () => expect(screen.getByText(/Contrato PNCP ao vivo/)).toBeTruthy(),
+        { timeout: 2000 },
+      );
+      expect(fallbackMock).not.toHaveBeenCalled();
+    });
+  });
+
+  Scenario('City view falls back to Parquet when PNCP fails', ({ Given, And, When, Then }) => {
+    Given('the PNCP API is unavailable for ibge "3550308"', () => {
+      global.fetch = vi.fn().mockResolvedValue(new Response('boom', { status: 503 }));
+    });
+
+    And('the Parquet fallback returns one contract row for ibge "3550308"', () => {
+      fallbackMock.mockResolvedValue({
+        rows: [ARCHIVED_CITY_ROW],
+        dataParticao: '2024-12-01',
+      });
+    });
+
+    When('the city detail view mounts for ibge "3550308"', async () => {
+      setUrlQuery('ibge=3550308');
+      render(CityDetailView);
+      await tick();
+    });
+
+    Then('I should see an info banner about PNCP indisponível', async () => {
+      await waitFor(
+        () => {
+          const alert = screen.getByRole('alert');
+          expect(alert.textContent).toMatch(/PNCP indisponível/i);
+        },
+        { timeout: 2000 },
+      );
+    });
+
+    And('I should see the archived contract from the Parquet snapshot', () => {
+      expect(screen.getByText(/Aquisição arquivada – município/)).toBeTruthy();
+    });
+  });
+
+  Scenario('City view shows combined error when both fail', ({ Given, And, When, Then }) => {
+    Given('the PNCP API is unavailable for ibge "3550308"', () => {
+      global.fetch = vi.fn().mockResolvedValue(new Response('boom', { status: 503 }));
+    });
+
+    And('the Parquet fallback returns no rows for ibge "3550308"', () => {
+      fallbackMock.mockResolvedValue(null);
+    });
+
+    When('the city detail view mounts for ibge "3550308"', async () => {
+      setUrlQuery('ibge=3550308');
+      render(CityDetailView);
+      await tick();
+    });
+
+    Then('I should see an error banner about arquivo histórico', async () => {
+      await waitFor(
+        () => {
+          const alert = screen.getByRole('alert');
+          expect(alert.textContent).toMatch(/arquivo histórico/i);
+        },
+        { timeout: 2000 },
+      );
+    });
+  });
+
+  Scenario('Contract view falls back to Parquet when PNCP fails', ({ Given, And, When, Then }) => {
+    Given('the PNCP API is unavailable for id "00000000000191-1-000001-1"', () => {
+      global.fetch = vi.fn().mockResolvedValue(new Response('boom', { status: 503 }));
+    });
+
+    And('the Parquet fallback returns one row for id "00000000000191-1-000001-1"', () => {
+      fallbackMock.mockResolvedValue({
+        rows: [ARCHIVED_CONTRACT_ROW],
+        dataParticao: '2024-12-01',
+      });
+    });
+
+    When('the contract detail view mounts for id "00000000000191-1-000001-1"', async () => {
+      setUrlQuery('id=00000000000191-1-000001-1');
+      render(ContractDetailView);
+      await tick();
+    });
+
+    Then('I should see an info banner about PNCP indisponível', async () => {
+      await waitFor(
+        () => {
+          const alert = screen.getByRole('alert');
+          expect(alert.textContent).toMatch(/PNCP indisponível/i);
+        },
+        { timeout: 2000 },
+      );
+    });
+
+    And('I should see the archived contract objeto', () => {
+      const matches = screen.getAllByText(/Aquisição arquivada – contratação/);
+      expect(matches.length).toBeGreaterThan(0);
+    });
+  });
+
+  Scenario('Contract view shows combined error when both fail', ({ Given, And, When, Then }) => {
+    Given('the PNCP API is unavailable for id "00000000000191-1-000001-1"', () => {
+      global.fetch = vi.fn().mockResolvedValue(new Response('boom', { status: 503 }));
+    });
+
+    And('the Parquet fallback returns no rows for id "00000000000191-1-000001-1"', () => {
+      fallbackMock.mockResolvedValue(null);
+    });
+
+    When('the contract detail view mounts for id "00000000000191-1-000001-1"', async () => {
+      setUrlQuery('id=00000000000191-1-000001-1');
+      render(ContractDetailView);
+      await tick();
+    });
+
+    Then('I should see an error banner about arquivo histórico', async () => {
+      await waitFor(
+        () => {
+          const alert = screen.getByRole('alert');
+          expect(alert.textContent).toMatch(/arquivo histórico/i);
+        },
+        { timeout: 2000 },
+      );
+    });
+  });
+});

--- a/web/src/components/__steps__/detail-view-fallback.steps.ts
+++ b/web/src/components/__steps__/detail-view-fallback.steps.ts
@@ -272,4 +272,41 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       );
     });
   });
+
+  Scenario('Contract view accepts slash-separated PNCP IDs and reaches the fallback', ({ Given, And, When, Then }) => {
+    const slashId = '00000000000191-1-000001/2024';
+    const slashRow = { ...ARCHIVED_CONTRACT_ROW, numero_controle_pncp: slashId };
+
+    Given('the PNCP API is unavailable for id "00000000000191-1-000001/2024"', () => {
+      global.fetch = vi.fn().mockResolvedValue(new Response('boom', { status: 503 }));
+    });
+
+    And('the Parquet fallback returns one row for id "00000000000191-1-000001/2024"', () => {
+      fallbackMock.mockResolvedValue({
+        rows: [slashRow],
+        dataParticao: '2024-12-01',
+      });
+    });
+
+    When('the contract detail view mounts for id "00000000000191-1-000001/2024"', async () => {
+      setUrlQuery(`id=${encodeURIComponent(slashId)}`);
+      render(ContractDetailView);
+      await tick();
+    });
+
+    Then('I should see an info banner about PNCP indisponível', async () => {
+      await waitFor(
+        () => {
+          const alert = screen.getByRole('alert');
+          expect(alert.textContent).toMatch(/PNCP indisponível/i);
+        },
+        { timeout: 2000 },
+      );
+    });
+
+    And('I should see the archived contract objeto', () => {
+      const matches = screen.getAllByText(/Aquisição arquivada – contratação/);
+      expect(matches.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/web/src/components/__steps__/detail-view-fallback.steps.ts
+++ b/web/src/components/__steps__/detail-view-fallback.steps.ts
@@ -22,32 +22,31 @@ function setUrlQuery(qs: string) {
 
 const ARCHIVED_AGENCY_ROW = {
   numero_controle_pncp: '00000000000191-1-000001/2024',
-  objeto_contratacao: 'Aquisição arquivada – órgão',
+  objeto_contrato: 'Aquisição arquivada – órgão',
   data_publicacao_pncp: '2024-01-15T00:00:00',
-  valor_total_estimado: 9999,
-  orgao_cnpj: '00000000000191',
-  orgao_razao_social: 'Órgão Arquivado',
+  valor_global: 9999,
+  cnpj_orgao: '00000000000191',
+  razao_social_orgao: 'Órgão Arquivado',
 };
 
 const ARCHIVED_CITY_ROW = {
   numero_controle_pncp: '00000000000191-1-000002/2024',
-  objeto_contratacao: 'Aquisição arquivada – município',
+  objeto_contrato: 'Aquisição arquivada – município',
   data_publicacao_pncp: '2024-02-20T00:00:00',
-  valor_total_estimado: 5555,
+  valor_global: 5555,
   municipio_nome: 'São Paulo',
   uf_sigla: 'SP',
-  codigo_municipio_ibge: '3550308',
+  codigo_ibge: '3550308',
 };
 
 const ARCHIVED_CONTRACT_ROW = {
   numero_controle_pncp: '00000000000191-1-000001-1',
-  objeto_contratacao: 'Aquisição arquivada – contratação',
+  objeto_contrato: 'Aquisição arquivada – contratação',
   data_publicacao_pncp: '2024-03-01T00:00:00',
-  valor_total_estimado: 7777,
+  valor_global: 7777,
   modalidade_nome: 'Pregão Eletrônico',
-  situacao_nome: 'Publicada',
-  orgao_cnpj: '00000000000191',
-  orgao_razao_social: 'Órgão Arquivado',
+  cnpj_orgao: '00000000000191',
+  razao_social_orgao: 'Órgão Arquivado',
 };
 
 describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
@@ -270,6 +269,52 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
         },
         { timeout: 2000 },
       );
+    });
+  });
+
+  Scenario('Agency fallback uses the exported cnpj_orgao column and orders by recency', ({ Given, When, Then }) => {
+    Given('the PNCP API is unavailable for cnpj "00000000000191"', () => {
+      global.fetch = vi.fn().mockResolvedValue(new Response('boom', { status: 503 }));
+    });
+
+    When('the agency detail view mounts for cnpj "00000000000191"', async () => {
+      setUrlQuery('cnpj=00000000000191');
+      render(AgencyDetailView);
+      await tick();
+    });
+
+    Then('the Parquet fallback should be called with column "cnpj_orgao" ordered by "data_publicacao_pncp"', async () => {
+      await waitFor(
+        () => expect(fallbackMock).toHaveBeenCalled(),
+        { timeout: 2000 },
+      );
+      const call = fallbackMock.mock.calls[0];
+      expect(call[0]).toBe('cnpj_orgao');
+      expect(call[1]).toBe('00000000000191');
+      expect(call[3]).toBe('data_publicacao_pncp');
+    });
+  });
+
+  Scenario('City fallback uses the exported codigo_ibge column and orders by recency', ({ Given, When, Then }) => {
+    Given('the PNCP API is unavailable for ibge "3550308"', () => {
+      global.fetch = vi.fn().mockResolvedValue(new Response('boom', { status: 503 }));
+    });
+
+    When('the city detail view mounts for ibge "3550308"', async () => {
+      setUrlQuery('ibge=3550308');
+      render(CityDetailView);
+      await tick();
+    });
+
+    Then('the Parquet fallback should be called with column "codigo_ibge" ordered by "data_publicacao_pncp"', async () => {
+      await waitFor(
+        () => expect(fallbackMock).toHaveBeenCalled(),
+        { timeout: 2000 },
+      );
+      const call = fallbackMock.mock.calls[0];
+      expect(call[0]).toBe('codigo_ibge');
+      expect(call[1]).toBe('3550308');
+      expect(call[3]).toBe('data_publicacao_pncp');
     });
   });
 

--- a/web/src/components/__steps__/search-hero.steps.ts
+++ b/web/src/components/__steps__/search-hero.steps.ts
@@ -1,6 +1,6 @@
 import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber';
 import { screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte/pure';
-import { expect } from 'vitest';
+import { vi, expect } from 'vitest';
 import { tick } from 'svelte';
 import { render } from './shared';
 import SearchHeroRaw from '../SearchHero.svelte';
@@ -15,9 +15,20 @@ async function typeInSearch(value: string) {
   return input;
 }
 
+function stubLocationAssign() {
+  const assign = vi.fn();
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, assign },
+  });
+  return assign;
+}
+
 describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
   BeforeEachScenario(async () => {
     cleanup();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   Scenario('Detect CNPJ pattern and show correct jump link', ({ Given, Then, And }) => {
@@ -108,6 +119,169 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
 
     Then('the input should have an accessible label', () => {
       expect(screen.getByLabelText('Buscar contratos públicos')).toBeTruthy();
+    });
+  });
+
+  Scenario('Submitting a CNPJ navigates to the agency page', ({ Given, When, Then }) => {
+    let assign: ReturnType<typeof vi.fn>;
+
+    Given('the user types "12345678000195" into the search box', async () => {
+      assign = stubLocationAssign();
+      render(SearchHero);
+      await tick();
+      await typeInSearch('12345678000195');
+    });
+
+    When('the user submits the search form', async () => {
+      const form = document.querySelector('form.search-form') as HTMLFormElement;
+      await fireEvent.submit(form);
+      await tick();
+    });
+
+    Then('the browser should navigate to "/baliza/orgao?cnpj=12345678000195"', () => {
+      expect(assign).toHaveBeenCalledWith('/baliza/orgao?cnpj=12345678000195');
+    });
+  });
+
+  Scenario('Submitting an IBGE code navigates to the municipality page', ({ Given, When, Then }) => {
+    let assign: ReturnType<typeof vi.fn>;
+
+    Given('the user types "3550308" into the search box', async () => {
+      assign = stubLocationAssign();
+      render(SearchHero);
+      await tick();
+      await typeInSearch('3550308');
+    });
+
+    When('the user submits the search form', async () => {
+      const form = document.querySelector('form.search-form') as HTMLFormElement;
+      await fireEvent.submit(form);
+      await tick();
+    });
+
+    Then('the browser should navigate to "/baliza/municipio?ibge=3550308"', () => {
+      expect(assign).toHaveBeenCalledWith('/baliza/municipio?ibge=3550308');
+    });
+  });
+
+  Scenario('Submitting a PNCP contract ID navigates to the contract page', ({ Given, When, Then }) => {
+    let assign: ReturnType<typeof vi.fn>;
+
+    Given('the user types "12345678000195-1-000001-1" into the search box', async () => {
+      assign = stubLocationAssign();
+      render(SearchHero);
+      await tick();
+      await typeInSearch('12345678000195-1-000001-1');
+    });
+
+    When('the user submits the search form', async () => {
+      const form = document.querySelector('form.search-form') as HTMLFormElement;
+      await fireEvent.submit(form);
+      await tick();
+    });
+
+    Then('the browser should navigate to "/baliza/contratacao?id=12345678000195-1-000001-1"', () => {
+      expect(assign).toHaveBeenCalledWith('/baliza/contratacao?id=12345678000195-1-000001-1');
+    });
+  });
+
+  Scenario('Free text triggers a PNCP search and renders results listbox', ({ Given, When, Then, And }) => {
+    Given('the PNCP search API returns two results for "hospital"', () => {
+      const payload = {
+        items: [
+          {
+            numero_controle_pncp: '00000000000191-1-000001/2024',
+            title: 'Edital nº 001/2024',
+            description: 'Aquisição de materiais hospitalares para atendimento emergencial',
+            orgao_nome: 'Secretaria Municipal de Saúde',
+            data_publicacao_pncp: '2024-05-01T00:00:00',
+            valor_global: 150000,
+          },
+          {
+            numero_controle_pncp: '00000000000191-1-000002/2024',
+            title: 'Edital nº 002/2024',
+            description: 'Contrato de manutenção de equipamento hospitalar',
+            orgao_nome: 'Fundo de Saúde',
+            data_publicacao_pncp: '2024-04-12T00:00:00',
+            valor_global: 50000,
+          },
+        ],
+        total: 2,
+      };
+      global.fetch = vi
+        .fn()
+        .mockImplementation(async () => new Response(JSON.stringify(payload), { status: 200 }));
+    });
+
+    When('the user types "hospital" into the search box', async () => {
+      render(SearchHero);
+      await tick();
+      await typeInSearch('hospital');
+    });
+
+    Then('I should see a results listbox with at least one link', async () => {
+      await waitFor(
+        () => {
+          const listbox = screen.getByRole('listbox');
+          expect(listbox).toBeTruthy();
+          expect(listbox.querySelectorAll('a').length).toBeGreaterThan(0);
+        },
+        { timeout: 2000 },
+      );
+    });
+
+    And('the first result should link to a contratação page', () => {
+      const firstLink = screen.getByRole('listbox').querySelector('a') as HTMLAnchorElement;
+      expect(firstLink.getAttribute('href')).toMatch(/\/baliza\/contratacao\?id=/);
+    });
+  });
+
+  Scenario('PNCP search failure shows an alert banner', ({ Given, When, Then }) => {
+    Given('the PNCP search API fails for "hospital"', () => {
+      global.fetch = vi
+        .fn()
+        .mockImplementation(async () => new Response('boom', { status: 500 }));
+    });
+
+    When('the user types "hospital" into the search box', async () => {
+      render(SearchHero);
+      await tick();
+      await typeInSearch('hospital');
+    });
+
+    Then('I should see an alert banner about the search error', async () => {
+      await waitFor(
+        () => {
+          const alert = screen.getByRole('alert');
+          expect(alert.textContent).toMatch(/busca|PNCP/i);
+        },
+        { timeout: 2000 },
+      );
+    });
+  });
+
+  Scenario('PNCP search zero results shows an empty state', ({ Given, When, Then }) => {
+    Given('the PNCP search API returns zero results for "xyzneverexists"', () => {
+      global.fetch = vi
+        .fn()
+        .mockImplementation(
+          async () => new Response(JSON.stringify({ items: [], total: 0 }), { status: 200 }),
+        );
+    });
+
+    When('the user types "xyzneverexists" into the search box', async () => {
+      render(SearchHero);
+      await tick();
+      await typeInSearch('xyzneverexists');
+    });
+
+    Then('I should see an empty state for the search', async () => {
+      await waitFor(
+        () => {
+          expect(screen.getByText(/Nenhum resultado/i)).toBeTruthy();
+        },
+        { timeout: 2000 },
+      );
     });
   });
 });

--- a/web/src/components/__steps__/search-hero.steps.ts
+++ b/web/src/components/__steps__/search-hero.steps.ts
@@ -185,6 +185,27 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
   });
 
+  Scenario('Submitting a slash-separated PNCP contract ID also navigates', ({ Given, When, Then }) => {
+    let assign: ReturnType<typeof vi.fn>;
+
+    Given('the user types "12345678000195-1-000001/2024" into the search box', async () => {
+      assign = stubLocationAssign();
+      render(SearchHero);
+      await tick();
+      await typeInSearch('12345678000195-1-000001/2024');
+    });
+
+    When('the user submits the search form', async () => {
+      const form = document.querySelector('form.search-form') as HTMLFormElement;
+      await fireEvent.submit(form);
+      await tick();
+    });
+
+    Then('the browser should navigate to "/baliza/contratacao?id=12345678000195-1-000001/2024"', () => {
+      expect(assign).toHaveBeenCalledWith('/baliza/contratacao?id=12345678000195-1-000001/2024');
+    });
+  });
+
   Scenario('Free text triggers a PNCP search and renders results listbox', ({ Given, When, Then, And }) => {
     Given('the PNCP search API returns two results for "hospital"', () => {
       const payload = {

--- a/web/src/components/__steps__/shared.ts
+++ b/web/src/components/__steps__/shared.ts
@@ -20,8 +20,13 @@ vi.mock('../../lib/duckdb', () => ({
 
 vi.mock('../../lib/ia-manifest', () => ({
   getLatestParquetUrl: vi.fn().mockResolvedValue(null),
+  getLatestParquetInfo: vi.fn().mockResolvedValue(null),
   resetIaManifestCache: vi.fn(),
   IA_MANIFEST_URL: 'https://archive.org/download/baliza-pncp-manifest/manifest.csv',
+}));
+
+vi.mock('../../lib/parquetFallback', () => ({
+  queryParquetFallback: vi.fn().mockResolvedValue(null),
 }));
 
 export function render(

--- a/web/src/lib/ia-manifest.ts
+++ b/web/src/lib/ia-manifest.ts
@@ -9,13 +9,18 @@ interface ManifestRow {
   parquet_url?: string;
 }
 
-let cached: Promise<string | null> | null = null;
+export interface ParquetInfo {
+  url: string;
+  dataParticao: string | null;
+}
+
+let cached: Promise<ParquetInfo | null> | null = null;
 
 export function resetIaManifestCache() {
   cached = null;
 }
 
-export async function getLatestParquetUrl(): Promise<string | null> {
+export async function getLatestParquetInfo(): Promise<ParquetInfo | null> {
   if (cached) return cached;
   cached = (async () => {
     try {
@@ -32,7 +37,10 @@ export async function getLatestParquetUrl(): Promise<string | null> {
       rows.sort((a, b) =>
         (b.data_particao ?? '').localeCompare(a.data_particao ?? ''),
       );
-      return rows[0].parquet_url ?? null;
+      const top = rows[0];
+      return top.parquet_url
+        ? { url: top.parquet_url, dataParticao: top.data_particao ?? null }
+        : null;
     } catch {
       return null;
     }
@@ -40,4 +48,9 @@ export async function getLatestParquetUrl(): Promise<string | null> {
   const result = await cached;
   if (result === null) cached = null;
   return result;
+}
+
+export async function getLatestParquetUrl(): Promise<string | null> {
+  const info = await getLatestParquetInfo();
+  return info?.url ?? null;
 }

--- a/web/src/lib/parquetFallback.ts
+++ b/web/src/lib/parquetFallback.ts
@@ -1,0 +1,41 @@
+import { getDuckDB } from './duckdb';
+import { getLatestParquetInfo } from './ia-manifest';
+
+export interface ParquetFallback<T> {
+  rows: T[];
+  dataParticao: string | null;
+}
+
+// Matches a safe SQL identifier — letters, digits, underscores. Prevents any
+// caller-supplied column name from smuggling SQL via string interpolation.
+const SAFE_IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function escapeSqlLiteral(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+export async function queryParquetFallback<T = Record<string, unknown>>(
+  column: string,
+  value: string,
+  limit = 10,
+): Promise<ParquetFallback<T> | null> {
+  if (!SAFE_IDENT.test(column)) return null;
+  const info = await getLatestParquetInfo();
+  if (!info) return null;
+  const safeUrl = escapeSqlLiteral(info.url);
+  const safeValue = escapeSqlLiteral(value);
+  const safeLimit = Math.max(1, Math.min(200, Math.floor(limit)));
+  const sql = `SELECT * FROM read_parquet('${safeUrl}') WHERE ${column} = '${safeValue}' LIMIT ${safeLimit}`;
+  try {
+    const { conn } = await getDuckDB();
+    const res = await conn.query(sql);
+    const rows = res.toArray().map((r: unknown) => {
+      const anyRow = r as { toJSON?: () => unknown };
+      return (typeof anyRow.toJSON === 'function' ? anyRow.toJSON() : r) as T;
+    });
+    if (rows.length === 0) return null;
+    return { rows, dataParticao: info.dataParticao };
+  } catch {
+    return null;
+  }
+}

--- a/web/src/lib/parquetFallback.ts
+++ b/web/src/lib/parquetFallback.ts
@@ -18,14 +18,17 @@ export async function queryParquetFallback<T = Record<string, unknown>>(
   column: string,
   value: string,
   limit = 10,
+  orderByColumn?: string,
 ): Promise<ParquetFallback<T> | null> {
   if (!SAFE_IDENT.test(column)) return null;
+  if (orderByColumn !== undefined && !SAFE_IDENT.test(orderByColumn)) return null;
   const info = await getLatestParquetInfo();
   if (!info) return null;
   const safeUrl = escapeSqlLiteral(info.url);
   const safeValue = escapeSqlLiteral(value);
   const safeLimit = Math.max(1, Math.min(200, Math.floor(limit)));
-  const sql = `SELECT * FROM read_parquet('${safeUrl}') WHERE ${column} = '${safeValue}' LIMIT ${safeLimit}`;
+  const orderBy = orderByColumn ? ` ORDER BY ${orderByColumn} DESC NULLS LAST` : '';
+  const sql = `SELECT * FROM read_parquet('${safeUrl}') WHERE ${column} = '${safeValue}'${orderBy} LIMIT ${safeLimit}`;
   try {
     const { conn } = await getDuckDB();
     const res = await conn.query(sql);

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -2,27 +2,43 @@
  * Baliza Core Types
  */
 
+export interface PNCPContractItem {
+  sequencialItem: number;
+  descricao: string;
+  quantidade?: number;
+  unidadeMedida?: string;
+  valorUnitarioEstimado?: number;
+}
+
 export interface PNCPContract {
   numeroControlePNCP: string;
   dataPublicacaoPncp: string;
+  dataAberturaProposta?: string;
+  dataEncerramentoProposta?: string;
   objetoContratacao: string;
   valorTotalEstimado: number;
+  valorTotalHomologado?: number;
   orgaoEntidade: {
     razaoSocial: string;
     cnpj: string;
   };
   unidadeOrgao: {
     nomeUnidade: string;
+    municipioNome?: string;
+    ufSigla?: string;
+    codigoMunicipioIbge?: string;
   };
   municipio?: {
     nomeMunicipio: string;
   };
   modalidadeNome?: string;
+  modoDisputaNome?: string;
   situacaoNome?: string;
   anoCompra?: number;
   sequencialCompra?: number;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  itens?: any[]; 
+  linkSistemaOrigem?: string;
+  usuarioNome?: string;
+  itens?: PNCPContractItem[];
 }
 
 export interface PNCPAgency {


### PR DESCRIPTION
## Summary

This PR adds two major features to improve resilience and search capabilities:

1. **Parquet fallback for detail views** — When the PNCP Consulta API is unavailable, Agency, City, and Contract detail views now fall back to querying a Parquet snapshot from the Internet Archive, allowing users to see archived contract data with a clear "PNCP indisponível" banner.

2. **Free-text search in the hero component** — The SearchHero component now supports keyword-based searches via the PNCP Portal search API (`/api/search`), complementing the existing pattern-based navigation (CNPJ, IBGE, PNCP ID). Results are displayed in a listbox with debounced requests and error handling.

## Key Changes

### Detail Views (Agency, City, Contract)
- Added `queryParquetFallback()` utility to query archived Parquet snapshots via DuckDB when PNCP fails
- Implemented fallback logic in query functions: if PNCP fetch fails, attempt Parquet query
- Added `archivedRowToContract()` mappers to transform Parquet row format to `PNCPContract` shape
- Display info banner when data comes from archive; show combined error if both sources fail
- Updated `ContractDetailView` with expanded detail blocks (Detalhes, Órgão, Valores, Itens, Fontes)
- Added formatting helpers for BRL currency and ISO date display

### SearchHero Component
- Converted to form-based submission with proper `<form>` element
- Added free-text search via PNCP Portal search API with debouncing (300ms)
- Implemented results listbox showing up to 10 items with title, description, agency, date, and value
- Added search error handling with AlertBanner display
- Pattern-based navigation (CNPJ/IBGE/PNCP ID) now triggers form submission with `window.location.assign()`
- Maintained existing pattern detection UI (jump links, badges)

### Supporting Infrastructure
- Created `parquetFallback.ts` with SQL injection prevention (safe identifier validation, literal escaping)
- Updated `ia-manifest.ts` to return `ParquetInfo` object (url + dataParticao) instead of just URL
- Extended `PNCPContract` type with optional fields (dates, homologado value, item details)
- Added new `PNCPContractItem` interface for line items

### Tests
- Added comprehensive BDD scenarios for Parquet fallback across all three detail views
- Added scenarios for free-text search, form submission, error states, and empty results
- Updated existing test mocks to support new fallback functions

## Notable Implementation Details

- **SQL Safety**: Column names validated against `/^[A-Za-z_][A-Za-z0-9_]*$/` regex; string literals escaped by doubling single quotes
- **Debouncing**: Free-text search debounced at 300ms to avoid excessive API calls; pattern-based queries bypass debounce
- **Token-based cancellation**: Search requests use incrementing token to discard stale responses
- **Graceful degradation**: If Parquet snapshot unavailable, shows combined error message referencing "arquivo histórico"
- **Accessible markup**: Results listbox uses proper ARIA roles; form submission accessible via Enter key

https://claude.ai/code/session_01YD6Z4HjdD18PAQQJ6YiQHv