### PR TITLE
Enforce canonical PNCP ID format and harden archive fallback

### DIFF
--- a/web/features/agency-detail.feature
+++ b/web/features/agency-detail.feature
@@ -26,6 +26,6 @@ Feature: Agency Detail View
 
   Scenario: Contracts render as links
     Given the URL has cnpj "00000000000191"
-    And the PNCP API returns a contract with id "00000000000191-1-000001-1"
+    And the PNCP API returns a contract with id "00000000000191-1-000001/2024"
     When the agency detail view mounts
     Then I should see a link to that contract

--- a/web/features/archive-fallback.feature
+++ b/web/features/archive-fallback.feature
@@ -1,0 +1,50 @@
+Feature: Archive fallback hardening
+  queryArchivedTable is the primary offline/historical data layer. Every
+  failure mode is reported as a discriminated reason so callers can decide
+  how to present it; limits are clamped and the layer can be preloaded.
+
+  Scenario: Manifest endpoint 404 yields reason "no_manifest"
+    Given the IA manifest endpoint returns 404
+    When queryArchivedTable is called for "contratos" filtered by "cnpj_orgao"
+    Then the result should be a failure with reason "no_manifest"
+
+  Scenario: DuckDB init failure yields reason "duckdb_init_failed"
+    Given the IA manifest resolves to a parquet url
+    And DuckDB initialization throws
+    When queryArchivedTable is called for "contratos" filtered by "cnpj_orgao"
+    Then the result should be a failure with reason "duckdb_init_failed"
+
+  Scenario: SQL returning zero rows yields reason "empty"
+    Given the IA manifest resolves to a parquet url
+    And DuckDB returns no rows
+    When queryArchivedTable is called for "contratos" filtered by "cnpj_orgao"
+    Then the result should be a failure with reason "empty"
+
+  Scenario: SQL thrown error yields reason "sql_error"
+    Given the IA manifest resolves to a parquet url
+    And DuckDB query throws
+    When queryArchivedTable is called for "contratos" filtered by "cnpj_orgao"
+    Then the result should be a failure with reason "sql_error"
+
+  Scenario: Limit above 200 is clamped to 200
+    Given the IA manifest resolves to a parquet url
+    And DuckDB captures the query text and returns one row
+    When queryArchivedTable is called for "contratos" with limit 5000
+    Then the executed SQL should contain "LIMIT 200"
+
+  Scenario: Unknown table is rejected without touching the manifest
+    Given the IA manifest endpoint is never called
+    When queryArchivedTable is called for "not_a_table" filtered by "cnpj_orgao"
+    Then the result should be a failure with reason "sql_error"
+
+  Scenario: prefetchArchive warms manifest and DuckDB before a query runs
+    Given prefetchArchive was called for "contratos"
+    When the caller later invokes queryArchivedTable for "contratos" filtered by "cnpj_orgao"
+    Then the IA manifest should have been fetched exactly once
+    And DuckDB should have been initialized exactly once
+
+  Scenario: Multi-table wrappers route through the table allow-list
+    When queryArchivedOrgaos is called
+    And queryArchivedUnidades is called
+    And queryArchivedFornecedores is called
+    Then each call should request its own parquet snapshot from the manifest

--- a/web/features/contract-detail.feature
+++ b/web/features/contract-detail.feature
@@ -7,19 +7,19 @@ Feature: Contract Detail View
     Then I should see "CONTRATAÇÃO não encontrada"
 
   Scenario: Fetch pending shows skeleton
-    Given the URL has id "00000000000191-1-000001-1"
+    Given the URL has id "00000000000191-1-000001/2024"
     And the fetch is pending
     When the contract detail view mounts
     Then I should see an aria-busy element
 
   Scenario: Fetch error shows AlertBanner
-    Given the URL has id "00000000000191-1-000001-1"
+    Given the URL has id "00000000000191-1-000001/2024"
     And the fetch throws "Contratação não localizada"
     When the contract detail view mounts
     Then I should see an alert banner with the error message
 
   Scenario: Successful fetch renders all detail blocks
-    Given the URL has id "00000000000191-1-000001-1"
+    Given the URL has id "00000000000191-1-000001/2024"
     And the PNCP API returns a valid contract payload
     When the contract detail view mounts
     Then I should see the "Detalhes da Contratação" block
@@ -29,7 +29,7 @@ Feature: Contract Detail View
     And I should see the "Fontes e Metadados" block
 
   Scenario: Successful fetch renders formatted currency and links
-    Given the URL has id "00000000000191-1-000001-1"
+    Given the URL has id "00000000000191-1-000001/2024"
     And the PNCP API returns a valid contract payload
     When the contract detail view mounts
     Then I should see the BRL-formatted valor "R$ 1.500,00"

--- a/web/features/detail-view-fallback.feature
+++ b/web/features/detail-view-fallback.feature
@@ -33,24 +33,17 @@ Feature: Detail view Parquet fallback
     Then I should see an error banner about arquivo histórico
 
   Scenario: Contract view falls back to Parquet when PNCP fails
-    Given the PNCP API is unavailable for id "00000000000191-1-000001-1"
-    And the Parquet fallback returns one row for id "00000000000191-1-000001-1"
-    When the contract detail view mounts for id "00000000000191-1-000001-1"
-    Then I should see an info banner about PNCP indisponível
-    And I should see the archived contract objeto
-
-  Scenario: Contract view shows combined error when both fail
-    Given the PNCP API is unavailable for id "00000000000191-1-000001-1"
-    And the Parquet fallback returns no rows for id "00000000000191-1-000001-1"
-    When the contract detail view mounts for id "00000000000191-1-000001-1"
-    Then I should see an error banner about arquivo histórico
-
-  Scenario: Contract view accepts slash-separated PNCP IDs and reaches the fallback
     Given the PNCP API is unavailable for id "00000000000191-1-000001/2024"
     And the Parquet fallback returns one row for id "00000000000191-1-000001/2024"
     When the contract detail view mounts for id "00000000000191-1-000001/2024"
     Then I should see an info banner about PNCP indisponível
     And I should see the archived contract objeto
+
+  Scenario: Contract view shows combined error when both fail
+    Given the PNCP API is unavailable for id "00000000000191-1-000001/2024"
+    And the Parquet fallback returns no rows for id "00000000000191-1-000001/2024"
+    When the contract detail view mounts for id "00000000000191-1-000001/2024"
+    Then I should see an error banner about arquivo histórico
 
   Scenario: Agency fallback uses the exported cnpj_orgao column and orders by recency
     Given the PNCP API is unavailable for cnpj "00000000000191"

--- a/web/features/pncp-id.feature
+++ b/web/features/pncp-id.feature
@@ -1,0 +1,38 @@
+Feature: PNCP ID canonical parsing
+  PNCP's canonical numeroControlePNCP form is {cnpj}-{tipo}-{sequencial}/{ano}
+  with a 14-digit CNPJ, 6-digit sequencial, and 4-digit year. The parser is
+  strict — anything else is rejected at the boundary.
+
+  Scenario: Canonical ID parses into its four segments
+    Given the PNCP ID "12345678000195-1-000001/2024"
+    When it is parsed
+    Then the result should have cnpj "12345678000195"
+    And the result should have tipo "1"
+    And the result should have sequencial "000001"
+    And the result should have ano "2024"
+
+  Scenario: Hyphen-only ID is rejected
+    Given the PNCP ID "12345678000195-1-000001-1"
+    When it is parsed
+    Then the result should be null
+
+  Scenario: Missing year segment is rejected
+    Given the PNCP ID "12345678000195-1-000001"
+    When it is parsed
+    Then the result should be null
+
+  Scenario: Three-digit year is rejected
+    Given the PNCP ID "12345678000195-1-000001/202"
+    When it is parsed
+    Then the result should be null
+
+  Scenario: Lowercase letters are rejected
+    Given the PNCP ID "abcdefghijklmn-1-000001/2024"
+    When it is parsed
+    Then the result should be null
+
+  Scenario: ContractDetailView renders a targeted EntityNotFound for non-canonical IDs
+    Given the URL has id "12345678000195-1-000001-1"
+    When the contract detail view mounts
+    Then I should see a non-canonical ID notice
+    And I should see the expected format hint

--- a/web/features/search-hero.feature
+++ b/web/features/search-hero.feature
@@ -16,6 +16,18 @@ Feature: Search Hero
     Given the user types "12345678000195-1-000001/2024" into the search box
     Then I should see "Ver Contratação" as a jump suggestion
 
+  Scenario: Reject PNCP ID with missing year segment
+    Given the user types "12345678000195-1-000001" into the search box
+    Then I should not see any jump suggestion
+
+  Scenario: Reject PNCP ID with 3-digit year
+    Given the user types "12345678000195-1-000001/202" into the search box
+    Then I should not see any jump suggestion
+
+  Scenario: Reject hyphen-only PNCP ID
+    Given the user types "12345678000195-1-000001-1" into the search box
+    Then I should not see any jump suggestion
+
   Scenario: Short query shows no jump suggestion
     Given the user types "ab" into the search box
     Then I should not see any jump suggestion
@@ -39,12 +51,7 @@ Feature: Search Hero
     When the user submits the search form
     Then the browser should navigate to "/baliza/municipio?ibge=3550308"
 
-  Scenario: Submitting a PNCP contract ID navigates to the contract page
-    Given the user types "12345678000195-1-000001-1" into the search box
-    When the user submits the search form
-    Then the browser should navigate to "/baliza/contratacao?id=12345678000195-1-000001-1"
-
-  Scenario: Submitting a slash-separated PNCP contract ID also navigates
+  Scenario: Submitting a canonical PNCP contract ID navigates to the contract page
     Given the user types "12345678000195-1-000001/2024" into the search box
     When the user submits the search form
     Then the browser should navigate to "/baliza/contratacao?id=12345678000195-1-000001/2024"

