### PR TITLE
Add theme toggle component with persistence and accessibility

### DIFF
--- a/web/features/README.md
+++ b/web/features/README.md
@@ -32,9 +32,11 @@ All commands run from `web/`.
 
 Tag filtering is driven by the standard `VITEST_INCLUDE_TAGS` and
 `VITEST_EXCLUDE_TAGS` environment variables, plus the default
-`excludeTags: ['wip', 'planned']` configured in `web/vitest.setup.ts`.
-Setting either env var overrides the default (pass `ignore` as the
-exclude to effectively disable the default exclusion).
+`excludeTags: ['planned', 'wip']` configured in `web/vitest.setup.ts`.
+Setting `VITEST_INCLUDE_TAGS` drops matching tags from the default
+exclusion, so `npm run test:bdd:wip` actually exercises `@wip` scenarios.
+Pass `VITEST_EXCLUDE_TAGS=ignore` to effectively disable the default
+exclusion entirely.
 
 ### Tag conventions
 

--- a/web/package.json
+++ b/web/package.json
@@ -13,8 +13,8 @@
     "test:watch": "vitest",
     "test:bdd": "vitest run",
     "test:bdd:journeys": "vitest run src/components/__steps__/journeys",
-    "test:bdd:green": "VITEST_INCLUDE_TAGS=green VITEST_EXCLUDE_TAGS=ignore vitest run",
-    "test:bdd:wip": "VITEST_INCLUDE_TAGS=wip VITEST_EXCLUDE_TAGS=ignore vitest run",
+    "test:bdd:green": "VITEST_INCLUDE_TAGS=green vitest run",
+    "test:bdd:wip": "VITEST_INCLUDE_TAGS=wip vitest run",
     "test:bdd:planned": "VITEST_INCLUDE_TAGS=planned VITEST_EXCLUDE_TAGS=ignore vitest run",
     "test:bdd:report": "node scripts/bdd-report.mjs"
   },


### PR DESCRIPTION
## Summary
Implements a theme toggle component with localStorage persistence, system preference detection, and full keyboard accessibility. Also refines global typography and shadow design tokens for consistency.

## Key Changes

### Theme Toggle Component
- **New `ThemeToggle.svelte`**: Interactive button component that toggles between light/dark themes
  - Persists user preference to localStorage (`baliza-theme` key)
  - Gracefully handles localStorage unavailability (private mode)
  - Displays Sun/Moon icons from lucide-svelte
  - Fully accessible with `aria-pressed` and `aria-label` attributes
  - Styled with hover/focus states following shadow doctrine (shadows only on interaction)

- **New BDD test suite (`theme-toggle.steps.ts`)**: Comprehensive Cucumber-style tests covering:
  - Theme persistence across page reloads
  - System preference detection (`prefers-color-scheme`)
  - Keyboard operability (Enter key support)
  - ARIA state reflection

### Layout & Navigation Updates
- **Layout.astro**: Enhanced FOUC-prevention script to respect `prefers-color-scheme: light` when no stored preference exists
- **Navigation.astro**: Integrated ThemeToggle component into header

### Typography & Design Token Refinements
- **global.css**: 
  - Added `--font-size-md` (1.125rem) as canonical subheading size
  - Introduced `.page-deck` utility class for consistent page descriptions
  - Documented typography scale (Major Third ratio) and shadow doctrine
  - Fixed badge contrast issues: warning badge now uses base-content text in light theme; error badge reduced to 5% mix for AA compliance in dark theme

- **Component updates**: Standardized secondary text sizing across pages/components to use `--font-size-md` with `line-height: 1.6`
  - ProjectAnatomy.astro, status.astro, SearchHero.svelte, sobre.astro, explorador.astro

### Shadow Doctrine Implementation
- Removed static box-shadows from resting states (EntityNotFound.svelte, ProjectAnatomy.astro, SearchHero.svelte)
- Shadows now appear only on `:hover` and `:focus-visible` states via `var(--transition-base)`

## Implementation Details
- Theme state is read synchronously from `data-theme` attribute set by inline script to prevent flash of unstyled content (FOUC)
- Component uses Svelte 5 runes (`$state`) for reactive theme tracking
- localStorage operations wrapped in try-catch for robustness
- Test mocks Storage API and matchMedia for deterministic BDD scenarios

https://claude.ai/code/session_015aUtasXyWDetjZqLyJYnbD