### PR TITLE
Add developer portal and journey-based homepage navigation

### DIFF
--- a/web/features/journeys/03_investigative_journalist.feature
+++ b/web/features/journeys/03_investigative_journalist.feature
@@ -24,9 +24,9 @@ Feature: Journey 3 — Investigative journalist
     Then the page URL contains "?q=hospital%20municipal"
     And reloading the page restores the same result list
 
-  @planned @export
+  @green @export
   Scenario: Export a result list as Markdown
-    # Planned: only CSV export exists, in the explorer.
+    # Covered by SearchHero data-testid="export-markdown" → clipboard GFM table.
     Given a search result list is visible for "hospital municipal"
     When the user clicks "Exportar Markdown"
     Then the clipboard contains a Markdown table with headers and rows

--- a/web/features/journeys/03_investigative_journalist.feature
+++ b/web/features/journeys/03_investigative_journalist.feature
@@ -41,7 +41,7 @@ Feature: Journey 3 — Investigative journalist
   @green @permalink
   Scenario: Crossover with journey 7 — journalist subscribes to a saved query
     # crosses @journey7
-    # Covered by SearchHero "Acompanhar esta busca" button → /alertas/<slug>.xml offer.
+    # Covered by SearchHero "Salvar vigilância" button → /alertas/<slug>.xml offer.
     Given a search result list is visible for "hospital municipal"
-    When the user clicks "Acompanhar esta busca"
+    When the user clicks "Salvar vigilância"
     Then the user is offered an RSS URL for new matches

--- a/web/features/journeys/04_informed_citizen.feature
+++ b/web/features/journeys/04_informed_citizen.feature
@@ -19,9 +19,9 @@ Feature: Journey 4 — Informed citizen
     When the user hovers the term "Dispensa"
     Then the user sees a tooltip explaining what a "Dispensa" is in plain language
 
-  @planned @plain-language
+  @green @plain-language
   Scenario: Detail page renders a plain-language summary above the schema dump
-    # Planned: plain-language summary is not generated today.
+    # Covered by ContractDetailView data-testid="plain-language-summary".
     Given the user opens "/contratacao?id=00000000000191-1-000001/2024"
     Then the user sees a one-paragraph summary that names the buyer, supplier, value and what was bought
 

--- a/web/features/journeys/05_academic_researcher.feature
+++ b/web/features/journeys/05_academic_researcher.feature
@@ -25,9 +25,9 @@ Feature: Journey 5 — Academic researcher
     Given the user opens "/schema/changelog"
     Then the user sees a reverse-chronological list of column additions, removals and renames
 
-  @planned @citation
+  @green @citation
   Scenario: Generate a citable reference block for the current snapshot
-    # Planned: citation generator does not exist.
+    # Covered by CitationBlock on /sobre (data-testid=open-citation, bibtex-block, citation-meta).
     Given the user opens "/sobre"
     When the user clicks "Gerar citação acadêmica"
     Then a BibTeX block is rendered with the snapshot date and Internet Archive item URL

--- a/web/features/journeys/07_auditor_watchdog.feature
+++ b/web/features/journeys/07_auditor_watchdog.feature
@@ -5,9 +5,9 @@ Feature: Journey 7 — Auditor and watchdog
   CNPJ, exemptions above a value threshold, anomalies in a state.
   See VISION.md → "Auditor / watchdog".
 
-  @planned @alerts
+  @green @alerts
   Scenario: Save the current query as a watch in localStorage
-    # Planned: no watch persistence today.
+    # Covered by SearchHero "Salvar vigilância" → baliza.watches key + WatchList.
     Given a search result list is visible for "dispensa acima de 1 milhão"
     When the user clicks "Salvar vigilância"
     Then a watch entry is persisted in localStorage
@@ -36,9 +36,9 @@ Feature: Journey 7 — Auditor and watchdog
     When the user opens the watch again
     Then the user sees a "novidades desde sua última visita" section listing only new matches
 
-  @planned @alerts
+  @green @alerts
   Scenario: Subscribe to a CNPJ from its agency or supplier page
-    # Planned: per-CNPJ subscription entry point does not exist.
+    # Covered by AgencyDetailView data-testid="subscribe-agency" → saveWatch kind=cnpj-agency.
     Given the user opens "/orgao?cnpj=00000000000191"
     When the user clicks "Receber alertas deste órgão"
     Then a watch is created with the agency CNPJ as the filter

--- a/web/scripts/check-bundle-size.mjs
+++ b/web/scripts/check-bundle-size.mjs
@@ -22,7 +22,11 @@ const DIST_DIR = join(__dirname, '..', 'dist', '_astro');
 // what landed.
 // 2026-04: raised to 285_000 for the SupplierDetailView (+6.7 KB) — adds the
 // /fornecedor?cnpj= supplier prospecting page (Journey 1 @green).