--- a/web/src/components/AgencyDetailView.svelte
+++ b/web/src/components/AgencyDetailView.svelte
@@ -3,7 +3,7 @@
   import { getQueryClient } from '../lib/queryClient';
   import { QUERY_KEYS } from '../lib/queryKeys';
   import type { PNCPContract } from '../lib/types';
-  import { queryParquetFallback, archiveErrorMessage } from '../lib/parquetFallback';
+  import { queryParquetFallback, archiveErrorMessage, prefetchArchive } from '../lib/parquetFallback';
   import type { ArchivedContrato } from '../lib/archive/schema';
   import EntityNotFound from './EntityNotFound.svelte';
   import AlertBanner from './AlertBanner.svelte';
@@ -19,6 +19,10 @@
         ? new URLSearchParams(window.location.search).get('cnpj') ?? ''
         : ''),
   );
+
+  $effect(() => {
+    if (cnpj) prefetchArchive('contratos');
+  });
 
   interface AgencyView {
     name: string;

--- a/web/src/components/AgencyDetailView.svelte
+++ b/web/src/components/AgencyDetailView.svelte
@@ -3,7 +3,8 @@
   import { getQueryClient } from '../lib/queryClient';
   import { QUERY_KEYS } from '../lib/queryKeys';
   import type { PNCPContract } from '../lib/types';
-  import { queryParquetFallback } from '../lib/parquetFallback';
+  import { queryParquetFallback, archiveErrorMessage } from '../lib/parquetFallback';
+  import type { ArchivedContrato } from '../lib/archive/schema';
   import EntityNotFound from './EntityNotFound.svelte';
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
@@ -26,18 +27,18 @@
     archived?: { dataParticao: string | null };
   }
 
-  function archivedRowToContract(row: Record<string, unknown>): PNCPContract {
+  function archivedRowToContract(row: ArchivedContrato): PNCPContract {
     return {
-      numeroControlePNCP: String(row.numero_controle_pncp ?? ''),
-      dataPublicacaoPncp: String(row.data_publicacao_pncp ?? ''),
-      objetoContratacao: String(row.objeto_contrato ?? ''),
-      valorTotalEstimado: Number(row.valor_global ?? row.valor_inicial ?? 0),
+      numeroControlePNCP: row.numero_controle_pncp ?? '',
+      dataPublicacaoPncp: row.data_publicacao_pncp ?? '',
+      objetoContratacao: row.objeto_contrato ?? '',
+      valorTotalEstimado: row.valor_global ?? row.valor_inicial ?? 0,
       orgaoEntidade: {
-        razaoSocial: String(row.razao_social_orgao ?? 'Órgão Arquivado'),
-        cnpj: String(row.cnpj_orgao ?? ''),
+        razaoSocial: row.razao_social_orgao ?? 'Órgão Arquivado',
+        cnpj: row.cnpj_orgao ?? '',
       },
       unidadeOrgao: {
-        nomeUnidade: String(row.nome_unidade ?? ''),
+        nomeUnidade: row.nome_unidade ?? '',
       },
     };
   }
@@ -55,17 +56,14 @@
         const agencyName = contracts[0]?.orgaoEntidade?.razaoSocial || "Órgão Público";
         return { name: agencyName, cnpj, contracts };
       } catch (pncpErr) {
-        const archived = await queryParquetFallback<Record<string, unknown>>(
+        const archived = await queryParquetFallback(
           'cnpj_orgao',
           cnpj,
           10,
           'data_publicacao_pncp',
         );
-        if (!archived) {
-          throw new Error(
-            "PNCP indisponível e arquivo histórico sem registro para este identificador.",
-            { cause: pncpErr },
-          );
+        if (!archived.ok) {
+          throw new Error(archiveErrorMessage(archived.reason), { cause: pncpErr });
         }
         const contracts = archived.rows.map(archivedRowToContract);
         const agencyName = contracts[0]?.orgaoEntidade?.razaoSocial || "Órgão Arquivado";

--- a/web/src/components/CityDetailView.svelte
+++ b/web/src/components/CityDetailView.svelte
@@ -3,7 +3,7 @@
   import { getQueryClient } from '../lib/queryClient';
   import { QUERY_KEYS } from '../lib/queryKeys';
   import type { PNCPContract } from '../lib/types';
-  import { queryParquetFallback, archiveErrorMessage } from '../lib/parquetFallback';
+  import { queryParquetFallback, archiveErrorMessage, prefetchArchive } from '../lib/parquetFallback';
   import type { ArchivedContrato } from '../lib/archive/schema';
   import EntityNotFound from './EntityNotFound.svelte';
   import AlertBanner from './AlertBanner.svelte';
@@ -20,6 +20,10 @@
         ? new URLSearchParams(window.location.search).get('ibge') ?? ''
         : ''),
   );
+
+  $effect(() => {
+    if (ibge) prefetchArchive('contratos');
+  });
 
   interface CityView {
     name: string;

--- a/web/src/components/CityDetailView.svelte
+++ b/web/src/components/CityDetailView.svelte
@@ -3,7 +3,8 @@
   import { getQueryClient } from '../lib/queryClient';
   import { QUERY_KEYS } from '../lib/queryKeys';
   import type { PNCPContract } from '../lib/types';
-  import { queryParquetFallback } from '../lib/parquetFallback';
+  import { queryParquetFallback, archiveErrorMessage } from '../lib/parquetFallback';
+  import type { ArchivedContrato } from '../lib/archive/schema';
   import EntityNotFound from './EntityNotFound.svelte';
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
@@ -28,21 +29,21 @@
     archived?: { dataParticao: string | null };
   }
 
-  function archivedRowToContract(row: Record<string, unknown>): PNCPContract {
+  function archivedRowToContract(row: ArchivedContrato): PNCPContract {
     return {
-      numeroControlePNCP: String(row.numero_controle_pncp ?? ''),
-      dataPublicacaoPncp: String(row.data_publicacao_pncp ?? ''),
-      objetoContratacao: String(row.objeto_contrato ?? ''),
-      valorTotalEstimado: Number(row.valor_global ?? row.valor_inicial ?? 0),
+      numeroControlePNCP: row.numero_controle_pncp ?? '',
+      dataPublicacaoPncp: row.data_publicacao_pncp ?? '',
+      objetoContratacao: row.objeto_contrato ?? '',
+      valorTotalEstimado: row.valor_global ?? row.valor_inicial ?? 0,
       orgaoEntidade: {
-        razaoSocial: String(row.razao_social_orgao ?? ''),
-        cnpj: String(row.cnpj_orgao ?? ''),
+        razaoSocial: row.razao_social_orgao ?? '',
+        cnpj: row.cnpj_orgao ?? '',
       },
       unidadeOrgao: {
-        nomeUnidade: String(row.nome_unidade ?? ''),
-        municipioNome: String(row.municipio_nome ?? ''),
-        ufSigla: String(row.uf_sigla ?? ''),
-        codigoMunicipioIbge: String(row.codigo_ibge ?? ''),
+        nomeUnidade: row.nome_unidade ?? '',
+        municipioNome: row.municipio_nome ?? '',
+        ufSigla: row.uf_sigla ?? '',
+        codigoMunicipioIbge: row.codigo_ibge ?? '',
       },
     };
   }
@@ -61,22 +62,19 @@
         const uf = contracts[0]?.unidadeOrgao?.ufSigla || "";
         return { name: cityName, uf, ibge, contracts };
       } catch (pncpErr) {
-        const archived = await queryParquetFallback<Record<string, unknown>>(
+        const archived = await queryParquetFallback(
           'codigo_ibge',
           ibge,
           10,
           'data_publicacao_pncp',
         );
-        if (!archived) {
-          throw new Error(
-            "PNCP indisponível e arquivo histórico sem registro para este identificador.",
-            { cause: pncpErr },
-          );
+        if (!archived.ok) {
+          throw new Error(archiveErrorMessage(archived.reason), { cause: pncpErr });
         }
         const contracts = archived.rows.map(archivedRowToContract);
-        const first = archived.rows[0] as Record<string, unknown> | undefined;
-        const cityName = String(first?.municipio_nome ?? 'Município');
-        const uf = String(first?.uf_sigla ?? '');
+        const first = archived.rows[0];
+        const cityName = first?.municipio_nome ?? 'Município';
+        const uf = first?.uf_sigla ?? '';
         return {
           name: cityName,
           uf,

--- a/web/src/components/ContractDetailView.svelte
+++ b/web/src/components/ContractDetailView.svelte
@@ -3,7 +3,7 @@
   import { getQueryClient } from '../lib/queryClient';
   import { QUERY_KEYS } from '../lib/queryKeys';
   import type { PNCPContract } from '../lib/types';
-  import { queryParquetFallback, archiveErrorMessage } from '../lib/parquetFallback';
+  import { queryParquetFallback, archiveErrorMessage, prefetchArchive } from '../lib/parquetFallback';
   import type { ArchivedContrato } from '../lib/archive/schema';
   import { parsePncpId, PNCP_ID_EXAMPLE } from '../lib/pncpId';
   import EntityNotFound from './EntityNotFound.svelte';
@@ -20,6 +20,10 @@
         : ''),
   );
   const parsedId = $derived(id ? parsePncpId(id) : null);
+
+  $effect(() => {
+    if (parsedId) prefetchArchive('contratos');
+  });
 
   interface ContractView extends PNCPContract {
     archived?: { dataParticao: string | null };

--- a/web/src/components/ContractDetailView.svelte
+++ b/web/src/components/ContractDetailView.svelte
@@ -3,7 +3,8 @@
   import { getQueryClient } from '../lib/queryClient';
   import { QUERY_KEYS } from '../lib/queryKeys';
   import type { PNCPContract } from '../lib/types';
-  import { queryParquetFallback } from '../lib/parquetFallback';
+  import { queryParquetFallback, archiveErrorMessage } from '../lib/parquetFallback';
+  import type { ArchivedContrato } from '../lib/archive/schema';
   import { parsePncpId, PNCP_ID_EXAMPLE } from '../lib/pncpId';
   import EntityNotFound from './EntityNotFound.svelte';
   import AlertBanner from './AlertBanner.svelte';
@@ -24,24 +25,24 @@
     archived?: { dataParticao: string | null };
   }
 
-  function archivedRowToContract(row: Record<string, unknown>, id: string): ContractView {
+  function archivedRowToContract(row: ArchivedContrato, id: string): ContractView {
     return {
-      numeroControlePNCP: String(row.numero_controle_pncp ?? id),
-      dataPublicacaoPncp: String(row.data_publicacao_pncp ?? ''),
-      objetoContratacao: String(row.objeto_contrato ?? ''),
-      valorTotalEstimado: Number(row.valor_global ?? row.valor_inicial ?? 0),
-      modalidadeNome: row.modalidade_nome ? String(row.modalidade_nome) : undefined,
-      linkSistemaOrigem: row.link_sistema_origem ? String(row.link_sistema_origem) : undefined,
-      usuarioNome: row.usuario_nome ? String(row.usuario_nome) : undefined,
+      numeroControlePNCP: row.numero_controle_pncp ?? id,
+      dataPublicacaoPncp: row.data_publicacao_pncp ?? '',
+      objetoContratacao: row.objeto_contrato ?? '',
+      valorTotalEstimado: row.valor_global ?? row.valor_inicial ?? 0,
+      modalidadeNome: row.modalidade_nome ?? undefined,
+      linkSistemaOrigem: row.link_sistema_origem ?? undefined,
+      usuarioNome: row.usuario_nome ?? undefined,
       orgaoEntidade: {
-        razaoSocial: String(row.razao_social_orgao ?? ''),
-        cnpj: String(row.cnpj_orgao ?? ''),
+        razaoSocial: row.razao_social_orgao ?? '',
+        cnpj: row.cnpj_orgao ?? '',
       },
       unidadeOrgao: {
-        nomeUnidade: String(row.nome_unidade ?? ''),
-        municipioNome: row.municipio_nome ? String(row.municipio_nome) : undefined,
-        ufSigla: row.uf_sigla ? String(row.uf_sigla) : undefined,
-        codigoMunicipioIbge: row.codigo_ibge ? String(row.codigo_ibge) : undefined,
+        nomeUnidade: row.nome_unidade ?? '',
+        municipioNome: row.municipio_nome ?? undefined,
+        ufSigla: row.uf_sigla ?? undefined,
+        codigoMunicipioIbge: row.codigo_ibge ?? undefined,
       },
     };
   }
@@ -57,16 +58,13 @@
         if (!res.ok) throw new Error("Contratação não localizada no PNCP.");
         return (await res.json()) as ContractView;
       } catch (pncpErr) {
-        const archived = await queryParquetFallback<Record<string, unknown>>(
+        const archived = await queryParquetFallback(
           'numero_controle_pncp',
           id,
           1,
         );
-        if (!archived || archived.rows.length === 0) {
-          throw new Error(
-            "PNCP indisponível e arquivo histórico sem registro para este identificador.",
-            { cause: pncpErr },
-          );
+        if (!archived.ok) {
+          throw new Error(archiveErrorMessage(archived.reason), { cause: pncpErr });
         }
         const view = archivedRowToContract(archived.rows[0], id);
         view.archived = { dataParticao: archived.dataParticao };

--- a/web/src/components/ContractDetailView.svelte
+++ b/web/src/components/ContractDetailView.svelte
@@ -4,6 +4,7 @@
   import { QUERY_KEYS } from '../lib/queryKeys';
   import type { PNCPContract } from '../lib/types';
   import { queryParquetFallback } from '../lib/parquetFallback';
+  import { parsePncpId, PNCP_ID_EXAMPLE } from '../lib/pncpId';
   import EntityNotFound from './EntityNotFound.svelte';
   import AlertBanner from './AlertBanner.svelte';
 
@@ -17,6 +18,7 @@
         ? new URLSearchParams(window.location.search).get('id') ?? ''
         : ''),
   );
+  const parsedId = $derived(id ? parsePncpId(id) : null);
 
   interface ContractView extends PNCPContract {
     archived?: { dataParticao: string | null };
@@ -47,12 +49,8 @@
   const contractQuery = createQuery(() => ({
     queryKey: QUERY_KEYS.contratacao(id),
     queryFn: async (): Promise<ContractView | null> => {
-      if (!id) return null;
-      const parts = id.split(/[-/]/);
-      if (parts.length < 4) throw new Error("ID de contrato inválido. Formato esperado: CNPJ-ANO-SEQ-TIPO.");
-      const cnpj = parts[0];
-      const sequencial = parts[2];
-      const ano = parts[3];
+      if (!parsedId) return null;
+      const { cnpj, sequencial, ano } = parsedId;
       const url = `https://pncp.gov.br/api/consulta/v1/orgaos/${cnpj}/contratacoes/${ano}/${sequencial}`;
       try {
         const res = await fetch(url);
@@ -75,7 +73,7 @@
         return view;
       }
     },
-    enabled: !!id,
+    enabled: !!parsedId,
   }));
 
   const data = $derived(contractQuery.data);
@@ -97,6 +95,12 @@
 <div class="contract-view container">
   {#if !id}
     <EntityNotFound id="ausente" type="contratação" />
+  {:else if !parsedId}
+    <EntityNotFound
+      id={id}
+      type="contratação"
+      error={`ID fora do padrão PNCP. Formato esperado: ${PNCP_ID_EXAMPLE}.`}
+    />
   {:else if loading}
     <div class="skeleton-wrap" aria-busy="true" aria-label="Carregando contratação">
       <div class="skeleton skeleton-title"></div>

--- a/web/src/components/SearchHero.svelte
+++ b/web/src/components/SearchHero.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
   import { PROJECT_MISSION, SEARCH_HINTS } from '../lib/homepage-content';
+  import { isPncpId, parsePncpId } from '../lib/pncpId';
   import EmptyState from './EmptyState.svelte';
   import AlertBanner from './AlertBanner.svelte';
 
@@ -24,17 +25,15 @@
   let query = $state('');
   const cleanQuery = $derived(query.trim());
   const digitsOnly = $derived(cleanQuery.replace(/\D/g, ''));
-  const isCnpj   = $derived(/^\d{14}$/.test(digitsOnly) && /^\d{14}$/.test(cleanQuery));
-  const isIbge   = $derived(/^\d{7}$/.test(cleanQuery));
-  const isPncpIdLoose = $derived(/\d{14}[-/]\d+[-/]\d{6}[-/]\d+/.test(cleanQuery));
-  const hasPattern = $derived(isCnpj || isIbge || isPncpIdLoose);
+  const isCnpj     = $derived(/^\d{14}$/.test(digitsOnly) && /^\d{14}$/.test(cleanQuery));
+  const isIbge     = $derived(/^\d{7}$/.test(cleanQuery));
+  const isContract = $derived(isPncpId(cleanQuery));
+  const hasPattern = $derived(isCnpj || isIbge || isContract);
 
   function navigateFor(value: string): string | null {
     if (/^\d{14}$/.test(value)) return `/baliza/orgao?cnpj=${value}`;
     if (/^\d{7}$/.test(value))  return `/baliza/municipio?ibge=${value}`;
-    // Accept both separators used in the wild — PNCP URLs canonically use
-    // "<cnpj>-<seq>-<ano>/<num>" but the textual ID form uses hyphens only.
-    if (/^\d{14}[-/]\d+[-/]\d{6}[-/]\d+$/.test(value)) return `/baliza/contratacao?id=${value}`;
+    if (parsePncpId(value))     return `/baliza/contratacao?id=${value}`;
     return null;
   }
 
@@ -84,11 +83,7 @@
   }
 
   function isShapeMatch(term: string) {
-    return (
-      /^\d{14}$/.test(term) ||
-      /^\d{7}$/.test(term) ||
-      /\d{14}[-/]\d+[-/]\d{6}[-/]\d+/.test(term)
-    );
+    return /^\d{14}$/.test(term) || /^\d{7}$/.test(term) || isPncpId(term);
   }
 
   function scheduleSearch(term: string) {
@@ -174,7 +169,7 @@
             <a href={`/baliza/municipio?ibge=${cleanQuery}`} class="jump-link">
               Explorar Município <span class="badge badge-sm badge-info">{cleanQuery}</span>
             </a>
-          {:else if isPncpIdLoose}
+          {:else if isContract}
             <a href={`/baliza/contratacao?id=${cleanQuery}`} class="jump-link">
               Ver Contratação <span class="badge badge-sm badge-info">#{cleanQuery}</span>
             </a>

--- a/web/src/components/__steps__/agency-detail.steps.ts
+++ b/web/src/components/__steps__/agency-detail.steps.ts
@@ -117,14 +117,14 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
 
     And(
-      'the PNCP API returns a contract with id "00000000000191-1-000001-1"',
+      'the PNCP API returns a contract with id "00000000000191-1-000001/2024"',
       () => {
         global.fetch = vi.fn().mockResolvedValue(
           new Response(
             JSON.stringify({
               data: [
                 {
-                  numeroControlePNCP: '00000000000191-1-000001-1',
+                  numeroControlePNCP: '00000000000191-1-000001/2024',
                   dataPublicacaoPncp: '2025-01-15T00:00:00',
                   objetoContratacao: 'Aquisição de materiais de teste',
                   valorTotalEstimado: 1000,
@@ -151,7 +151,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await waitFor(
         () => {
           const link = document.querySelector(
-            'a[href*="00000000000191-1-000001-1"]',
+            'a[href*="00000000000191-1-000001/2024"]',
           );
           expect(link).toBeTruthy();
         },

--- a/web/src/components/__steps__/archive-fallback.steps.ts
+++ b/web/src/components/__steps__/archive-fallback.steps.ts
@@ -1,0 +1,258 @@
+import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber';
+import { vi, expect } from 'vitest';
+
+// IMPORTANT: this file intentionally does NOT import ./shared. shared.ts
+// globally mocks queryParquetFallback; here we exercise the REAL
+// queryArchivedTable implementation and control duckdb + fetch directly.
+
+const feature = await loadFeature('features/archive-fallback.feature');
+
+interface DuckDBHandle {
+  db: null;
+  conn: { query: ReturnType<typeof vi.fn> };
+}
+
+let queryMock: ReturnType<typeof vi.fn>;
+let duckdbInitCount = 0;
+let duckdbInstance: DuckDBHandle | null = null;
+let duckdbShouldThrow = false;
+
+async function fakeGetDuckDB(): Promise<DuckDBHandle> {
+  if (duckdbShouldThrow) throw new Error('duckdb boom');
+  if (!duckdbInstance) {
+    duckdbInitCount += 1;
+    duckdbInstance = { db: null, conn: { query: queryMock } };
+  }
+  return duckdbInstance;
+}
+
+const getDuckDBSpy = vi.fn(fakeGetDuckDB);
+
+vi.mock('../../lib/duckdb', () => ({
+  getDuckDB: (...args: unknown[]) =>
+    (getDuckDBSpy as unknown as (...a: unknown[]) => Promise<DuckDBHandle>)(...args),
+}));
+
+// NOTE: ia-manifest is NOT mocked. We mock the underlying global fetch so the
+// real manifest module's per-table Promise cache is exercised (this is what
+// makes prefetchArchive measurable — the second call hits the cache).
+
+const PARQUET_URL_BY_TABLE: Record<string, string> = {
+  contratos: 'https://archive.org/download/baliza-pncp-manifest/contratos.parquet',
+  orgaos: 'https://archive.org/download/baliza-pncp-manifest/orgaos.parquet',
+  unidades: 'https://archive.org/download/baliza-pncp-manifest/unidades.parquet',
+  fornecedores: 'https://archive.org/download/baliza-pncp-manifest/fornecedores.parquet',
+};
+
+function manifestCsvAllTables(): string {
+  const header = 'data_particao,table_name,parquet_url';
+  const rows = Object.entries(PARQUET_URL_BY_TABLE).map(
+    ([table, url]) => `2024-12-01,${table},${url}`,
+  );
+  return [header, ...rows].join('\n');
+}
+
+function installManifestFetch(status: number, body: string) {
+  // Response bodies are single-use; hand out a fresh one per call so the
+  // per-table manifest cache can issue multiple fetches against this stub.
+  const fetchSpy = vi.fn().mockImplementation(() =>
+    Promise.resolve(
+      new Response(body, { status, headers: { 'Content-Type': 'text/csv' } }),
+    ),
+  );
+  global.fetch = fetchSpy as unknown as typeof fetch;
+  return fetchSpy;
+}
+
+async function resetAll() {
+  const parquet = await import('../../lib/parquetFallback');
+  void parquet; // keep module side-effects
+  const manifest = await import('../../lib/ia-manifest');
+  manifest.resetIaManifestCache();
+
+  queryMock = vi.fn();
+  duckdbInstance = null;
+  duckdbInitCount = 0;
+  duckdbShouldThrow = false;
+  getDuckDBSpy.mockClear();
+  getDuckDBSpy.mockImplementation(fakeGetDuckDB);
+}
+
+describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
+  let result: Awaited<ReturnType<typeof callArchive>> | null = null;
+  let fetchSpy: ReturnType<typeof vi.fn> | null = null;
+
+  async function callArchive(
+    table: 'contratos' | 'orgaos' | 'unidades' | 'fornecedores' | string,
+    column: string,
+    value = 'xyz',
+    opts: { limit?: number; orderByColumn?: string } = {},
+  ) {
+    const { queryArchivedTable } = await import('../../lib/parquetFallback');
+    return queryArchivedTable(
+      table as 'contratos',
+      column,
+      value,
+      opts,
+    );
+  }
+
+  BeforeEachScenario(async () => {
+    vi.restoreAllMocks();
+    await resetAll();
+    result = null;
+    fetchSpy = null;
+  });
+
+  Scenario('Manifest endpoint 404 yields reason "no_manifest"', ({ Given, When, Then }) => {
+    Given('the IA manifest endpoint returns 404', () => {
+      fetchSpy = installManifestFetch(404, '');
+    });
+    When('queryArchivedTable is called for "contratos" filtered by "cnpj_orgao"', async () => {
+      result = await callArchive('contratos', 'cnpj_orgao');
+    });
+    Then('the result should be a failure with reason "no_manifest"', () => {
+      expect(result).toEqual({ ok: false, reason: 'no_manifest' });
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+  });
+
+  Scenario('DuckDB init failure yields reason "duckdb_init_failed"', ({ Given, And, When, Then }) => {
+    Given('the IA manifest resolves to a parquet url', () => {
+      installManifestFetch(200, manifestCsvAllTables());
+    });
+    And('DuckDB initialization throws', () => {
+      duckdbShouldThrow = true;
+    });
+    When('queryArchivedTable is called for "contratos" filtered by "cnpj_orgao"', async () => {
+      result = await callArchive('contratos', 'cnpj_orgao');
+    });
+    Then('the result should be a failure with reason "duckdb_init_failed"', () => {
+      expect(result).toEqual({ ok: false, reason: 'duckdb_init_failed' });
+    });
+  });
+
+  Scenario('SQL returning zero rows yields reason "empty"', ({ Given, And, When, Then }) => {
+    Given('the IA manifest resolves to a parquet url', () => {
+      installManifestFetch(200, manifestCsvAllTables());
+    });
+    And('DuckDB returns no rows', () => {
+      queryMock.mockResolvedValue({ toArray: () => [] });
+    });
+    When('queryArchivedTable is called for "contratos" filtered by "cnpj_orgao"', async () => {
+      result = await callArchive('contratos', 'cnpj_orgao');
+    });
+    Then('the result should be a failure with reason "empty"', () => {
+      expect(result).toEqual({ ok: false, reason: 'empty' });
+    });
+  });
+
+  Scenario('SQL thrown error yields reason "sql_error"', ({ Given, And, When, Then }) => {
+    Given('the IA manifest resolves to a parquet url', () => {
+      installManifestFetch(200, manifestCsvAllTables());
+    });
+    And('DuckDB query throws', () => {
+      queryMock.mockRejectedValue(new Error('syntax error'));
+    });
+    When('queryArchivedTable is called for "contratos" filtered by "cnpj_orgao"', async () => {
+      result = await callArchive('contratos', 'cnpj_orgao');
+    });
+    Then('the result should be a failure with reason "sql_error"', () => {
+      expect(result).toEqual({ ok: false, reason: 'sql_error' });
+    });
+  });
+
+  Scenario('Limit above 200 is clamped to 200', ({ Given, And, When, Then }) => {
+    Given('the IA manifest resolves to a parquet url', () => {
+      installManifestFetch(200, manifestCsvAllTables());
+    });
+    And('DuckDB captures the query text and returns one row', () => {
+      queryMock.mockResolvedValue({
+        toArray: () => [{ toJSON: () => ({ numero_controle_pncp: 'x' }) }],
+      });
+    });
+    When('queryArchivedTable is called for "contratos" with limit 5000', async () => {
+      result = await callArchive('contratos', 'cnpj_orgao', 'xyz', { limit: 5000 });
+    });
+    Then('the executed SQL should contain "LIMIT 200"', () => {
+      expect(queryMock).toHaveBeenCalledTimes(1);
+      const sql = queryMock.mock.calls[0][0] as string;
+      expect(sql).toContain('LIMIT 200');
+      expect(sql).not.toContain('LIMIT 5000');
+      expect(result?.ok).toBe(true);
+    });
+  });
+
+  Scenario('Unknown table is rejected without touching the manifest', ({ Given, When, Then }) => {
+    Given('the IA manifest endpoint is never called', () => {
+      fetchSpy = installManifestFetch(500, 'should not be reached');
+    });
+    When('queryArchivedTable is called for "not_a_table" filtered by "cnpj_orgao"', async () => {
+      result = await callArchive('not_a_table', 'cnpj_orgao');
+    });
+    Then('the result should be a failure with reason "sql_error"', () => {
+      expect(result).toEqual({ ok: false, reason: 'sql_error' });
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(getDuckDBSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  Scenario('prefetchArchive warms manifest and DuckDB before a query runs', ({ Given, When, Then, And }) => {
+    Given('prefetchArchive was called for "contratos"', async () => {
+      fetchSpy = installManifestFetch(200, manifestCsvAllTables());
+      queryMock.mockResolvedValue({
+        toArray: () => [{ toJSON: () => ({ numero_controle_pncp: 'x' }) }],
+      });
+      const { prefetchArchive } = await import('../../lib/parquetFallback');
+      prefetchArchive('contratos');
+      // Let the fire-and-forget promises settle before the "later" query runs.
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    When('the caller later invokes queryArchivedTable for "contratos" filtered by "cnpj_orgao"', async () => {
+      result = await callArchive('contratos', 'cnpj_orgao');
+    });
+    Then('the IA manifest should have been fetched exactly once', () => {
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(result?.ok).toBe(true);
+    });
+    And('DuckDB should have been initialized exactly once', () => {
+      expect(duckdbInitCount).toBe(1);
+    });
+  });
+
+  Scenario('Multi-table wrappers route through the table allow-list', ({ When, And, Then }) => {
+    const calls: Array<{ table: string; sql: string }> = [];
+
+    When('queryArchivedOrgaos is called', async () => {
+      fetchSpy = installManifestFetch(200, manifestCsvAllTables());
+      queryMock.mockImplementation(async (sql: string) => {
+        calls.push({ table: detectTable(sql), sql });
+        return { toArray: () => [{ toJSON: () => ({ cnpj: '00' }) }] };
+      });
+      const { queryArchivedOrgaos } = await import('../../lib/parquetFallback');
+      await queryArchivedOrgaos('cnpj', '00000000000191');
+    });
+    And('queryArchivedUnidades is called', async () => {
+      const { queryArchivedUnidades } = await import('../../lib/parquetFallback');
+      await queryArchivedUnidades('codigo_unidade', '1');
+    });
+    And('queryArchivedFornecedores is called', async () => {
+      const { queryArchivedFornecedores } = await import('../../lib/parquetFallback');
+      await queryArchivedFornecedores('ni_fornecedor', '00000000000191');
+    });
+    Then('each call should request its own parquet snapshot from the manifest', () => {
+      expect(calls).toHaveLength(3);
+      expect(calls.map((c) => c.table).sort()).toEqual(
+        ['fornecedores', 'orgaos', 'unidades'].sort(),
+      );
+    });
+
+    function detectTable(sql: string): string {
+      const entry = Object.entries(PARQUET_URL_BY_TABLE).find(([, url]) =>
+        sql.includes(url),
+      );
+      return entry ? entry[0] : 'unknown';
+    }
+  });
+});

--- a/web/src/components/__steps__/city-detail.steps.ts
+++ b/web/src/components/__steps__/city-detail.steps.ts
@@ -122,7 +122,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
           JSON.stringify({
             data: [
               {
-                numeroControlePNCP: '99999999999999-1-000001-1',
+                numeroControlePNCP: '99999999999999-1-000001/2024',
                 dataPublicacaoPncp: '2025-01-15T00:00:00',
                 objetoContratacao: 'Teste',
                 valorTotalEstimado: 500,

--- a/web/src/components/__steps__/contract-detail.steps.ts
+++ b/web/src/components/__steps__/contract-detail.steps.ts
@@ -13,7 +13,7 @@ function setUrlQuery(qs: string) {
 }
 
 const RICH_PAYLOAD = {
-  numeroControlePNCP: '00000000000191-1-000001-1',
+  numeroControlePNCP: '00000000000191-1-000001/2024',
   dataPublicacaoPncp: '2025-01-15T00:00:00',
   dataAberturaProposta: '2025-01-20T09:00:00',
   dataEncerramentoProposta: '2025-02-05T17:00:00',
@@ -78,8 +78,8 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
   });
 
   Scenario('Fetch pending shows skeleton', ({ Given, And, When, Then }) => {
-    Given('the URL has id "00000000000191-1-000001-1"', () => {
-      setUrlQuery('id=00000000000191-1-000001-1');
+    Given('the URL has id "00000000000191-1-000001/2024"', () => {
+      setUrlQuery('id=00000000000191-1-000001/2024');
     });
 
     And('the fetch is pending', () => {
@@ -99,8 +99,8 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
   });
 
   Scenario('Fetch error shows AlertBanner', ({ Given, And, When, Then }) => {
-    Given('the URL has id "00000000000191-1-000001-1"', () => {
-      setUrlQuery('id=00000000000191-1-000001-1');
+    Given('the URL has id "00000000000191-1-000001/2024"', () => {
+      setUrlQuery('id=00000000000191-1-000001/2024');
     });
 
     And('the fetch throws "Contratação não localizada"', () => {
@@ -126,8 +126,8 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
   });
 
   Scenario('Successful fetch renders all detail blocks', ({ Given, And, When, Then }) => {
-    Given('the URL has id "00000000000191-1-000001-1"', () => {
-      setUrlQuery('id=00000000000191-1-000001-1');
+    Given('the URL has id "00000000000191-1-000001/2024"', () => {
+      setUrlQuery('id=00000000000191-1-000001/2024');
     });
 
     And('the PNCP API returns a valid contract payload', () => {
@@ -166,8 +166,8 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
   });
 
   Scenario('Successful fetch renders formatted currency and links', ({ Given, And, When, Then }) => {
-    Given('the URL has id "00000000000191-1-000001-1"', () => {
-      setUrlQuery('id=00000000000191-1-000001-1');
+    Given('the URL has id "00000000000191-1-000001/2024"', () => {
+      setUrlQuery('id=00000000000191-1-000001/2024');
     });
 
     And('the PNCP API returns a valid contract payload', () => {

--- a/web/src/components/__steps__/detail-view-fallback.steps.ts
+++ b/web/src/components/__steps__/detail-view-fallback.steps.ts
@@ -54,7 +54,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     cleanup();
     vi.restoreAllMocks();
     fallbackMock.mockReset();
-    fallbackMock.mockResolvedValue(null);
+    fallbackMock.mockResolvedValue({ ok: false, reason: 'empty' });
     setUrlQuery('');
   });
 
@@ -65,6 +65,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
 
     And('the Parquet fallback returns one contract row for cnpj "00000000000191"', () => {
       fallbackMock.mockResolvedValue({
+        ok: true,
         rows: [ARCHIVED_AGENCY_ROW],
         dataParticao: '2024-12-01',
       });
@@ -97,7 +98,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
 
     And('the Parquet fallback returns no rows for cnpj "00000000000191"', () => {
-      fallbackMock.mockResolvedValue(null);
+      fallbackMock.mockResolvedValue({ ok: false, reason: 'empty' });
     });
 
     When('the agency detail view mounts for cnpj "00000000000191"', async () => {
@@ -160,6 +161,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
 
     And('the Parquet fallback returns one contract row for ibge "3550308"', () => {
       fallbackMock.mockResolvedValue({
+        ok: true,
         rows: [ARCHIVED_CITY_ROW],
         dataParticao: '2024-12-01',
       });
@@ -192,7 +194,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
 
     And('the Parquet fallback returns no rows for ibge "3550308"', () => {
-      fallbackMock.mockResolvedValue(null);
+      fallbackMock.mockResolvedValue({ ok: false, reason: 'empty' });
     });
 
     When('the city detail view mounts for ibge "3550308"', async () => {
@@ -219,6 +221,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
 
     And('the Parquet fallback returns one row for id "00000000000191-1-000001/2024"', () => {
       fallbackMock.mockResolvedValue({
+        ok: true,
         rows: [ARCHIVED_CONTRACT_ROW],
         dataParticao: '2024-12-01',
       });
@@ -252,7 +255,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
 
     And('the Parquet fallback returns no rows for id "00000000000191-1-000001/2024"', () => {
-      fallbackMock.mockResolvedValue(null);
+      fallbackMock.mockResolvedValue({ ok: false, reason: 'empty' });
     });
 
     When('the contract detail view mounts for id "00000000000191-1-000001/2024"', async () => {

--- a/web/src/components/__steps__/detail-view-fallback.steps.ts
+++ b/web/src/components/__steps__/detail-view-fallback.steps.ts
@@ -40,7 +40,7 @@ const ARCHIVED_CITY_ROW = {
 };
 
 const ARCHIVED_CONTRACT_ROW = {
-  numero_controle_pncp: '00000000000191-1-000001-1',
+  numero_controle_pncp: '00000000000191-1-000001/2024',
   objeto_contrato: 'Aquisição arquivada – contratação',
   data_publicacao_pncp: '2024-03-01T00:00:00',
   valor_global: 7777,
@@ -213,19 +213,19 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
   });
 
   Scenario('Contract view falls back to Parquet when PNCP fails', ({ Given, And, When, Then }) => {
-    Given('the PNCP API is unavailable for id "00000000000191-1-000001-1"', () => {
+    Given('the PNCP API is unavailable for id "00000000000191-1-000001/2024"', () => {
       global.fetch = vi.fn().mockResolvedValue(new Response('boom', { status: 503 }));
     });
 
-    And('the Parquet fallback returns one row for id "00000000000191-1-000001-1"', () => {
+    And('the Parquet fallback returns one row for id "00000000000191-1-000001/2024"', () => {
       fallbackMock.mockResolvedValue({
         rows: [ARCHIVED_CONTRACT_ROW],
         dataParticao: '2024-12-01',
       });
     });
 
-    When('the contract detail view mounts for id "00000000000191-1-000001-1"', async () => {
-      setUrlQuery('id=00000000000191-1-000001-1');
+    When('the contract detail view mounts for id "00000000000191-1-000001/2024"', async () => {
+      setUrlQuery('id=00000000000191-1-000001/2024');
       render(ContractDetailView);
       await tick();
     });
@@ -247,16 +247,16 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
   });
 
   Scenario('Contract view shows combined error when both fail', ({ Given, And, When, Then }) => {
-    Given('the PNCP API is unavailable for id "00000000000191-1-000001-1"', () => {
+    Given('the PNCP API is unavailable for id "00000000000191-1-000001/2024"', () => {
       global.fetch = vi.fn().mockResolvedValue(new Response('boom', { status: 503 }));
     });
 
-    And('the Parquet fallback returns no rows for id "00000000000191-1-000001-1"', () => {
+    And('the Parquet fallback returns no rows for id "00000000000191-1-000001/2024"', () => {
       fallbackMock.mockResolvedValue(null);
     });
 
-    When('the contract detail view mounts for id "00000000000191-1-000001-1"', async () => {
-      setUrlQuery('id=00000000000191-1-000001-1');
+    When('the contract detail view mounts for id "00000000000191-1-000001/2024"', async () => {
+      setUrlQuery('id=00000000000191-1-000001/2024');
       render(ContractDetailView);
       await tick();
     });
@@ -318,40 +318,4 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
   });
 
-  Scenario('Contract view accepts slash-separated PNCP IDs and reaches the fallback', ({ Given, And, When, Then }) => {
-    const slashId = '00000000000191-1-000001/2024';
-    const slashRow = { ...ARCHIVED_CONTRACT_ROW, numero_controle_pncp: slashId };
-
-    Given('the PNCP API is unavailable for id "00000000000191-1-000001/2024"', () => {
-      global.fetch = vi.fn().mockResolvedValue(new Response('boom', { status: 503 }));
-    });
-
-    And('the Parquet fallback returns one row for id "00000000000191-1-000001/2024"', () => {
-      fallbackMock.mockResolvedValue({
-        rows: [slashRow],
-        dataParticao: '2024-12-01',
-      });
-    });
-
-    When('the contract detail view mounts for id "00000000000191-1-000001/2024"', async () => {
-      setUrlQuery(`id=${encodeURIComponent(slashId)}`);
-      render(ContractDetailView);
-      await tick();
-    });
-
-    Then('I should see an info banner about PNCP indisponível', async () => {
-      await waitFor(
-        () => {
-          const alert = screen.getByRole('alert');
-          expect(alert.textContent).toMatch(/PNCP indisponível/i);
-        },
-        { timeout: 2000 },
-      );
-    });
-
-    And('I should see the archived contract objeto', () => {
-      const matches = screen.getAllByText(/Aquisição arquivada – contratação/);
-      expect(matches.length).toBeGreaterThan(0);
-    });
-  });
 });

--- a/web/src/components/__steps__/pncp-id.steps.ts
+++ b/web/src/components/__steps__/pncp-id.steps.ts
@@ -1,0 +1,114 @@
+import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber';
+import { screen, cleanup, waitFor } from '@testing-library/svelte/pure';
+import { vi, expect } from 'vitest';
+import { tick } from 'svelte';
+import { render } from './shared';
+import { parsePncpId, type PncpId } from '../../lib/pncpId';
+import ContractDetailViewRaw from '../ContractDetailView.svelte';
+
+const ContractDetailView = ContractDetailViewRaw as unknown as Parameters<typeof render>[0];
+const feature = await loadFeature('features/pncp-id.feature');
+
+function setUrlQuery(qs: string) {
+  window.history.replaceState({}, '', qs ? `/?${qs}` : '/');
+}
+
+describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
+  let raw = '';
+  let parsed: PncpId | null = null;
+
+  BeforeEachScenario(async () => {
+    cleanup();
+    vi.restoreAllMocks();
+    setUrlQuery('');
+    raw = '';
+    parsed = null;
+  });
+
+  Scenario('Canonical ID parses into its four segments', ({ Given, When, Then, And }) => {
+    Given('the PNCP ID "12345678000195-1-000001/2024"', () => {
+      raw = '12345678000195-1-000001/2024';
+    });
+    When('it is parsed', () => {
+      parsed = parsePncpId(raw);
+    });
+    Then('the result should have cnpj "12345678000195"', () => {
+      expect(parsed?.cnpj).toBe('12345678000195');
+    });
+    And('the result should have tipo "1"', () => {
+      expect(parsed?.tipo).toBe('1');
+    });
+    And('the result should have sequencial "000001"', () => {
+      expect(parsed?.sequencial).toBe('000001');
+    });
+    And('the result should have ano "2024"', () => {
+      expect(parsed?.ano).toBe('2024');
+    });
+  });
+
+  Scenario('Hyphen-only ID is rejected', ({ Given, When, Then }) => {
+    Given('the PNCP ID "12345678000195-1-000001-1"', () => {
+      raw = '12345678000195-1-000001-1';
+    });
+    When('it is parsed', () => {
+      parsed = parsePncpId(raw);
+    });
+    Then('the result should be null', () => {
+      expect(parsed).toBeNull();
+    });
+  });
+
+  Scenario('Missing year segment is rejected', ({ Given, When, Then }) => {
+    Given('the PNCP ID "12345678000195-1-000001"', () => {
+      raw = '12345678000195-1-000001';
+    });
+    When('it is parsed', () => {
+      parsed = parsePncpId(raw);
+    });
+    Then('the result should be null', () => {
+      expect(parsed).toBeNull();
+    });
+  });
+
+  Scenario('Three-digit year is rejected', ({ Given, When, Then }) => {
+    Given('the PNCP ID "12345678000195-1-000001/202"', () => {
+      raw = '12345678000195-1-000001/202';
+    });
+    When('it is parsed', () => {
+      parsed = parsePncpId(raw);
+    });
+    Then('the result should be null', () => {
+      expect(parsed).toBeNull();
+    });
+  });
+
+  Scenario('Lowercase letters are rejected', ({ Given, When, Then }) => {
+    Given('the PNCP ID "abcdefghijklmn-1-000001/2024"', () => {
+      raw = 'abcdefghijklmn-1-000001/2024';
+    });
+    When('it is parsed', () => {
+      parsed = parsePncpId(raw);
+    });
+    Then('the result should be null', () => {
+      expect(parsed).toBeNull();
+    });
+  });
+
+  Scenario('ContractDetailView renders a targeted EntityNotFound for non-canonical IDs', ({ Given, When, Then, And }) => {
+    Given('the URL has id "12345678000195-1-000001-1"', () => {
+      setUrlQuery('id=12345678000195-1-000001-1');
+    });
+    When('the contract detail view mounts', async () => {
+      render(ContractDetailView);
+      await tick();
+    });
+    Then('I should see a non-canonical ID notice', async () => {
+      await waitFor(() =>
+        expect(screen.getByText(/fora do padrão PNCP/i)).toBeTruthy(),
+      );
+    });
+    And('I should see the expected format hint', () => {
+      expect(screen.getByText(/00000000000000-1-000001\/2024/)).toBeTruthy();
+    });
+  });
+});

--- a/web/src/components/__steps__/search-hero.steps.ts
+++ b/web/src/components/__steps__/search-hero.steps.ts
@@ -164,28 +164,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
   });
 
-  Scenario('Submitting a PNCP contract ID navigates to the contract page', ({ Given, When, Then }) => {
-    let assign: ReturnType<typeof vi.fn>;
-
-    Given('the user types "12345678000195-1-000001-1" into the search box', async () => {
-      assign = stubLocationAssign();
-      render(SearchHero);
-      await tick();
-      await typeInSearch('12345678000195-1-000001-1');
-    });
-
-    When('the user submits the search form', async () => {
-      const form = document.querySelector('form.search-form') as HTMLFormElement;
-      await fireEvent.submit(form);
-      await tick();
-    });
-
-    Then('the browser should navigate to "/baliza/contratacao?id=12345678000195-1-000001-1"', () => {
-      expect(assign).toHaveBeenCalledWith('/baliza/contratacao?id=12345678000195-1-000001-1');
-    });
-  });
-
-  Scenario('Submitting a slash-separated PNCP contract ID also navigates', ({ Given, When, Then }) => {
+  Scenario('Submitting a canonical PNCP contract ID navigates to the contract page', ({ Given, When, Then }) => {
     let assign: ReturnType<typeof vi.fn>;
 
     Given('the user types "12345678000195-1-000001/2024" into the search box', async () => {
@@ -203,6 +182,42 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
 
     Then('the browser should navigate to "/baliza/contratacao?id=12345678000195-1-000001/2024"', () => {
       expect(assign).toHaveBeenCalledWith('/baliza/contratacao?id=12345678000195-1-000001/2024');
+    });
+  });
+
+  Scenario('Reject PNCP ID with missing year segment', ({ Given, Then }) => {
+    Given('the user types "12345678000195-1-000001" into the search box', async () => {
+      render(SearchHero);
+      await tick();
+      await typeInSearch('12345678000195-1-000001');
+    });
+
+    Then('I should not see any jump suggestion', () => {
+      expect(screen.queryByText(/Ver Contratação/)).toBeNull();
+    });
+  });
+
+  Scenario('Reject PNCP ID with 3-digit year', ({ Given, Then }) => {
+    Given('the user types "12345678000195-1-000001/202" into the search box', async () => {
+      render(SearchHero);
+      await tick();
+      await typeInSearch('12345678000195-1-000001/202');
+    });
+
+    Then('I should not see any jump suggestion', () => {
+      expect(screen.queryByText(/Ver Contratação/)).toBeNull();
+    });
+  });
+
+  Scenario('Reject hyphen-only PNCP ID', ({ Given, Then }) => {
+    Given('the user types "12345678000195-1-000001-1" into the search box', async () => {
+      render(SearchHero);
+      await tick();
+      await typeInSearch('12345678000195-1-000001-1');
+    });
+
+    Then('I should not see any jump suggestion', () => {
+      expect(screen.queryByText(/Ver Contratação/)).toBeNull();
     });
   });
 

--- a/web/src/components/__steps__/shared.ts
+++ b/web/src/components/__steps__/shared.ts
@@ -25,9 +25,15 @@ vi.mock('../../lib/ia-manifest', () => ({
   IA_MANIFEST_URL: 'https://archive.org/download/baliza-pncp-manifest/manifest.csv',
 }));
 
-vi.mock('../../lib/parquetFallback', () => ({
-  queryParquetFallback: vi.fn().mockResolvedValue(null),
-}));
+vi.mock('../../lib/parquetFallback', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/parquetFallback')>(
+    '../../lib/parquetFallback',
+  );
+  return {
+    ...actual,
+    queryParquetFallback: vi.fn().mockResolvedValue({ ok: false, reason: 'empty' }),
+  };
+});
 
 export function render(
   component: Parameters<typeof tlRender>[0],

--- a/web/src/lib/archive/schema.ts
+++ b/web/src/lib/archive/schema.ts
@@ -1,0 +1,128 @@
+// Typed mirror of the parquet schemas declared in
+// src/baliza/daily_exporter.py. When the Python schema changes, update these
+// interfaces too — they are the source of truth for the archive fallback layer.
+
+export interface ArchivedContrato {
+  // Identity
+  numero_controle_pncp: string;
+  numero_controle_pncp_compra: string | null;
+  ano_contrato: number | null;
+  sequencial_contrato: number | null;
+  ano_compra: number | null;
+  sequencial_compra: number | null;
+  numero_contrato_empenho: string | null;
+  numero_retificacao: number | null;
+  processo: string | null;
+
+  // Órgão contratante
+  cnpj_orgao: string;
+  razao_social_orgao: string | null;
+  poder_id: string | null;
+  esfera_id: string | null;
+  codigo_unidade: string | null;
+  nome_unidade: string | null;
+  uf_sigla: string | null;
+  uf_nome: string | null;
+  municipio_nome: string | null;
+  codigo_ibge: string | null;
+
+  // Órgão sub-rogado
+  cnpj_orgao_subrogado: string | null;
+  razao_social_orgao_subrogado: string | null;
+  codigo_unidade_subrogada: string | null;
+  nome_unidade_subrogada: string | null;
+  uf_sigla_subrogada: string | null;
+
+  // Fornecedor
+  ni_fornecedor: string | null;
+  tipo_pessoa: string | null;
+  nome_razao_social_fornecedor: string | null;
+  codigo_pais_fornecedor: string | null;
+  ni_fornecedor_subcontratado: string | null;
+  nome_fornecedor_subcontratado: string | null;
+  tipo_pessoa_subcontratada: string | null;
+
+  // Classification
+  modalidade_id: number | null;
+  modalidade_nome: string | null;
+  tipo_contrato_id: number | null;
+  tipo_contrato_nome: string | null;
+  categoria_processo_id: number | null;
+  categoria_processo_nome: string | null;
+  receita: boolean | null;
+
+  // Financial
+  valor_inicial: number | null;
+  valor_parcela: number | null;
+  valor_global: number | null;
+  valor_acumulado: number | null;
+  numero_parcelas: number | null;
+
+  // Dates (ISO strings as read back from DuckDB)
+  data_publicacao: string | null;
+  data_publicacao_pncp: string | null;
+  data_assinatura: string | null;
+  data_vigencia_inicio: string | null;
+  data_vigencia_fim: string | null;
+  data_inclusao: string | null;
+  data_atualizacao: string | null;
+  data_atualizacao_global: string | null;
+
+  // Text / links
+  objeto_contrato: string | null;
+  informacao_complementar: string | null;
+  link_sistema_origem: string | null;
+  identificador_cipi: string | null;
+  url_cipi: string | null;
+
+  // Audit + pipeline metadata
+  usuario_nome: string | null;
+  data_particao: string;
+}
+
+export interface ArchivedOrgao {
+  cnpj: string;
+  razao_social: string | null;
+  poder_id: string | null;
+  esfera_id: string | null;
+  contratos_no_dia: number | null;
+  valor_total_no_dia: number | null;
+}
+
+export interface ArchivedUnidade {
+  codigo_unidade: string;
+  cnpj_orgao: string;
+  nome_unidade: string | null;
+  uf_sigla: string | null;
+  municipio_nome: string | null;
+  codigo_ibge: string | null;
+  contratos_no_dia: number | null;
+}
+
+export interface ArchivedFornecedor {
+  ni_fornecedor: string;
+  tipo_pessoa: string | null;
+  nome_razao_social: string | null;
+  codigo_pais: string | null;
+  contratos_no_dia: number | null;
+  valor_total_no_dia: number | null;
+}
+
+// Closed set of tables served by the archive layer. New tables require a
+// schema interface above AND an entry here — we never accept caller-supplied
+// table names through a regex match.
+export const ARCHIVED_TABLES = [
+  'contratos',
+  'orgaos',
+  'unidades',
+  'fornecedores',
+] as const;
+
+export type ArchivedTable = (typeof ARCHIVED_TABLES)[number];
+
+export interface ArchivedTableRowMap {
+  contratos: ArchivedContrato;
+  orgaos: ArchivedOrgao;
+  unidades: ArchivedUnidade;
+  fornecedores: ArchivedFornecedor;
+}

--- a/web/src/lib/ia-manifest.ts
+++ b/web/src/lib/ia-manifest.ts
@@ -1,4 +1,5 @@
 import Papa from 'papaparse';
+import type { ArchivedTable } from './archive/schema';
 
 export const IA_MANIFEST_URL =
   'https://archive.org/download/baliza-pncp-manifest/manifest.csv';
@@ -14,24 +15,32 @@ export interface ParquetInfo {
   dataParticao: string | null;
 }
 
-let cached: Promise<ParquetInfo | null> | null = null;
+const cachedByTable = new Map<ArchivedTable, Promise<ParquetInfo | null>>();
 
 export function resetIaManifestCache() {
-  cached = null;
+  cachedByTable.clear();
 }
 
-export async function getLatestParquetInfo(): Promise<ParquetInfo | null> {
-  if (cached) return cached;
-  cached = (async () => {
+async function fetchManifestRows(): Promise<ManifestRow[]> {
+  const res = await fetch(IA_MANIFEST_URL);
+  if (!res.ok) return [];
+  const parsed = Papa.parse<ManifestRow>(await res.text(), {
+    header: true,
+    skipEmptyLines: true,
+  });
+  return parsed.data ?? [];
+}
+
+export async function getLatestParquetInfo(
+  tableName: ArchivedTable = 'contratos',
+): Promise<ParquetInfo | null> {
+  const hit = cachedByTable.get(tableName);
+  if (hit) return hit;
+
+  const promise = (async () => {
     try {
-      const res = await fetch(IA_MANIFEST_URL);
-      if (!res.ok) return null;
-      const parsed = Papa.parse<ManifestRow>(await res.text(), {
-        header: true,
-        skipEmptyLines: true,
-      });
-      const rows = (parsed.data ?? []).filter(
-        (r) => r.table_name === 'contratos' && r.parquet_url,
+      const rows = (await fetchManifestRows()).filter(
+        (r) => r.table_name === tableName && r.parquet_url,
       );
       if (rows.length === 0) return null;
       rows.sort((a, b) =>
@@ -45,12 +54,16 @@ export async function getLatestParquetInfo(): Promise<ParquetInfo | null> {
       return null;
     }
   })();
-  const result = await cached;
-  if (result === null) cached = null;
+  cachedByTable.set(tableName, promise);
+
+  const result = await promise;
+  if (result === null) cachedByTable.delete(tableName);
   return result;
 }
 
-export async function getLatestParquetUrl(): Promise<string | null> {
-  const info = await getLatestParquetInfo();
+export async function getLatestParquetUrl(
+  tableName: ArchivedTable = 'contratos',
+): Promise<string | null> {
+  const info = await getLatestParquetInfo(tableName);
   return info?.url ?? null;
 }

--- a/web/src/lib/parquetFallback.ts
+++ b/web/src/lib/parquetFallback.ts
@@ -1,10 +1,16 @@
 import { getDuckDB } from './duckdb';
 import { getLatestParquetInfo } from './ia-manifest';
+import type { ArchivedContrato } from './archive/schema';
 
-export interface ParquetFallback<T> {
-  rows: T[];
-  dataParticao: string | null;
-}
+export type ArchiveFailureReason =
+  | 'no_manifest'
+  | 'duckdb_init_failed'
+  | 'sql_error'
+  | 'empty';
+
+export type ArchiveResult<T> =
+  | { ok: true; rows: T[]; dataParticao: string | null }
+  | { ok: false; reason: ArchiveFailureReason };
 
 // Matches a safe SQL identifier — letters, digits, underscores. Prevents any
 // caller-supplied column name from smuggling SQL via string interpolation.
@@ -14,31 +20,55 @@ function escapeSqlLiteral(value: string): string {
   return value.replace(/'/g, "''");
 }
 
-export async function queryParquetFallback<T = Record<string, unknown>>(
+export function archiveErrorMessage(reason: ArchiveFailureReason): string {
+  switch (reason) {
+    case 'no_manifest':
+      return 'Arquivo histórico indisponível — manifesto do Internet Archive não pôde ser carregado.';
+    case 'duckdb_init_failed':
+      return 'Arquivo histórico indisponível — motor de consulta local não inicializou.';
+    case 'sql_error':
+      return 'Arquivo histórico indisponível — consulta ao parquet falhou.';
+    case 'empty':
+      return 'PNCP indisponível e arquivo histórico sem registro para este identificador.';
+  }
+}
+
+export async function queryParquetFallback<T = ArchivedContrato>(
   column: string,
   value: string,
   limit = 10,
   orderByColumn?: string,
-): Promise<ParquetFallback<T> | null> {
-  if (!SAFE_IDENT.test(column)) return null;
-  if (orderByColumn !== undefined && !SAFE_IDENT.test(orderByColumn)) return null;
+): Promise<ArchiveResult<T>> {
+  if (!SAFE_IDENT.test(column)) return { ok: false, reason: 'sql_error' };
+  if (orderByColumn !== undefined && !SAFE_IDENT.test(orderByColumn)) {
+    return { ok: false, reason: 'sql_error' };
+  }
+
   const info = await getLatestParquetInfo();
-  if (!info) return null;
+  if (!info) return { ok: false, reason: 'no_manifest' };
+
+  let conn;
+  try {
+    ({ conn } = await getDuckDB());
+  } catch {
+    return { ok: false, reason: 'duckdb_init_failed' };
+  }
+
   const safeUrl = escapeSqlLiteral(info.url);
   const safeValue = escapeSqlLiteral(value);
   const safeLimit = Math.max(1, Math.min(200, Math.floor(limit)));
   const orderBy = orderByColumn ? ` ORDER BY ${orderByColumn} DESC NULLS LAST` : '';
   const sql = `SELECT * FROM read_parquet('${safeUrl}') WHERE ${column} = '${safeValue}'${orderBy} LIMIT ${safeLimit}`;
+
   try {
-    const { conn } = await getDuckDB();
     const res = await conn.query(sql);
     const rows = res.toArray().map((r: unknown) => {
       const anyRow = r as { toJSON?: () => unknown };
       return (typeof anyRow.toJSON === 'function' ? anyRow.toJSON() : r) as T;
     });
-    if (rows.length === 0) return null;
-    return { rows, dataParticao: info.dataParticao };
+    if (rows.length === 0) return { ok: false, reason: 'empty' };
+    return { ok: true, rows, dataParticao: info.dataParticao };
   } catch {
-    return null;
+    return { ok: false, reason: 'sql_error' };
   }
 }

--- a/web/src/lib/parquetFallback.ts
+++ b/web/src/lib/parquetFallback.ts
@@ -1,6 +1,11 @@
 import { getDuckDB } from './duckdb';
 import { getLatestParquetInfo } from './ia-manifest';
-import type { ArchivedContrato } from './archive/schema';
+import {
+  ARCHIVED_TABLES,
+  type ArchivedContrato,
+  type ArchivedTable,
+  type ArchivedTableRowMap,
+} from './archive/schema';
 
 export type ArchiveFailureReason =
   | 'no_manifest'
@@ -12,12 +17,22 @@ export type ArchiveResult<T> =
   | { ok: true; rows: T[]; dataParticao: string | null }
   | { ok: false; reason: ArchiveFailureReason };
 
-// Matches a safe SQL identifier — letters, digits, underscores. Prevents any
-// caller-supplied column name from smuggling SQL via string interpolation.
+export interface QueryArchivedOpts {
+  limit?: number;
+  orderByColumn?: string;
+}
+
+// Matches a safe SQL identifier — letters, digits, underscores. Column names
+// still flow through this check; table names are matched against a closed
+// allow-list (ARCHIVED_TABLES) instead.
 const SAFE_IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 function escapeSqlLiteral(value: string): string {
   return value.replace(/'/g, "''");
+}
+
+function isArchivedTable(name: string): name is ArchivedTable {
+  return (ARCHIVED_TABLES as readonly string[]).includes(name);
 }
 
 export function archiveErrorMessage(reason: ArchiveFailureReason): string {
@@ -33,24 +48,55 @@ export function archiveErrorMessage(reason: ArchiveFailureReason): string {
   }
 }
 
-export async function queryParquetFallback<T = ArchivedContrato>(
+function logFallback(
+  table: ArchivedTable,
+  column: string,
+  outcome: 'ok' | ArchiveFailureReason,
+): void {
+  console.info('[archive] fallback engaged', { table, column, reason: outcome });
+}
+
+// Warm the manifest lookup and DuckDB runtime in parallel so that when a
+// detail view's PNCP fetch fails, the fallback can resolve without eating
+// the cold-start latency.
+export function prefetchArchive(
+  tableName: ArchivedTable = 'contratos',
+): void {
+  void getLatestParquetInfo(tableName).catch(() => null);
+  void getDuckDB().catch(() => null);
+}
+
+export async function queryArchivedTable<K extends ArchivedTable>(
+  table: K,
   column: string,
   value: string,
-  limit = 10,
-  orderByColumn?: string,
-): Promise<ArchiveResult<T>> {
-  if (!SAFE_IDENT.test(column)) return { ok: false, reason: 'sql_error' };
+  opts: QueryArchivedOpts = {},
+): Promise<ArchiveResult<ArchivedTableRowMap[K]>> {
+  if (!isArchivedTable(table)) {
+    logFallback(table as ArchivedTable, column, 'sql_error');
+    return { ok: false, reason: 'sql_error' };
+  }
+  if (!SAFE_IDENT.test(column)) {
+    logFallback(table, column, 'sql_error');
+    return { ok: false, reason: 'sql_error' };
+  }
+  const { limit = 10, orderByColumn } = opts;
   if (orderByColumn !== undefined && !SAFE_IDENT.test(orderByColumn)) {
+    logFallback(table, column, 'sql_error');
     return { ok: false, reason: 'sql_error' };
   }
 
-  const info = await getLatestParquetInfo();
-  if (!info) return { ok: false, reason: 'no_manifest' };
+  const info = await getLatestParquetInfo(table);
+  if (!info) {
+    logFallback(table, column, 'no_manifest');
+    return { ok: false, reason: 'no_manifest' };
+  }
 
   let conn;
   try {
     ({ conn } = await getDuckDB());
   } catch {
+    logFallback(table, column, 'duckdb_init_failed');
     return { ok: false, reason: 'duckdb_init_failed' };
   }
 
@@ -64,11 +110,52 @@ export async function queryParquetFallback<T = ArchivedContrato>(
     const res = await conn.query(sql);
     const rows = res.toArray().map((r: unknown) => {
       const anyRow = r as { toJSON?: () => unknown };
-      return (typeof anyRow.toJSON === 'function' ? anyRow.toJSON() : r) as T;
+      return (typeof anyRow.toJSON === 'function' ? anyRow.toJSON() : r) as ArchivedTableRowMap[K];
     });
-    if (rows.length === 0) return { ok: false, reason: 'empty' };
+    if (rows.length === 0) {
+      logFallback(table, column, 'empty');
+      return { ok: false, reason: 'empty' };
+    }
+    logFallback(table, column, 'ok');
     return { ok: true, rows, dataParticao: info.dataParticao };
   } catch {
+    logFallback(table, column, 'sql_error');
     return { ok: false, reason: 'sql_error' };
   }
+}
+
+export function queryParquetFallback<T = ArchivedContrato>(
+  column: string,
+  value: string,
+  limit = 10,
+  orderByColumn?: string,
+): Promise<ArchiveResult<T>> {
+  return queryArchivedTable('contratos', column, value, {
+    limit,
+    orderByColumn,
+  }) as Promise<ArchiveResult<T>>;
+}
+
+export function queryArchivedOrgaos(
+  column: string,
+  value: string,
+  opts: QueryArchivedOpts = {},
+) {
+  return queryArchivedTable('orgaos', column, value, opts);
+}
+
+export function queryArchivedUnidades(
+  column: string,
+  value: string,
+  opts: QueryArchivedOpts = {},
+) {
+  return queryArchivedTable('unidades', column, value, opts);
+}
+
+export function queryArchivedFornecedores(
+  column: string,
+  value: string,
+  opts: QueryArchivedOpts = {},
+) {
+  return queryArchivedTable('fornecedores', column, value, opts);
 }

--- a/web/src/lib/pncpId.ts
+++ b/web/src/lib/pncpId.ts
@@ -1,0 +1,23 @@
+// PNCP's canonical `numeroControlePNCP` format: {cnpj}-{tipo}-{sequencial}/{ano}
+// where cnpj is 14 digits, sequencial is 6 digits, and ano is 4 digits.
+// Anything else is rejected at the boundary — no hyphen-only or short-year fallback.
+const CANONICAL_PNCP_ID = /^(\d{14})-(\d+)-(\d{6})\/(\d{4})$/;
+
+export interface PncpId {
+  cnpj: string;
+  tipo: string;
+  sequencial: string;
+  ano: string;
+}
+
+export function parsePncpId(raw: string): PncpId | null {
+  const m = CANONICAL_PNCP_ID.exec(raw);
+  if (!m) return null;
+  return { cnpj: m[1], tipo: m[2], sequencial: m[3], ano: m[4] };
+}
+
+export function isPncpId(raw: string): boolean {
+  return CANONICAL_PNCP_ID.test(raw);
+}
+
+export const PNCP_ID_EXAMPLE = '00000000000000-1-000001/2024';


### PR DESCRIPTION
## Summary
This PR introduces strict parsing of PNCP contract IDs to enforce the canonical format `{cnpj}-{tipo}-{sequencial}/{ano}`, and significantly hardens the archive fallback layer with discriminated error reasons, per-table manifest caching, and prefetch optimization.

## Key Changes

### PNCP ID Parsing
- Added `pncpId.ts` with strict canonical format validation using regex `/^(\d{14})-(\d+)-(\d{6})\/(\d{4})$/`
- Rejects hyphen-only IDs (e.g., `...-1-000001-1`), missing year segments, and non-4-digit years
- Integrated into `SearchHero.svelte` to only suggest navigation for valid canonical IDs
- Updated `ContractDetailView.svelte` to detect and display a targeted error for non-canonical IDs with format hint

### Archive Fallback Hardening
- Replaced `queryParquetFallback` with new `queryArchivedTable<K>` generic function that returns discriminated `ArchiveResult<T>` type:
  - `{ ok: true; rows: T[]; dataParticao: string | null }` on success
  - `{ ok: false; reason: ArchiveFailureReason }` on failure with specific reason: `'no_manifest'`, `'duckdb_init_failed'`, `'sql_error'`, or `'empty'`
- Added `archiveErrorMessage()` helper to map failure reasons to user-facing Portuguese messages
- Implemented `prefetchArchive()` to warm manifest and DuckDB in parallel before queries run, eliminating cold-start latency on detail views

### Schema & Type Safety
- Created `archive/schema.ts` with typed interfaces for all archived tables:
  - `ArchivedContrato`, `ArchivedOrgao`, `ArchivedUnidade`, `ArchivedFornecedor`
  - Closed `ARCHIVED_TABLES` allow-list prevents caller-supplied table names from bypassing validation
  - `ArchivedTableRowMap` provides type-safe row mapping per table
- Updated detail views (`ContractDetailView`, `AgencyDetailView`, `CityDetailView`) to use typed `ArchivedContrato` instead of generic `Record<string, unknown>`

### Manifest Caching
- Changed `ia-manifest.ts` from single global cache to per-table cache using `Map<ArchivedTable, Promise<ParquetInfo | null>>`
- Enables independent manifest fetches for different tables while respecting per-table Promise cache (measurable in `prefetchArchive` tests)
- Added `resetIaManifestCache()` export for test isolation

### Testing
- Added comprehensive BDD test suite `archive-fallback.steps.ts` exercising real `queryArchivedTable` implementation (not mocked) with controlled DuckDB and fetch stubs
- Added `pncp-id.steps.ts` validating canonical ID parsing and non-canonical error handling in `ContractDetailView`
- Updated existing detail view fallback tests to expect discriminated `ArchiveResult` type
- Updated search hero tests to reflect canonical ID format requirement

### Implementation Details
- Limit clamping: requests above 200 rows are silently clamped to 200 (enforced in SQL)
- Unknown tables rejected immediately without touching manifest or DuckDB
- All failure paths logged via `logFallback()` for observability
- Detail views call `prefetchArchive()` in `$effect` when ID/CNPJ/IBGE becomes available
- `queryParquetFallback()` retained as backward-compatible wrapper around `queryArchivedTable('contratos', ...)`

https://claude.ai/code/session_01Xvufa1da1jVQW21iJMG1Pw