-const BUDGET_BYTES = 285_000;
+// 2026-04: raised to 295_000 for the Journey 3/5/7 shipments — SearchHero
+// Markdown export, CitationBlock (BibTeX on /sobre), WatchList ("Minhas
+// vigilâncias"), watches.ts shared persistence, and the subscribe-from-
+// agency button on AgencyDetailView. Net +4.2 KB across the entry payload.
+const BUDGET_BYTES = 295_000;
 
 function isClientEntryFile(name) {
   if (!name.endsWith('.js')) return false;

--- a/web/src/components/AgencyDetailView.svelte
+++ b/web/src/components/AgencyDetailView.svelte
@@ -13,6 +13,7 @@
   import EmptyState from './EmptyState.svelte';
   import LookbackWindow from './LookbackWindow.svelte';
   import { DEFAULT_SINCE_DAYS } from '../lib/pncpPublicacao';
+  import { saveWatch, watchExists, slugify } from '../lib/watches';
 
   setQueryClientContext(getQueryClient());
 
@@ -192,6 +193,25 @@
   const maxMonthly = $derived(
     data ? Math.max(1, ...data.monthly.map((m) => m.count)) : 1,
   );
+
+  // J7 "subscribe-from-agency" — watchExists is localStorage-backed, so it
+  // needs an effect (not $derived) to resync after the click mutates storage
+  // in this same tab. Cross-tab sync flows through WatchList's storage event.
+  let subscribed = $state(false);
+  $effect(() => {
+    if (data?.cnpj) subscribed = watchExists(slugify(`agency-${data.cnpj}`));
+  });
+
+  function subscribeAgency() {
+    if (!data?.cnpj) return;
+    saveWatch({
+      kind: 'cnpj-agency',
+      cnpj: data.cnpj,
+      label: data.name,
+      slug: slugify(`agency-${data.cnpj}`),
+    });
+    subscribed = true;
+  }
 </script>
 
 <div class="agency-detail container">
@@ -226,6 +246,17 @@
       <div class="meta-row">
         <span>CNPJ: {data.cnpj}</span>
         <span>Fonte: {data.archived ? 'Arquivo Parquet (IA)' : 'PNCP V1'}</span>
+      </div>
+      <div class="hub-actions">
+        <button
+          type="button"
+          class="btn btn-outline btn-sm"
+          data-testid="subscribe-agency"
+          aria-pressed={subscribed}
+          onclick={subscribeAgency}
+        >
+          {subscribed ? 'Vigilância ativa ✓' : 'Receber alertas deste órgão'}
+        </button>
       </div>
     </header>
 
@@ -313,6 +344,7 @@
   .type-badge { font-family: var(--font-mono); font-size: 0.7rem; background: var(--color-primary); color: white; padding: 2px 8px; border-radius: 4px; }
   h1 { font-size: var(--font-size-2xl); margin-top: var(--space-sm); }
   .meta-row { display: flex; gap: var(--space-md); color: var(--color-secondary); font-size: var(--font-size-sm); margin-top: 4px; }
+  .hub-actions { display: flex; gap: var(--space-sm); margin-top: var(--space-sm); }
 
   .rollup-grid {
     display: grid;

--- a/web/src/components/CitationBlock.svelte
+++ b/web/src/components/CitationBlock.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { getLatestParquetUrl, getLatestParquetInfo } from '../lib/ia-manifest';
+
+  let snapshotDate = $state<string | null>(null);
+  let archiveUrl = $state<string | null>(null);
+  let loading = $state(true);
+  let visible = $state(false);
+  let copied = $state(false);
+
+  onMount(async () => {
+    try {
+      const info = await getLatestParquetInfo();
+      if (info) {
+        snapshotDate = info.dataParticao;
+        archiveUrl = info.url;
+      } else {
+        // Fallback: use whatever URL the explorer resolves for the default
+        // contratos table. The date may be absent from older manifests.
+        archiveUrl = await getLatestParquetUrl();
+      }
+    } catch {
+      archiveUrl = null;
+    } finally {
+      loading = false;
+    }
+  });
+
+  // BibTeX block the researcher pastes into their paper. Anchoring on the
+  // item URL (not the file URL) keeps the citation valid even if the
+  // specific Parquet partition gets rotated, since the IA item page lists
+  // every historical snapshot.
+  function buildBibtex(): string {
+    const year = snapshotDate ? snapshotDate.slice(0, 4) : new Date().getFullYear().toString();
+    const urlTarget = archiveUrl ?? 'https://franklinbaldo.github.io/baliza/';
+    const note = snapshotDate
+      ? `Snapshot de ${snapshotDate}`
+      : 'Snapshot mais recente disponível no Internet Archive';
+    return `@misc{baliza${year},
+  author       = {Baldo, Franklin},
+  title        = {Baliza: Arquivo p\\'ublico das contrata\\c{c}\\~oes nacionais brasileiras (PNCP)},
+  year         = {${year}},
+  howpublished = {\\url{${urlTarget}}},
+  note         = {${note}}
+}`;
+  }
+
+  const bibtex = $derived(buildBibtex());
+
+  async function copyBibtex() {
+    try {
+      await navigator.clipboard.writeText(bibtex);
+      copied = true;
+      setTimeout(() => {
+        copied = false;
+      }, 2500);
+    } catch {
+      // Clipboard blocked — the pre block is already visible; user can
+      // manually select and copy.
+    }
+  }
+</script>
+
+<section class="citation" aria-labelledby="citation-title">
+  <h2 id="citation-title">Como citar academicamente</h2>
+  <p>
+    Gere um bloco BibTeX ancorado no snapshot Parquet mais recente do Internet Archive.
+    O URL do item permanece estável mesmo quando novas partições são adicionadas.
+  </p>
+
+  {#if !visible}
+    <button
+      type="button"
+      class="btn btn-outline"
+      data-testid="open-citation"
+      onclick={() => { visible = true; }}
+      disabled={loading}
+    >
+      {loading ? 'Carregando snapshot…' : 'Gerar citação acadêmica'}
+    </button>
+  {:else}
+    <div class="citation-meta" data-testid="citation-meta">
+      {#if snapshotDate}
+        Snapshot: <code>{snapshotDate}</code>
+      {:else}
+        Snapshot: <em>não identificado no manifesto — verifique o /status</em>
+      {/if}
+      {#if archiveUrl}
+        <span class="sep">·</span>
+        <a href={archiveUrl} target="_blank" rel="noopener" class="ia-link">Arquivo no Internet Archive</a>
+      {/if}
+    </div>
+    <pre class="bibtex" data-testid="bibtex-block"><code>{bibtex}</code></pre>
+    <button
+      type="button"
+      class="btn btn-outline btn-sm"
+      data-testid="copy-bibtex"
+      onclick={copyBibtex}
+    >
+      {copied ? 'Copiado ✓' : 'Copiar BibTeX'}
+    </button>
+  {/if}
+</section>
+
+<style>
+  .citation {
+    margin-top: var(--space-xl);
+    padding: var(--space-md);
+    background: var(--color-base-200);
+    border-left: 4px solid var(--color-primary);
+    border-radius: var(--radius-box);
+  }
+  .citation h2 {
+    margin: 0 0 var(--space-sm);
+    font-size: var(--font-size-xl);
+  }
+  .citation p {
+    color: var(--color-secondary);
+    line-height: 1.6;
+    margin-bottom: var(--space-sm);
+  }
+  .citation-meta {
+    font-size: var(--font-size-sm);
+    color: var(--color-secondary);
+    margin-bottom: var(--space-sm);
+  }
+  .sep {
+    margin: 0 var(--space-xs);
+    opacity: 0.6;
+  }
+  .ia-link {
+    color: var(--color-primary);
+    font-family: var(--font-mono, monospace);
+    font-size: var(--font-size-xs);
+    word-break: break-all;
+  }
+  .bibtex {
+    background: var(--color-base-100);
+    border: 1px solid var(--color-base-300);
+    padding: var(--space-sm);
+    border-radius: var(--radius-sm);
+    overflow-x: auto;
+    font-family: var(--font-mono, monospace);
+    font-size: var(--font-size-xs);
+    line-height: 1.5;
+    margin-bottom: var(--space-sm);
+  }
+</style>

--- a/web/src/components/ContractDetailView.svelte
+++ b/web/src/components/ContractDetailView.svelte
@@ -211,6 +211,29 @@
           </span>
         {/if}
       </div>
+
+      {#snippet plainLanguageSummary()}
+        <p class="plain-summary" data-testid="plain-language-summary">
+          {#if data.orgaoEntidade?.razaoSocial}
+            <strong>{data.orgaoEntidade.razaoSocial}</strong>
+          {:else}
+            Um órgão público
+          {/if}
+          contratou
+          {#if data.supplierName || data.supplierCnpj}
+            <strong>{data.supplierName ?? data.supplierCnpj}</strong>
+          {:else}
+            um fornecedor (ainda não identificado no snapshot)
+          {/if}
+          {#if data.valorTotalEstimado}
+            pelo valor de <strong>{formatBRL(data.valorTotalEstimado)}</strong>
+          {:else}
+            com valor não informado
+          {/if}
+          para <strong>{data.objetoContratacao || 'um objeto não descrito'}</strong>{data.modalidadeNome ? `, via ${data.modalidadeNome}` : ''}.
+        </p>
+      {/snippet}
+      {@render plainLanguageSummary()}
     </header>
 
     <div class="grid-details">
@@ -378,6 +401,17 @@
   .back-row { display: flex; }
 
   .hub-header { margin-bottom: var(--space-2xl); border-bottom: 2px solid var(--color-base-300); padding-bottom: var(--space-md); }
+  .plain-summary {
+    margin-top: var(--space-md);
+    padding: var(--space-sm) var(--space-md);
+    background: var(--color-base-200);
+    border-left: 4px solid var(--color-primary);
+    border-radius: var(--radius-sm);
+    line-height: 1.6;
+    color: var(--color-base-content);
+    font-size: var(--font-size-md);
+  }
+  .plain-summary strong { color: var(--color-primary); }
   .type-badge { font-family: var(--font-mono); font-size: 0.7rem; background: var(--color-primary); color: white; padding: 2px 8px; border-radius: 4px; }
   h1 { font-size: var(--font-size-xl); margin-top: var(--space-sm); line-height: 1.3; }
   .meta-row { display: flex; gap: var(--space-md); color: var(--color-secondary); font-size: var(--font-size-sm); margin-top: 8px; flex-wrap: wrap; }

--- a/web/src/components/ContractDetailView.svelte
+++ b/web/src/components/ContractDetailView.svelte
@@ -225,7 +225,7 @@
           {:else}
             um fornecedor (ainda não identificado no snapshot)
           {/if}
-          {#if data.valorTotalEstimado}
+          {#if data.valorTotalEstimado != null}
             pelo valor de <strong>{formatBRL(data.valorTotalEstimado)}</strong>
           {:else}
             com valor não informado

--- a/web/src/components/Dashboard.svelte
+++ b/web/src/components/Dashboard.svelte
@@ -44,19 +44,20 @@
 {:else if stats}
   <div class="dashboard-grid">
     <StatCard
-      title="Contratos arquivados"
+      title="Contratos citáveis"
       value={formatInteger(stats.total_contracts)}
+      hint="cada um com permalink e snapshot imutável"
     />
     <StatCard
-      title="Dias de histórico preservados"
+      title="Dias no Internet Archive"
       value={formatInteger(stats.days_on_ia)}
-      hint={stats.generated_at ? `Atualizado ${formatRelativeTime(stats.generated_at)}` : undefined}
+      hint={stats.generated_at ? `Atualizado ${formatRelativeTime(stats.generated_at)}` : 'fora do alcance de qualquer servidor único'}
     />
     <StatCard
       title="Em quarentena"
       value={formatInteger(stats.total_quarantine)}
       tone="warning"
-      hint="O que é isso?"
+      hint="anomalias sinalizadas — entenda o critério"
       href="/baliza/sobre#quarentena"
     />
   </div>

--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -36,6 +36,18 @@
 
   const hasUnresolvedUrl = $derived(query.includes("'IA_URL'"));
 
+  // Embed mode: a third-party iframe passes ?sql=…&embed=true and expects the
+  // query to auto-execute once the Parquet URL resolves. We read the flag
+  // once on mount so a user toggling query strings later does not re-trigger.
+  const isEmbed = (() => {
+    if (typeof window === 'undefined') return false;
+    try {
+      return new URLSearchParams(window.location.search).get('embed') === 'true';
+    } catch {
+      return false;
+    }
+  })();
+
   onMount(async () => {
     resolvedParquetUrl = await getLatestParquetUrl();
     // Resolve every archived table's latest Parquet URL once. Each
@@ -45,6 +57,13 @@
       ARCHIVED_TABLES.map(async (t) => [t, await getLatestParquetUrl(t)] as const),
     );
     resolvedUrls = Object.fromEntries(entries) as Partial<Record<ArchivedTable, string | null>>;
+
+    if (isEmbed && !query.includes("'IA_URL'")) {
+      // Give the IA_URL $effect a tick to substitute; in embed mode the SQL
+      // was already URL-encoded by the embedding page so substitution is
+      // usually a no-op, but we still need to wait one microtask.
+      void runQuery();
+    }
   });
 
   $effect(() => {

--- a/web/src/components/JourneyPicker.astro
+++ b/web/src/components/JourneyPicker.astro
@@ -1,0 +1,124 @@
+---
+import { JOURNEYS } from '../lib/homepage-content';
+
+const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
+const resolveHref = (href: string) => {
+  if (href.startsWith('#')) return href;
+  return `${BASE}${href.replace(/^\//, '')}`;
+};
+
+const STATUS_LABEL: Record<'green' | 'wip' | 'planned', string> = {
+  green: 'Disponível',
+  wip: 'Parcial',
+  planned: 'Planejado',
+};
+---
+
+<section class="journeys-section" aria-labelledby="journeys-title">
+  <div class="container">
+    <div class="journeys-header">
+      <h2 id="journeys-title" class="section-title">Por onde começar?</h2>
+      <p class="section-desc">
+        O Baliza é construído primeiro para quem trabalha com licitação no dia a dia — fornecedores e compradores públicos. Quando resolvemos o caso exigente, as capacidades descem para jornalistas, pesquisadores e cidadãos. Escolha seu ponto de partida:
+      </p>
+    </div>
+
+    <ul class="journey-grid">
+      {JOURNEYS.map(j => (
+        <li class={`journey-card journey-${j.status}`}>
+          <a href={resolveHref(j.href)} class="journey-link">
+            <div class="journey-head">
+              <span class="journey-icon" aria-hidden="true">{j.icon}</span>
+              <span class={`journey-status status-${j.status}`}>{STATUS_LABEL[j.status]}</span>
+            </div>
+            <h3 class="journey-role">{j.role}</h3>
+            <p class="journey-question">"{j.question}"</p>
+          </a>
+        </li>
+      ))}
+    </ul>
+  </div>
+</section>
+
+<style>
+  .journeys-section {
+    padding: var(--space-2xl) 0;
+    background: var(--color-base-200);
+    border-top: 1px solid var(--color-base-300);
+    border-bottom: 1px solid var(--color-base-300);
+  }
+  .journeys-header {
+    max-width: 780px;
+    margin-bottom: var(--space-xl);
+  }
+  .section-title {
+    font-size: var(--font-size-2xl);
+    margin-bottom: var(--space-sm);
+    color: var(--color-primary);
+  }
+  .section-desc {
+    color: var(--color-secondary);
+    line-height: 1.6;
+    font-size: var(--font-size-md);
+  }
+  .journey-grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: var(--space-md);
+  }
+  .journey-card {
+    background: var(--color-base-100);
+    border: 1px solid var(--color-base-300);
+    border-radius: var(--radius-box);
+    transition: border-color var(--transition-base), transform var(--transition-base), box-shadow var(--transition-base);
+  }
+  .journey-card:hover {
+    border-color: var(--color-primary);
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-glow);
+  }
+  .journey-link {
+    display: block;
+    padding: var(--space-md);
+    text-decoration: none;
+    color: inherit;
+    height: 100%;
+  }
+  .journey-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--space-sm);
+  }
+  .journey-icon {
+    font-size: 1.6rem;
+  }
+  .journey-status {
+    font-family: var(--font-mono, monospace);
+    font-size: var(--font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.15rem 0.5rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid currentColor;
+  }
+  .status-green { color: #3ba776; }
+  .status-wip { color: #d1a400; }
+  .status-planned { color: var(--color-secondary); opacity: 0.85; }
+  .journey-role {
+    font-size: var(--font-size-lg);
+    font-weight: 700;
+    margin: 0 0 var(--space-xs);
+    color: var(--color-base-content);
+  }
+  .journey-question {
+    font-size: var(--font-size-sm);
+    line-height: 1.55;
+    color: var(--color-secondary);
+    font-style: italic;
+    margin: 0;
+  }
+</style>

--- a/web/src/components/Navigation.astro
+++ b/web/src/components/Navigation.astro
@@ -20,6 +20,7 @@ const isActive = (path: string) => {
     <ul class="nav-links">
       <li><a href={BASE} class={isActive(BASE) ? 'active' : ''} aria-current={isActive(BASE) ? 'page' : undefined}>Início</a></li>
       <li><a href={BASE + 'explorador'} class={isActive(BASE + 'explorador') ? 'active' : ''} aria-current={isActive(BASE + 'explorador') ? 'page' : undefined}>Explorador</a></li>
+      <li><a href={BASE + 'desenvolvedores'} class={isActive(BASE + 'desenvolvedores') ? 'active' : ''} aria-current={isActive(BASE + 'desenvolvedores') ? 'page' : undefined}>Desenvolvedores</a></li>
       <li><a href={BASE + 'status'} class={isActive(BASE + 'status') ? 'active' : ''} aria-current={isActive(BASE + 'status') ? 'page' : undefined}>Status</a></li>
       <li><a href={BASE + 'sobre'} class={isActive(BASE + 'sobre') ? 'active' : ''} aria-current={isActive(BASE + 'sobre') ? 'page' : undefined}>Sobre</a></li>
     </ul>

--- a/web/src/components/ProjectAnatomy.astro
+++ b/web/src/components/ProjectAnatomy.astro
@@ -6,9 +6,9 @@ import { HOW_IT_WORKS_CARDS } from '../lib/homepage-content';
   <div class="container">
     <div class="anatomy-grid">
       <div class="anatomy-intro">
-        <h2 class="section-title">Como garantimos a transparência?</h2>
+        <h2 class="section-title">Por que o Baliza existe</h2>
         <p class="section-desc">
-          O Baliza extrai e processa dados abertos de contratações, facilitando consultas locais ou no navegador.
+          O PNCP é o coração administrativo do Brasil — e um ponto único de falha. O Baliza é a camada arquivística e analítica acima dele: preservação primeiro, análise depois. Sem servidor em produção, sem banco central que pode ser desligado.
         </p>
       </div>
 

--- a/web/src/components/SearchHero.svelte
+++ b/web/src/components/SearchHero.svelte
@@ -5,6 +5,7 @@
   import { isPncpId, parsePncpId } from '../lib/pncpId';
   import { formatBRL, formatDate, normalizeSearchInput } from '../lib/format';
   import { suggestAccented } from '../lib/accentSuggest';
+  import { saveWatch, slugify as slugifyShared } from '../lib/watches';
   import EmptyState from './EmptyState.svelte';
   import AlertBanner from './AlertBanner.svelte';
 
@@ -81,16 +82,7 @@
   // the URL shape is part of the public contract (see VISION.md → "Auditor /
   // watchdog"); emitting it here lets journalists copy the future-proof link
   // before the feed exists.
-  function slugifyWatch(term: string): string {
-    return term
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '')
-      .slice(0, 64);
-  }
-
+  const slugifyWatch = slugifyShared;
   const watchSlug = $derived(slugifyWatch(lastSearchedTerm));
   const watchUrl = $derived(watchSlug ? `/baliza/alertas/${watchSlug}.xml` : '');
   let watchOffered = $state(false);
@@ -248,6 +240,72 @@
 
   function offerWatch() {
     watchOffered = true;
+    persistWatchForTerm(lastSearchedTerm);
+  }
+
+  // Persist a watch entry in localStorage via the shared `watches` module.
+  // The fuller alerting pipeline (RSS route, webhook dispatcher) is @planned,
+  // but the saved query itself is a local artifact that survives page reloads
+  // and feeds the "Minhas vigilâncias" list surfaced on the homepage.
+  function persistWatchForTerm(term: string) {
+    if (!term) return;
+    saveWatch({ label: term, kind: 'query', term, slug: slugifyWatch(term) });
+  }
+
+  // Markdown export is the journalist's counterpart to CSV: the clipboard
+  // payload is a ready-to-paste GFM table with one row per visible result.
+  function mdEscape(value: unknown): string {
+    const raw = value == null ? '' : String(value);
+    return raw.replace(/\|/g, '\\|').replace(/\n/g, ' ').trim();
+  }
+
+  function buildMarkdownTable(): string {
+    const headers = ['PNCP', 'Objeto', 'Órgão', 'UF', 'Modalidade', 'Data', 'Valor'];
+    const rows = filteredResults.map((r) =>
+      [
+        r.numero_controle_pncp
+          ? `[${r.numero_controle_pncp}](/baliza/contratacao?id=${r.numero_controle_pncp})`
+          : '',
+        mdEscape(r.description ?? r.title ?? ''),
+        mdEscape(r.orgao_nome ?? ''),
+        mdEscape(r.uf_sigla ?? ''),
+        mdEscape(r.modalidade_nome ?? ''),
+        mdEscape(formatDate(r.data_publicacao_pncp)),
+        mdEscape(formatBRL(r.valor_global)),
+      ].join(' | '),
+    );
+    const body = [
+      `| ${headers.join(' | ')} |`,
+      `| ${headers.map(() => '---').join(' | ')} |`,
+      ...rows.map((r) => `| ${r} |`),
+    ].join('\n');
+    return body;
+  }
+
+  let mdCopied = $state(false);
+  async function exportMarkdown() {
+    if (filteredResults.length === 0) return;
+    const md = buildMarkdownTable();
+    try {
+      await navigator.clipboard.writeText(md);
+      mdCopied = true;
+      setTimeout(() => {
+        mdCopied = false;
+      }, 2500);
+    } catch {
+      // Clipboard API may be blocked (insecure origin, permissions). Fall back
+      // to a download so the journalist can still paste the file contents.
+      const blob = new Blob([md], { type: 'text/markdown;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      const slug = slugifyWatch(lastSearchedTerm) || 'resultados';
+      a.href = url;
+      a.download = `baliza-busca-${slug}.md`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    }
   }
 
   // CSV export of the currently visible (filtered) result set. Columns mirror
@@ -403,6 +461,12 @@
               <button type="button" class="btn btn-outline btn-sm" onclick={exportCsv}>
                 Exportar CSV
               </button>
+              <button type="button" class="btn btn-outline btn-sm" data-testid="export-markdown" onclick={exportMarkdown}>
+                {mdCopied ? 'Markdown copiado ✓' : 'Exportar Markdown'}
+              </button>
+              <button type="button" class="btn btn-outline btn-sm" data-testid="save-watch" onclick={offerWatch}>
+                Salvar vigilância
+              </button>
               <button type="button" class="btn btn-outline btn-sm" onclick={offerWatch}>
                 Acompanhar esta busca
               </button>
@@ -410,8 +474,9 @@
           </div>
           {#if watchOffered && watchUrl}
             <div class="watch-offer" role="status" aria-live="polite" data-testid="watch-offer">
-              RSS disponível em
+              Vigilância salva. RSS disponível em
               <code class="watch-url">{watchUrl}</code>
+              <span class="watch-hint">(alimentado no futuro pela extração diária)</span>
             </div>
           {/if}
           <ul class="results-list" role="listbox" aria-label="Resultados da busca PNCP">

--- a/web/src/components/SearchHero.svelte
+++ b/web/src/components/SearchHero.svelte
@@ -354,7 +354,7 @@
   }
 </script>
 
-<section class="hero-section">
+<section class="hero-section" id="busca">
   <div class="container hero-inner">
     <h1 class="hero-title">{PROJECT_MISSION.title}</h1>
     <p class="hero-tagline">{PROJECT_MISSION.tagline}</p>
@@ -466,9 +466,6 @@
               </button>
               <button type="button" class="btn btn-outline btn-sm" data-testid="save-watch" onclick={offerWatch}>
                 Salvar vigilância
-              </button>
-              <button type="button" class="btn btn-outline btn-sm" onclick={offerWatch}>
-                Acompanhar esta busca
               </button>
             </div>
           </div>

--- a/web/src/components/WatchList.svelte
+++ b/web/src/components/WatchList.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { readWatches, removeWatch, type Watch } from '../lib/watches';
+
+  let watches = $state<Watch[]>([]);
+  let mounted = $state(false);
+
+  function refresh() {
+    watches = readWatches();
+  }
+
+  onMount(() => {
+    mounted = true;
+    refresh();
+    // Cross-tab sync: another tab saving a watch should update this list
+    // without requiring a full reload.
+    const onStorage = (ev: StorageEvent) => {
+      if (ev.key === 'baliza.watches') refresh();
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  });
+
+  function drop(slug: string) {
+    removeWatch(slug);
+    refresh();
+  }
+
+  function hrefFor(w: Watch): string {
+    if (w.kind === 'query' && w.term) {
+      return `/baliza/?q=${encodeURIComponent(w.term)}`;
+    }
+    if (w.kind === 'cnpj-agency' && w.cnpj) {
+      return `/baliza/orgao?cnpj=${w.cnpj}`;
+    }
+    if (w.kind === 'cnpj-supplier' && w.cnpj) {
+      return `/baliza/fornecedor?cnpj=${w.cnpj}`;
+    }
+    return '/baliza/';
+  }
+
+  function feedFor(w: Watch): string {
+    return `/baliza/alertas/${w.slug}.xml`;
+  }
+</script>
+
+{#if mounted && watches.length > 0}
+  <section class="watchlist" aria-labelledby="watchlist-title" data-testid="my-watches">
+    <div class="container">
+      <div class="watchlist-head">
+        <h2 id="watchlist-title">Minhas vigilâncias</h2>
+        <p>
+          Consultas salvas localmente neste navegador. Quando o feed RSS estiver disponível, cada vigilância terá novidades publicadas em <code>/alertas/{'{slug}'}.xml</code>.
+        </p>
+      </div>
+      <ul class="watch-items">
+        {#each watches as w (w.slug)}
+          <li class="watch-item" data-testid={`watch-item-${w.slug}`}>
+            <div class="watch-main">
+              <a href={hrefFor(w)} class="watch-label">{w.label}</a>
+              <span class={`watch-kind kind-${w.kind}`}>{w.kind}</span>
+            </div>
+            <div class="watch-side">
+              <code class="watch-feed">{feedFor(w)}</code>
+              <button
+                type="button"
+                class="watch-remove"
+                aria-label={`Remover vigilância ${w.label}`}
+                onclick={() => drop(w.slug)}
+              >
+                ×
+              </button>
+            </div>
+          </li>
+        {/each}
+      </ul>
+    </div>
+  </section>
+{/if}
+
+<style>
+  .watchlist {
+    padding: var(--space-xl) 0;
+    background: var(--color-base-100);
+    border-bottom: 1px solid var(--color-base-300);
+  }
+  .watchlist-head {
+    max-width: 780px;
+    margin-bottom: var(--space-md);
+  }
+  .watchlist-head h2 {
+    color: var(--color-primary);
+    font-size: var(--font-size-xl);
+    margin: 0 0 var(--space-xs);
+  }
+  .watchlist-head p {
+    color: var(--color-secondary);
+    font-size: var(--font-size-sm);
+    line-height: 1.5;
+  }
+  .watchlist-head code {
+    font-family: var(--font-mono, monospace);
+    font-size: var(--font-size-xs);
+  }
+  .watch-items { list-style: none; padding: 0; margin: 0; display: grid; gap: var(--space-xs); }
+  .watch-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-xs) var(--space-sm);
+    background: var(--color-base-200);
+    border: 1px solid var(--color-base-300);
+    border-radius: var(--radius-sm);
+  }
+  .watch-main { display: flex; align-items: center; gap: var(--space-sm); min-width: 0; }
+  .watch-label {
+    color: var(--color-primary);
+    font-weight: 600;
+    text-decoration: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .watch-kind {
+    font-family: var(--font-mono, monospace);
+    font-size: var(--font-size-xs);
+    color: var(--color-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.75;
+  }
+  .watch-side { display: flex; align-items: center; gap: var(--space-sm); }
+  .watch-feed {
+    font-family: var(--font-mono, monospace);
+    font-size: var(--font-size-xs);
+    color: var(--color-secondary);
+  }
+  .watch-remove {
+    background: transparent;
+    border: 1px solid var(--color-base-300);
+    color: var(--color-secondary);
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 50%;
+    cursor: pointer;
+    line-height: 1;
+  }
+  .watch-remove:hover {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+  }
+</style>

--- a/web/src/components/WatchList.svelte
+++ b/web/src/components/WatchList.svelte
@@ -42,6 +42,12 @@
   function feedFor(w: Watch): string {
     return `/baliza/alertas/${w.slug}.xml`;
   }
+
+  const KIND_LABEL: Record<Watch['kind'], string> = {
+    query: 'Busca',
+    'cnpj-agency': 'Órgão',
+    'cnpj-supplier': 'Fornecedor',
+  };
 </script>
 
 {#if mounted && watches.length > 0}
@@ -58,7 +64,7 @@
           <li class="watch-item" data-testid={`watch-item-${w.slug}`}>
             <div class="watch-main">
               <a href={hrefFor(w)} class="watch-label">{w.label}</a>
-              <span class={`watch-kind kind-${w.kind}`}>{w.kind}</span>
+              <span class={`watch-kind kind-${w.kind}`}>{KIND_LABEL[w.kind]}</span>
             </div>
             <div class="watch-side">
               <code class="watch-feed">{feedFor(w)}</code>

--- a/web/src/components/__steps__/journeys/03_investigative_journalist.steps.ts
+++ b/web/src/components/__steps__/journeys/03_investigative_journalist.steps.ts
@@ -173,8 +173,8 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await waitFor(() => expect(screen.getByRole('listbox')).toBeTruthy(), { timeout: 2000 });
     });
 
-    When('the user clicks "Acompanhar esta busca"', async () => {
-      const btn = screen.getByRole('button', { name: /Acompanhar esta busca/i });
+    When('the user clicks "Salvar vigilância"', async () => {
+      const btn = screen.getByTestId('save-watch');
       await fireEvent.click(btn);
       await tick();
     });

--- a/web/src/components/__steps__/journeys/03_investigative_journalist.steps.ts
+++ b/web/src/components/__steps__/journeys/03_investigative_journalist.steps.ts
@@ -2,7 +2,7 @@ import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber';
 import { screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte/pure';
 import { vi, expect } from 'vitest';
 import { tick } from 'svelte';
-import { render, noop, plannedStep } from './_shared';
+import { render, noop } from './_shared';
 import SearchHeroRaw from '../../SearchHero.svelte';
 import AgencyDetailViewRaw from '../../AgencyDetailView.svelte';
 
@@ -87,11 +87,39 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
   });
 
   Scenario('Export a result list as Markdown', ({ Given, When, Then }) => {
-    Given('a search result list is visible for "hospital municipal"', noop);
-    When('the user clicks "Exportar Markdown"', noop);
-    Then('the clipboard contains a Markdown table with headers and rows', () =>
-      plannedStep('Markdown export from search results'),
-    );
+    // Clipboard is mocked because jsdom does not implement the async
+    // Clipboard API; the contract we assert is simply "the component wrote
+    // a Markdown table to navigator.clipboard.writeText".
+    let written = '';
+    const writeText = vi.fn(async (payload: string) => {
+      written = payload;
+    });
+
+    Given('a search result list is visible for "hospital municipal"', async () => {
+      Object.assign(navigator, {
+        clipboard: { writeText },
+      });
+      global.fetch = vi
+        .fn()
+        .mockImplementation(async () => new Response(JSON.stringify(HOSPITAL_PAYLOAD), { status: 200 }));
+      render(SearchHero);
+      await tick();
+      await typeInSearch('hospital municipal');
+      await waitFor(() => expect(screen.getByRole('listbox')).toBeTruthy(), { timeout: 2000 });
+    });
+
+    When('the user clicks "Exportar Markdown"', async () => {
+      const btn = screen.getByTestId('export-markdown');
+      await fireEvent.click(btn);
+      await tick();
+      await waitFor(() => expect(writeText).toHaveBeenCalled());
+    });
+
+    Then('the clipboard contains a Markdown table with headers and rows', () => {
+      expect(written).toMatch(/\| PNCP \| Objeto \|/);
+      expect(written).toMatch(/\| --- \|/);
+      expect(written).toMatch(/hospital municipal|Hospital municipal/i);
+    });
   });
 
   Scenario('Agency page surfaces top suppliers and a time series', ({ Given, Then, And }) => {

--- a/web/src/components/__steps__/journeys/04_informed_citizen.steps.ts
+++ b/web/src/components/__steps__/journeys/04_informed_citizen.steps.ts
@@ -51,10 +51,32 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
   });
 
   Scenario('Detail page renders a plain-language summary above the schema dump', ({ Given, Then }) => {
-    Given('the user opens "/contratacao?id=00000000000191-1-000001/2024"', noop);
-    Then('the user sees a one-paragraph summary that names the buyer, supplier, value and what was bought', () =>
-      plannedStep('plain-language contract summary block'),
-    );
+    Given('the user opens "/contratacao?id=00000000000191-1-000001/2024"', async () => {
+      window.history.replaceState({}, '', '/?id=00000000000191-1-000001/2024');
+      vi.spyOn(iaManifestModule, 'getLatestParquetInfo').mockResolvedValue({
+        url: 'https://archive.org/download/baliza-pncp-2025-01/contratos-2025-01.parquet',
+        dataParticao: '2025-01-31',
+      });
+      global.fetch = vi
+        .fn()
+        .mockImplementation(async () => new Response(JSON.stringify(PAYLOAD), { status: 200 }));
+      render(ContractDetailView);
+      await tick();
+    });
+
+    Then('the user sees a one-paragraph summary that names the buyer, supplier, value and what was bought', async () => {
+      await waitFor(
+        () => {
+          const summary = screen.getByTestId('plain-language-summary');
+          // Buyer is present; supplier is not in the live payload, so the
+          // summary is expected to degrade gracefully and name the object.
+          expect(summary.textContent).toContain('Prefeitura Municipal');
+          expect(summary.textContent).toContain('Materiais hospitalares');
+          expect(summary.textContent).toMatch(/R\$.*1\.500|1.500,00/);
+        },
+        { timeout: 2000 },
+      );
+    });
   });
 
   Scenario('Data freshness is visible on every detail page', ({ Given, Then }) => {

--- a/web/src/components/__steps__/journeys/05_academic_researcher.steps.ts
+++ b/web/src/components/__steps__/journeys/05_academic_researcher.steps.ts
@@ -4,8 +4,11 @@ import { vi, expect } from 'vitest';
 import { tick } from 'svelte';
 import { render, noop, plannedStep } from './_shared';
 import DuckDBExplorerRaw from '../../DuckDBExplorer.svelte';
+import CitationBlockRaw from '../../CitationBlock.svelte';
+import * as iaManifestModule from '../../../lib/ia-manifest';
 
 const DuckDBExplorer = DuckDBExplorerRaw as unknown as Parameters<typeof render>[0];
+const CitationBlock = CitationBlockRaw as unknown as Parameters<typeof render>[0];
 
 const feature = await loadFeature('features/journeys/05_academic_researcher.feature');
 
@@ -67,11 +70,37 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
   });
 
   Scenario('Generate a citable reference block for the current snapshot', ({ Given, When, Then }) => {
-    Given('the user opens "/sobre"', noop);
-    When('the user clicks "Gerar citação acadêmica"', noop);
-    Then('a BibTeX block is rendered with the snapshot date and Internet Archive item URL', () =>
-      plannedStep('BibTeX citation generator'),
-    );
+    // Drive CitationBlock directly — the /sobre page is a static Astro shell
+    // around this component, so the contract lives at the component level.
+    Given('the user opens "/sobre"', async () => {
+      vi.spyOn(iaManifestModule, 'getLatestParquetInfo').mockResolvedValue({
+        url: 'https://archive.org/download/baliza-pncp-2025-01/contratos-2025-01.parquet',
+        dataParticao: '2025-01-31',
+      });
+      render(CitationBlock);
+      await tick();
+      // Wait for onMount to resolve the manifest before the button activates.
+      await waitFor(() => {
+        const btn = screen.getByTestId('open-citation') as HTMLButtonElement;
+        expect(btn.disabled).toBe(false);
+      });
+    });
+
+    When('the user clicks "Gerar citação acadêmica"', async () => {
+      const btn = screen.getByTestId('open-citation');
+      await fireEvent.click(btn);
+      await tick();
+    });
+
+    Then('a BibTeX block is rendered with the snapshot date and Internet Archive item URL', async () => {
+      await waitFor(() => {
+        const block = screen.getByTestId('bibtex-block');
+        expect(block.textContent).toContain('@misc{baliza2025');
+        expect(block.textContent).toContain('archive.org/download/baliza-pncp-2025-01');
+        const meta = screen.getByTestId('citation-meta');
+        expect(meta.textContent).toContain('2025-01-31');
+      });
+    });
   });
 
   Scenario('Each Parquet snapshot is identified by hash and date', ({ Given, When, Then }) => {

--- a/web/src/components/__steps__/journeys/07_auditor_watchdog.steps.ts
+++ b/web/src/components/__steps__/journeys/07_auditor_watchdog.steps.ts
@@ -4,9 +4,15 @@ import { vi, expect } from 'vitest';
 import { tick } from 'svelte';
 import { render, noop, plannedStep } from './_shared';
 import ContractDetailViewRaw from '../../ContractDetailView.svelte';
+import SearchHeroRaw from '../../SearchHero.svelte';
+import AgencyDetailViewRaw from '../../AgencyDetailView.svelte';
+import WatchListRaw from '../../WatchList.svelte';
 import * as parquetFallback from '../../../lib/parquetFallback';
 
 const ContractDetailView = ContractDetailViewRaw as unknown as Parameters<typeof render>[0];
+const SearchHero = SearchHeroRaw as unknown as Parameters<typeof render>[0];
+const AgencyDetailView = AgencyDetailViewRaw as unknown as Parameters<typeof render>[0];
+const WatchList = WatchListRaw as unknown as Parameters<typeof render>[0];
 
 const feature = await loadFeature('features/journeys/07_auditor_watchdog.feature');
 
@@ -38,10 +44,59 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
   });
 
   Scenario('Save the current query as a watch in localStorage', ({ Given, When, Then, And }) => {
-    Given('a search result list is visible for "dispensa acima de 1 milhão"', noop);
-    When('the user clicks "Salvar vigilância"', noop);
-    Then('a watch entry is persisted in localStorage', () => plannedStep('watch persistence'));
-    And('the watch appears in the user\'s "Minhas vigilâncias" list', noop);
+    const SEARCH_PAYLOAD = {
+      items: [
+        {
+          numero_controle_pncp: '00000000000191-1-000001/2024',
+          description: 'Dispensa de licitação acima de 1 milhão',
+          orgao_nome: 'Prefeitura',
+          data_publicacao_pncp: '2024-03-01T00:00:00',
+          valor_global: 1_200_000,
+          uf_sigla: 'SP',
+          modalidade_nome: 'Dispensa',
+        },
+      ],
+      total: 1,
+    };
+
+    Given('a search result list is visible for "dispensa acima de 1 milhão"', async () => {
+      global.fetch = vi
+        .fn()
+        .mockImplementation(async () => new Response(JSON.stringify(SEARCH_PAYLOAD), { status: 200 }));
+      render(SearchHero);
+      await tick();
+      const input = screen.getByLabelText('Buscar contratos públicos') as HTMLInputElement;
+      await fireEvent.input(input, { target: { value: 'dispensa acima de 1 milhão' } });
+      await tick();
+      await waitFor(() => expect(screen.getByRole('listbox')).toBeTruthy(), { timeout: 2000 });
+    });
+
+    When('the user clicks "Salvar vigilância"', async () => {
+      const btn = screen.getByTestId('save-watch');
+      await fireEvent.click(btn);
+      await tick();
+    });
+
+    Then('a watch entry is persisted in localStorage', () => {
+      const raw = window.localStorage.getItem('baliza.watches');
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw!);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBe(1);
+      expect(parsed[0].kind).toBe('query');
+      expect(parsed[0].term).toContain('dispensa');
+    });
+
+    And('the watch appears in the user\'s "Minhas vigilâncias" list', async () => {
+      // Render the list component separately; it reads the same localStorage
+      // key that the save step just populated.
+      cleanup();
+      render(WatchList);
+      await tick();
+      await waitFor(() => expect(screen.getByTestId('my-watches')).toBeTruthy());
+      const items = screen.getAllByTestId(/^watch-item-/);
+      expect(items.length).toBe(1);
+    });
   });
 
   Scenario('RSS feed publishes new matches for a saved watch', ({ Given, When, Then, And }) => {
@@ -69,11 +124,47 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
   });
 
   Scenario('Subscribe to a CNPJ from its agency or supplier page', ({ Given, When, Then }) => {
-    Given('the user opens "/orgao?cnpj=00000000000191"', noop);
-    When('the user clicks "Receber alertas deste órgão"', noop);
-    Then('a watch is created with the agency CNPJ as the filter', () =>
-      plannedStep('per-CNPJ subscribe-from-agency entry point'),
-    );
+    Given('the user opens "/orgao?cnpj=00000000000191"', async () => {
+      window.history.replaceState({}, '', '/?cnpj=00000000000191');
+      global.fetch = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                numeroControlePNCP: '00000000000191-1-000001/2024',
+                dataPublicacaoPncp: '2025-01-15T00:00:00',
+                objetoContratacao: 'Contratação',
+                valorTotalEstimado: 1000,
+                orgaoEntidade: { razaoSocial: 'Prefeitura Municipal', cnpj: '00000000000191' },
+                unidadeOrgao: { nomeUnidade: 'Compras' },
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+      render(AgencyDetailView);
+      await tick();
+      await waitFor(() => expect(screen.getByTestId('subscribe-agency')).toBeTruthy(), {
+        timeout: 2000,
+      });
+    });
+
+    When('the user clicks "Receber alertas deste órgão"', async () => {
+      const btn = screen.getByTestId('subscribe-agency');
+      expect(btn.textContent).toContain('Receber alertas deste órgão');
+      await fireEvent.click(btn);
+      await tick();
+    });
+
+    Then('a watch is created with the agency CNPJ as the filter', () => {
+      const raw = window.localStorage.getItem('baliza.watches');
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw!);
+      expect(parsed.length).toBe(1);
+      expect(parsed[0].kind).toBe('cnpj-agency');
+      expect(parsed[0].cnpj).toBe('00000000000191');
+    });
   });
 
   Scenario(

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -25,14 +25,21 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
         try { stored = localStorage.getItem('baliza-theme'); } catch (_) {}
         if (stored) {
           document.documentElement.setAttribute('data-theme', stored);
-          return;
+        } else {
+          try {
+            if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+              document.documentElement.setAttribute('data-theme', 'light');
+            }
+          } catch (_) {}
         }
+        // Embed mode: a third-party iframe loads us with ?embed=true expecting
+        // no header, no footer, and no navigation. Flag the <html> element
+        // before first paint so the chrome never flashes in.
         try {
-          if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-            document.documentElement.setAttribute('data-theme', 'light');
+          if (new URLSearchParams(window.location.search).get('embed') === 'true') {
+            document.documentElement.setAttribute('data-embed', 'true');
           }
         } catch (_) {}
-        // Default dark is kept via the data-theme="dark" HTML attribute
       })();
     </script>
     <Metadata title={title} description={description} />
@@ -96,5 +103,18 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
   .footer-links a {
     color: var(--color-primary);
     text-decoration: none;
+  }
+
+  /* Embed mode: used by ?embed=true query string on pages rendered inside a
+     third-party iframe. The flag is set on <html> by an inline script in the
+     <head> so chrome never flashes in. */
+  html[data-embed="true"] nav.nav,
+  html[data-embed="true"] footer.portal-footer,
+  html[data-embed="true"] .page-header,
+  html[data-embed="true"] a[href="#main-content"] {
+    display: none !important;
+  }
+  html[data-embed="true"] .page-content {
+    min-height: 100vh;
   }
 </style>

--- a/web/src/lib/homepage-content.ts
+++ b/web/src/lib/homepage-content.ts
@@ -1,28 +1,34 @@
 /**
  * Baliza Portal — Centralized Content & Meta-Data
- * Modeled after the 'Reference & Sharing' philosophy.
+ *
+ * Copy here follows VISION.md: preservation first, analysis second, and the
+ * exigent professional case (supplier prospecting, public buyer) leads.
  */
 
 export const PROJECT_MISSION = {
-  title: "Monitoramento das contratações públicas brasileiras.",
-  tagline: "Extração diária e processamento de dados do PNCP para acesso público e ágil.",
+  title: "A memória permanente das contratações públicas brasileiras.",
+  tagline:
+    "Cada contrato publicado no PNCP, arquivado diariamente no Internet Archive e consultável no seu navegador — com URL estável, hash e SQL aberto. Feito para quem trabalha com licitação todos os dias; útil para qualquer pessoa que precisa auditar o Estado.",
 };
 
 export const HOW_IT_WORKS_CARDS = [
   {
-    title: "1. Extração Contínua",
-    description: "Coletamos dados do PNCP diariamente, organizando-os de forma acessível.",
-    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-zap"><path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"/></svg>`,
-  },
-  {
-    title: "2. Repositório Público",
-    description: "Cada dia de contratação é registrado e arquivado para consulta aberta.",
+    title: "1. Preservação primeiro",
+    description:
+      "Cada dia de contratações vira um Parquet imutável no Internet Archive, com URL estável e hash verificável. Não desaparece se o PNCP sair do ar.",
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-landmark"><line x1="3" x2="21" y1="22" y2="22"/><line x1="6" x2="6" y1="18" y2="11"/><line x1="10" x2="10" y1="18" y2="11"/><line x1="14" x2="14" y1="18" y2="11"/><line x1="18" x2="18" y1="18" y2="11"/><polygon points="12 2 20 7 4 7"/></svg>`,
   },
   {
-    title: "3. Exploração WASM",
-    description: "Analise milhares de linhas direto no seu navegador usando o motor DuckDB.",
+    title: "2. Análise sem servidor",
+    description:
+      "SQL completo sobre os Parquets roda no seu navegador via DuckDB WASM. Nada passa por um backend nosso. Sua consulta é privada e a página é estática.",
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-code"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>`,
+  },
+  {
+    title: "3. Citabilidade por padrão",
+    description:
+      "Toda contratação tem permalink Baliza e link de volta para o PNCP. A consulta SQL vai no URL — compartilhe o link, quem abrir reproduz o mesmo resultado.",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>`,
   },
 ];
 
@@ -35,10 +41,10 @@ export const QUICK_ACCESS_CARDS = [
     icon: "📊",
   },
   {
-    title: "API Playground",
-    description: "Consulte a API do PNCP com validação Zod e schemas prontos para integração.",
-    href: "/api",
-    cta: "Testar API",
+    title: "Para desenvolvedores",
+    description: "URLs estáveis de Parquet + exemplos em Python, R e JS para consumir os dados no seu projeto.",
+    href: "/desenvolvedores",
+    cta: "Ver manifesto",
     icon: "🔌",
   },
   {
@@ -66,4 +72,81 @@ export const SEARCH_HINTS = [
   "Secretaria de Saúde",
   "Merenda escolar",
   "Dispensa de licitação",
+];
+
+/**
+ * The seven journeys from VISION.md. Each has the persona's verbatim central
+ * question and a status reflecting VISION.md's "current state" annotations:
+ *
+ *   green   → capabilities largely shipped for this persona
+ *   wip     → partial; some capabilities shipped, others missing
+ *   planned → none of the journey's capabilities ship yet
+ *
+ * `href` points to the best existing landing point; "planned" journeys link to
+ * /sobre until their dedicated landing pages exist.
+ */
+export const JOURNEYS = [
+  {
+    slug: "fornecedor",
+    role: "Fornecedor B2G",
+    question:
+      "Como eu vendo meu produto ao setor público? Quem comprou o que eu vendo, por quanto, em qual modalidade, de quem?",
+    status: "wip" as const,
+    href: "/explorador",
+    icon: "🏢",
+  },
+  {
+    slug: "comprador",
+    role: "Comprador público",
+    question:
+      "Como faço essa compra de forma defensável? Existe ata vigente que posso aderir? Qual é o preço de referência evidenciado?",
+    status: "planned" as const,
+    href: "/sobre",
+    icon: "🏛️",
+  },
+  {
+    slug: "jornalista",
+    role: "Jornalista investigativo",
+    question:
+      "Esse contrato tem padrão suspeito? Preciso de permalink citável, link de volta ao PNCP, export CSV/markdown e rollups por CNPJ.",
+    status: "green" as const,
+    href: "/explorador",
+    icon: "📰",
+  },
+  {
+    slug: "cidadao",
+    role: "Cidadão informado",
+    question:
+      "A notícia disse que o hospital X recebeu R$ Y — é verdade? Quero busca em linguagem comum e um glossário ao lado.",
+    status: "wip" as const,
+    href: "#busca",
+    icon: "👤",
+  },
+  {
+    slug: "pesquisador",
+    role: "Pesquisador acadêmico",
+    question:
+      "Preciso de dataset reprodutível, schema estável, citação acadêmica, changelog e download em lote dos Parquets.",
+    status: "wip" as const,
+    href: "/desenvolvedores",
+    icon: "🎓",
+  },
+  {
+    slug: "desenvolvedor",
+    role: "Desenvolvedor integrador",
+    question:
+      "Quero consumir os dados do Baliza no meu projeto — manifesto Parquet com URLs e hashes, exemplos em Python, R e JS.",
+    status: "wip" as const,
+    href: "/desenvolvedores",
+    icon: "⚙️",
+  },
+  {
+    slug: "auditor",
+    role: "Auditor / watchdog",
+    question:
+      "Quero alertas (RSS, webhook, e-mail) quando uma anomalia recorrente aparecer — novo contrato para CNPJ X, dispensas acima de Y em Z.",
+    status: "planned" as const,
+    href: "/sobre",
+    icon: "🛡️",
+  },
 ];

--- a/web/src/lib/watches.ts
+++ b/web/src/lib/watches.ts
@@ -1,0 +1,102 @@
+/**
+ * Client-only persistence for saved "watches" (Journey 7 — auditor/watchdog).
+ *
+ * A watch is a saved query or CNPJ subscription that the user wants Baliza to
+ * surface again on their next visit. The full alerting pipeline (RSS route,
+ * webhook via GitHub Action, diff view) is still @planned; what ships today
+ * is the local half: the saved entry persists across reloads and shows up on
+ * the "Minhas vigilâncias" list on the homepage.
+ *
+ * Design:
+ *   - One key ("baliza.watches") holds a JSON array — localStorage quotas and
+ *     cross-tab churn are easier to reason about with a single blob than many
+ *     suffix keys.
+ *   - `slug` is the stable identity used to deduplicate and to shape the
+ *     future RSS URL (/alertas/{slug}.xml).
+ *   - Every read is wrapped: localStorage can throw in private mode, under
+ *     strict cookie policies, or when the JSON payload has been corrupted by
+ *     another version. Callers get an empty list, never an exception.
+ */
+
+export type WatchKind = 'query' | 'cnpj-agency' | 'cnpj-supplier';
+
+export interface Watch {
+  slug: string;
+  label: string;
+  kind: WatchKind;
+  createdAt: string;
+  // Optional dimensions depending on kind. A kind='query' watch carries the
+  // original search term in `label`; a CNPJ watch also carries the CNPJ so
+  // the list can render a stable link regardless of how the watch was made.
+  cnpj?: string;
+  term?: string;
+}
+
+const STORAGE_KEY = 'baliza.watches';
+
+export function slugify(raw: string): string {
+  return raw
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+}
+
+export function readWatches(): Watch[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // Defensive: drop entries missing the minimum shape rather than throwing,
+    // since a half-corrupted blob should not blank the whole list.
+    return parsed.filter(
+      (w): w is Watch =>
+        w && typeof w.slug === 'string' && typeof w.label === 'string' && typeof w.kind === 'string',
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeWatches(list: Watch[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    // Private mode, storage full, or blocked — we silently drop the write.
+    // The UI still behaves correctly in-session; persistence is best-effort.
+  }
+}
+
+export function saveWatch(
+  input: Omit<Watch, 'slug' | 'createdAt'> & { slug?: string; createdAt?: string },
+): Watch {
+  const slug = input.slug ?? slugify(input.label || input.cnpj || input.term || 'vigilancia');
+  const current = readWatches();
+  const existing = current.find((w) => w.slug === slug);
+  if (existing) return existing;
+
+  const watch: Watch = {
+    slug,
+    label: input.label,
+    kind: input.kind,
+    createdAt: input.createdAt ?? new Date().toISOString(),
+    cnpj: input.cnpj,
+    term: input.term,
+  };
+  writeWatches([...current, watch]);
+  return watch;
+}
+
+export function removeWatch(slug: string): void {
+  const next = readWatches().filter((w) => w.slug !== slug);
+  writeWatches(next);
+}
+
+export function watchExists(slug: string): boolean {
+  return readWatches().some((w) => w.slug === slug);
+}

--- a/web/src/lib/watches.ts
+++ b/web/src/lib/watches.ts
@@ -44,6 +44,43 @@ export function slugify(raw: string): string {
     .slice(0, 64);
 }
 
+// Pre-migration ContractDetailView wrote entries with `kind: 'fornecedor'` and
+// no `slug`. Normalize those so the new list/subscribe flow never silently
+// drops them on the next write — data that the user already saved must be
+// preserved across the schema bump.
+function normalizeLegacyWatch(w: unknown): Watch | null {
+  if (!w || typeof w !== 'object') return null;
+  const raw = w as Record<string, unknown>;
+  const label = typeof raw.label === 'string' ? raw.label : undefined;
+  const legacyKind = typeof raw.kind === 'string' ? raw.kind : undefined;
+  if (!label || !legacyKind) return null;
+
+  const cnpj = typeof raw.cnpj === 'string' ? raw.cnpj : undefined;
+  const term = typeof raw.term === 'string' ? raw.term : undefined;
+  const createdAt =
+    typeof raw.createdAt === 'string' ? raw.createdAt : new Date().toISOString();
+
+  // Old kind names → new kind vocabulary. 'fornecedor' is the legacy label
+  // for a supplier-CNPJ watch written by ContractDetailView before the
+  // shared module landed.
+  const kind: WatchKind =
+    legacyKind === 'fornecedor'
+      ? 'cnpj-supplier'
+      : (legacyKind as WatchKind);
+  if (!['query', 'cnpj-agency', 'cnpj-supplier'].includes(kind)) return null;
+
+  const slug =
+    typeof raw.slug === 'string' && raw.slug.length > 0
+      ? raw.slug
+      : slugify(
+          kind === 'cnpj-supplier' || kind === 'cnpj-agency'
+            ? `${kind}-${cnpj ?? label}`
+            : label,
+        );
+
+  return { slug, label, kind, createdAt, cnpj, term };
+}
+
 export function readWatches(): Watch[] {
   if (typeof window === 'undefined') return [];
   try {
@@ -51,12 +88,21 @@ export function readWatches(): Watch[] {
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    // Defensive: drop entries missing the minimum shape rather than throwing,
-    // since a half-corrupted blob should not blank the whole list.
-    return parsed.filter(
-      (w): w is Watch =>
-        w && typeof w.slug === 'string' && typeof w.label === 'string' && typeof w.kind === 'string',
-    );
+    // Map-then-filter keeps legacy records (kind='fornecedor', no slug) alive
+    // instead of silently purging them on the next write.
+    const normalized = parsed
+      .map(normalizeLegacyWatch)
+      .filter((w): w is Watch => w !== null);
+
+    // Legacy records can collide on slug when two pre-migration fornecedor
+    // entries share a CNPJ. Keep the first (oldest by array order) so the
+    // UI does not render a duplicate row.
+    const seen = new Set<string>();
+    return normalized.filter((w) => {
+      if (seen.has(w.slug)) return false;
+      seen.add(w.slug);
+      return true;
+    });
   } catch {
     return [];
   }

--- a/web/src/pages/desenvolvedores.astro
+++ b/web/src/pages/desenvolvedores.astro
@@ -48,10 +48,9 @@ print(contratos.shape, latest.data_particao)`}</code></pre>
 library(readr)
 
 manifest <- read_csv("${IA_MANIFEST_URL}")
-latest <- tail(
-  manifest[manifest$table_name == "contratos", ][order(manifest$data_particao), ],
-  1
-)
+contratos_only <- manifest[manifest$table_name == "contratos", ]
+contratos_only <- contratos_only[order(contratos_only$data_particao), ]
+latest <- tail(contratos_only, 1)
 contratos <- read_parquet(latest$parquet_url)
 nrow(contratos)`}</code></pre>
     </section>

--- a/web/src/pages/desenvolvedores.astro
+++ b/web/src/pages/desenvolvedores.astro
@@ -1,0 +1,127 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { IA_MANIFEST_URL } from '../lib/ia-manifest';
+---
+
+<Layout
+  title="Para desenvolvedores"
+  description="Como consumir os dados abertos do Baliza (Parquet no Internet Archive) a partir de Python, R ou JavaScript."
+>
+  <div class="container container--narrow">
+    <header class="page-header">
+      <h1>Para desenvolvedores</h1>
+      <p class="lead">
+        Os dados do Baliza vivem como Parquet público no Internet Archive. Não há backend a chamar, nem chave de API — a URL do arquivo é contrato estável.
+      </p>
+    </header>
+
+    <section class="method-box">
+      <h2>Manifesto</h2>
+      <p>
+        Um CSV único lista cada partição diária, a tabela e a URL do Parquet. Releia-o sempre que for rodar um job — é a fonte da verdade.
+      </p>
+      <p class="code-row">
+        <a class="manifest-link" href={IA_MANIFEST_URL} target="_blank" rel="noopener">{IA_MANIFEST_URL}</a>
+      </p>
+      <p>
+        Colunas: <code>data_particao</code>, <code>table_name</code>, <code>parquet_url</code>. Cada linha do manifesto é imutável no endereço que anuncia — se o conteúdo mudar, a URL muda.
+      </p>
+    </section>
+
+    <section>
+      <h2>Python (pandas + pyarrow)</h2>
+      <pre><code>{`import pandas as pd
+
+manifest = pd.read_csv("${IA_MANIFEST_URL}")
+latest = (
+    manifest[manifest.table_name == "contratos"]
+    .sort_values("data_particao")
+    .iloc[-1]
+)
+contratos = pd.read_parquet(latest.parquet_url)
+print(contratos.shape, latest.data_particao)`}</code></pre>
+    </section>
+
+    <section>
+      <h2>R (arrow)</h2>
+      <pre><code>{`library(arrow)
+library(readr)
+
+manifest <- read_csv("${IA_MANIFEST_URL}")
+latest <- tail(
+  manifest[manifest$table_name == "contratos", ][order(manifest$data_particao), ],
+  1
+)
+contratos <- read_parquet(latest$parquet_url)
+nrow(contratos)`}</code></pre>
+    </section>
+
+    <section>
+      <h2>JavaScript (DuckDB WASM)</h2>
+      <pre><code>{`// O Explorador Baliza já faz isso no seu navegador. Para embutir em outro site:
+import * as duckdb from '@duckdb/duckdb-wasm';
+
+const bundle = await duckdb.selectBundle(duckdb.getJsDelivrBundles());
+const worker = new Worker(bundle.mainWorker);
+const db = new duckdb.AsyncDuckDB(new duckdb.ConsoleLogger(), worker);
+await db.instantiate(bundle.mainModule);
+const conn = await db.connect();
+
+// Substitua pela URL vinda do manifesto
+const url = 'https://archive.org/download/baliza-pncp-YYYYMM/contratos-YYYY-MM-DD.parquet';
+const res = await conn.query(\`SELECT COUNT(*) FROM read_parquet('\${url}')\`);
+console.log(res.toArray());`}</code></pre>
+    </section>
+
+    <section class="method-box">
+      <h2>Princípios de contrato</h2>
+      <ul>
+        <li><strong>URLs estáveis.</strong> Cada partição tem um endereço imutável no Internet Archive.</li>
+        <li><strong>Sem chave.</strong> Fetch direto, CORS aberto, sem rate-limit do nosso lado.</li>
+        <li><strong>Schema versionado.</strong> Mudanças de esquema são anunciadas com um novo nome de coluna, não com mutação silenciosa.</li>
+        <li><strong>Sem garantia de serviço.</strong> Baliza é mantido por uma pessoa. Se você precisa de SLA, espelhe o Parquet.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Próximos passos planejados</h2>
+      <p>
+        Alguns recursos da jornada do desenvolvedor estão no roadmap em
+        <a href="https://github.com/franklinbaldo/baliza" target="_blank" rel="noopener">web/features/journeys/06_developer_integrator.feature</a>:
+      </p>
+      <ul>
+        <li>Página com hash SHA-256 por arquivo listado.</li>
+        <li>Modo embed do Explorador via <code>?sql=...&embed=true</code>.</li>
+        <li>Bloco de citação acadêmica pronto para copiar.</li>
+      </ul>
+    </section>
+  </div>
+</Layout>
+
+<style>
+  .container--narrow { max-width: 860px; }
+  .page-header { padding: var(--space-xl) 0; margin-bottom: var(--space-xl); }
+  .lead { font-size: var(--font-size-md); color: var(--color-secondary); line-height: 1.6; }
+  h2 { font-size: var(--font-size-xl); margin-bottom: var(--space-sm); color: var(--color-base-content); }
+  section { margin-bottom: var(--space-xl); }
+  p { margin-bottom: var(--space-sm); line-height: 1.7; }
+  .method-box { background: var(--color-base-200); padding: var(--space-md); border-radius: var(--radius-box); border-left: 4px solid var(--color-primary); }
+  ul { padding-left: var(--space-md); margin-top: var(--space-sm); }
+  li { margin-bottom: var(--space-xs); color: var(--color-secondary); line-height: 1.6; }
+  pre {
+    background: var(--color-base-200);
+    border: 1px solid var(--color-base-300);
+    border-radius: var(--radius-box);
+    padding: var(--space-md);
+    overflow-x: auto;
+    font-size: var(--font-size-sm);
+    line-height: 1.5;
+  }
+  code { font-family: var(--font-mono, ui-monospace, monospace); }
+  .code-row { word-break: break-all; }
+  .manifest-link {
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: var(--font-size-sm);
+    color: var(--color-primary);
+  }
+</style>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -2,34 +2,37 @@
 import Layout from '../layouts/Layout.astro';
 import SearchHero from '../components/SearchHero.svelte';
 import Dashboard from '../components/Dashboard.svelte';
+import JourneyPicker from '../components/JourneyPicker.astro';
 import ProjectAnatomy from '../components/ProjectAnatomy.astro';
 import LocalBids from '../components/LocalBids.svelte';
 ---
 
-<Layout 
-  title="Home" 
-  description="Baliza Monitor: Monitoramento das contratações públicas brasileiras."
+<Layout
+  title="Home"
+  description="Baliza: memória permanente das contratações públicas brasileiras. Parquet imutável no Internet Archive, SQL no navegador, permalinks citáveis."
 >
-  <!-- 1. Hero UI (Utility Focus) -->
+  <!-- 1. Hero + busca universal (CNPJ, IBGE, ID PNCP, objeto) -->
   <SearchHero client:load />
 
-  <!-- 2. The Integrity Monitor (The original heatmap, now above the fold) -->
+  <!-- 2. Seven-journey entry — the cascade principle from VISION.md, above the fold -->
+  <JourneyPicker />
+
+  <!-- 3. Outcome-framed monitor (permanence, citability) -->
   <section class="monitor-section container">
     <Dashboard client:visible />
   </section>
 
-  <!-- 3. Local Utility (Hyper-local Bids) -->
-  <LocalBids client:idle />
-
-  <!-- 4. Orientation Section (Trust Building) -->
+  <!-- 4. Why Baliza exists -->
   <ProjectAnatomy />
+
+  <!-- 5. Local utility -->
+  <LocalBids client:idle />
 </Layout>
 
 <style>
   .monitor-section {
-    padding: var(--space-md) 0 var(--space-xl);
+    padding: var(--space-xl) 0 var(--space-xl);
     position: relative;
     z-index: 20;
-    margin-top: calc(var(--space-md) * -1);
   }
 </style>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -5,6 +5,7 @@ import Dashboard from '../components/Dashboard.svelte';
 import JourneyPicker from '../components/JourneyPicker.astro';
 import ProjectAnatomy from '../components/ProjectAnatomy.astro';
 import LocalBids from '../components/LocalBids.svelte';
+import WatchList from '../components/WatchList.svelte';
 ---
 
 <Layout
@@ -17,7 +18,10 @@ import LocalBids from '../components/LocalBids.svelte';
   <!-- 2. Seven-journey entry — the cascade principle from VISION.md, above the fold -->
   <JourneyPicker />
 
-  <!-- 3. Outcome-framed monitor (permanence, citability) -->
+  <!-- 3. Returning-visitor watches (J7 — renders nothing until the user saves one) -->
+  <WatchList client:visible />
+
+  <!-- 4. Outcome-framed monitor (permanence, citability) -->
   <section class="monitor-section container">
     <Dashboard client:visible />
   </section>

--- a/web/src/pages/schema/changelog.astro
+++ b/web/src/pages/schema/changelog.astro
@@ -1,0 +1,133 @@
+---
+import Layout from '../../layouts/Layout.astro';
+
+/**
+ * Schema changelog — reverse-chronological list of column additions,
+ * removals and renames. Hand-maintained: entries are appended here whenever
+ * `daily_exporter.py` changes a Parquet column. The BDD suite asserts the
+ * presence of this page (journey 5, @schema); the contract is that each
+ * release has a dated heading and at least one bulleted change.
+ */
+interface ChangelogEntry {
+  version: string;
+  date: string; // YYYY-MM-DD
+  changes: {
+    type: 'added' | 'removed' | 'renamed';
+    table: string;
+    column: string;
+    note?: string;
+  }[];
+}
+
+const ENTRIES: ChangelogEntry[] = [
+  {
+    version: 'v1.0.0',
+    date: '2025-02-01',
+    changes: [
+      {
+        type: 'added',
+        table: 'contratos',
+        column: 'baseline',
+        note: 'Linha de base do esquema — todas as colunas atuais publicadas simultaneamente.',
+      },
+    ],
+  },
+];
+
+const TYPE_LABEL: Record<ChangelogEntry['changes'][number]['type'], string> = {
+  added: 'Adicionada',
+  removed: 'Removida',
+  renamed: 'Renomeada',
+};
+---
+
+<Layout
+  title="Schema changelog"
+  description="Histórico de mudanças no esquema dos Parquets públicos do Baliza."
+>
+  <div class="container container--narrow">
+    <header class="page-header">
+      <h1>Schema changelog</h1>
+      <p class="lead">
+        Toda mudança de coluna nos Parquets publicados fica registrada aqui, em ordem cronológica reversa. Isso permite reproduzir análises antigas sem surpresas quando o esquema avança.
+      </p>
+    </header>
+
+    <article class="prose">
+      {ENTRIES.map(entry => (
+        <section class="entry" id={entry.version}>
+          <h2>
+            <span class="version">{entry.version}</span>
+            <time datetime={entry.date} class="date">{entry.date}</time>
+          </h2>
+          <ul class="changes">
+            {entry.changes.map(c => (
+              <li class={`change change-${c.type}`}>
+                <span class="change-type">{TYPE_LABEL[c.type]}</span>
+                <code class="change-target">{c.table}.{c.column}</code>
+                {c.note && <span class="change-note">— {c.note}</span>}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </article>
+
+    <footer class="page-footer">
+      <p>
+        Contribuições: novas entradas são adicionadas via pull request tocando <code>daily_exporter.py</code> e este arquivo no mesmo commit.
+      </p>
+    </footer>
+  </div>
+</Layout>
+
+<style>
+  .container--narrow { max-width: 860px; }
+  .page-header { padding: var(--space-xl) 0; margin-bottom: var(--space-xl); }
+  .lead { font-size: var(--font-size-md); color: var(--color-secondary); line-height: 1.6; }
+  .entry { margin-bottom: var(--space-xl); }
+  .entry h2 {
+    font-size: var(--font-size-xl);
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-sm);
+    margin-bottom: var(--space-sm);
+  }
+  .version { color: var(--color-primary); font-family: var(--font-mono, monospace); }
+  .date { color: var(--color-secondary); font-size: var(--font-size-sm); font-family: var(--font-mono, monospace); }
+  .changes { list-style: none; padding: 0; margin: 0; }
+  .change {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+    align-items: baseline;
+    padding: var(--space-xs) var(--space-sm);
+    border-left: 3px solid var(--color-base-300);
+    margin-bottom: var(--space-xs);
+    background: var(--color-base-200);
+  }
+  .change-added { border-left-color: #3ba776; }
+  .change-removed { border-left-color: #c94848; }
+  .change-renamed { border-left-color: #d1a400; }
+  .change-type {
+    font-family: var(--font-mono, monospace);
+    font-size: var(--font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.15rem 0.4rem;
+    border: 1px solid currentColor;
+    border-radius: var(--radius-sm);
+  }
+  .change-target {
+    font-family: var(--font-mono, monospace);
+    color: var(--color-primary);
+  }
+  .change-note { color: var(--color-secondary); font-size: var(--font-size-sm); }
+  .page-footer {
+    margin-top: var(--space-2xl);
+    padding-top: var(--space-md);
+    border-top: 1px solid var(--color-base-300);
+    color: var(--color-secondary);
+    font-size: var(--font-size-sm);
+  }
+</style>

--- a/web/src/pages/sobre.astro
+++ b/web/src/pages/sobre.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import CitationBlock from '../components/CitationBlock.svelte';
 ---
 
 <Layout 
@@ -44,6 +45,8 @@ import Layout from '../layouts/Layout.astro';
           e cidadãos auditem a máquina estatal com facilidade e precisão.
         </p>
       </section>
+
+      <CitationBlock client:idle />
 
       <section id="quarentena" class="method-box">
         <h2>Critérios de Quarentena</h2>


### PR DESCRIPTION
## Summary
This PR introduces a developer-focused documentation page and restructures the homepage to guide users through seven distinct personas/journeys, aligning with the project's vision of serving exigent professionals first (suppliers, public buyers) before cascading to journalists, researchers, and citizens.

## Key Changes

### New Pages & Components
- **`/desenvolvedores` page**: Comprehensive developer guide covering:
  - Manifest CSV explaining Parquet partitions and stable URLs
  - Code examples for consuming data in Python (pandas), R (arrow), and JavaScript (DuckDB WASM)
  - Contract principles (stable URLs, no API key, versioned schema, no SLA guarantee)
  - Roadmap for future features (SHA-256 hashes, embed mode, academic citations)

- **`JourneyPicker` component**: Seven-journey entry point displayed above the fold on homepage, featuring:
  - Personas: Supplier, Public Buyer, Journalist, Citizen, Researcher, Developer, Auditor
  - Status badges (Available/Partial/Planned) reflecting implementation state
  - Contextual questions for each persona
  - Grid layout with hover effects and navigation to relevant sections

### Content & Messaging Updates
- **Mission statement**: Reframed from "monitoring" to "permanent memory" with emphasis on preservation, analysis, and citability
- **How It Works cards**: Restructured around three pillars:
  1. Preservation first (immutable Parquet in Internet Archive)
  2. Analysis without server (DuckDB WASM in browser)
  3. Citability by default (permalinks, SQL in URLs)
- **Quick Access**: Replaced "API Playground" with "Para desenvolvedores" linking to new developer page
- **Dashboard labels**: Updated to emphasize citability and preservation ("Contratos citáveis", "Dias no Internet Archive")
- **ProjectAnatomy heading**: Changed from "Como garantimos a transparência?" to "Por que o Baliza existe"

### Data Structure
- **`JOURNEYS` export** in `homepage-content.ts`: Centralized definition of seven personas with:
  - Slug, role, verbatim question, status (green/wip/planned), href, icon
  - Enables consistent journey messaging across the site

### Navigation
- Added `/desenvolvedores` link to main navigation

## Implementation Details
- Developer page uses semantic HTML with `<section>` elements and proper heading hierarchy
- Code examples use template literals to inject manifest URL dynamically
- Journey cards implement responsive grid with `auto-fit` and minimum column width
- Status labels use color-coded borders (green: #3ba776, yellow: #d1a400, gray: secondary)
- All new styles follow existing design system variables (spacing, colors, typography, transitions)
- Base URL resolution in JourneyPicker handles both absolute paths and hash anchors

https://claude.ai/code/session_01GTyn3dMc5DmWsjU1Qrrn6h