### PR TITLE
Refactor BDD scenarios to follow Given-When-Then structure

### DIFF
--- a/web/features/README.md
+++ b/web/features/README.md
@@ -50,6 +50,9 @@ Every scenario carries:
    `@schema`, `@changelog`, `@citation`, `@api`, `@manifest`, `@embed`,
    `@cors`, `@alerts`, `@rss`, `@webhook`, `@diff`, `@frameworks`,
    `@catmat`, `@price-reference`, `@agency-rollup`.
+4. A cross-journey pointer — an optional trailing `# crosses @journeyN`
+   comment on a scenario that also advances another journey. Used for
+   traceability; no runtime effect.
 
 Status definitions:
 

--- a/web/features/agency-detail.feature
+++ b/web/features/agency-detail.feature
@@ -11,7 +11,7 @@ Feature: Agency Detail View
     Given the URL has cnpj "00000000000191"
     And the fetch is pending
     When the agency detail view mounts
-    Then I should see an aria-busy element
+    Then I should see a loading skeleton
 
   Scenario: Fetch error shows AlertBanner
     Given the URL has cnpj "00000000000191"

--- a/web/features/archive-fallback.feature
+++ b/web/features/archive-fallback.feature
@@ -1,8 +1,11 @@
 @journey5 @journey6 @green
 Feature: Archive fallback hardening
-  queryArchivedTable is the primary offline/historical data layer. Every
-  failure mode is reported as a discriminated reason so callers can decide
-  how to present it; limits are clamped and the layer can be preloaded.
+  Contract data must still be served from the Internet Archive Parquet
+  snapshots when PNCP is unreachable — with honest, discriminated failure
+  reasons the UI can explain, and without wasting boot time on work the
+  caller did not ask for. This is the resilience guarantee journeys 5 and
+  6 depend on: archival reproducibility for researchers and dependable
+  bulk access for integrators.
 
   Scenario: Manifest endpoint 404 yields reason "no_manifest"
     Given the IA manifest endpoint returns 404

--- a/web/features/archive-fallback.feature
+++ b/web/features/archive-fallback.feature
@@ -98,6 +98,11 @@ Feature: Archive fallback hardening
     When queryArchivedFornecedores is called
     Then the query should be routed to the "fornecedores" parquet snapshot
 
+  Scenario: Consecutive wrapper calls each hit their own parquet snapshot
+    Given the IA manifest resolves to a parquet url for every table
+    When queryArchivedOrgaos, queryArchivedUnidades and queryArchivedFornecedores are called in sequence
+    Then each wrapper should route to its own parquet snapshot
+
   Scenario: Malformed manifest rows are skipped with a warning
     Given the IA manifest endpoint returns a CSV with a valid contratos row and a malformed row missing parquet_url
     When getLatestParquetInfo is called for "contratos"

--- a/web/features/archive-fallback.feature
+++ b/web/features/archive-fallback.feature
@@ -70,17 +70,30 @@ Feature: Archive fallback hardening
     Then the result should be a failure with reason "sql_error"
 
   Scenario: prefetchArchive warms the manifest without booting DuckDB
-    Given prefetchArchive was called for "contratos"
-    Then DuckDB should not have been initialized yet
-    When the caller later invokes queryArchivedTable for "contratos" filtered by "cnpj_orgao"
+    Given the IA manifest resolves to a parquet url
+    When prefetchArchive is called for "contratos"
+    Then DuckDB should not have been initialized
+
+  Scenario: A later queryArchivedTable after prefetchArchive reuses the warmed manifest
+    Given prefetchArchive has warmed the manifest for "contratos"
+    When queryArchivedTable is called for "contratos" filtered by "cnpj_orgao"
     Then the IA manifest should have been fetched exactly once
     And DuckDB should have been initialized exactly once
 
-  Scenario: Multi-table wrappers route through the table allow-list
+  Scenario: queryArchivedOrgaos requests the orgaos parquet snapshot
+    Given the IA manifest resolves to a parquet url for every table
     When queryArchivedOrgaos is called
-    And queryArchivedUnidades is called
-    And queryArchivedFornecedores is called
-    Then each call should request its own parquet snapshot from the manifest
+    Then the query should be routed to the "orgaos" parquet snapshot
+
+  Scenario: queryArchivedUnidades requests the unidades parquet snapshot
+    Given the IA manifest resolves to a parquet url for every table
+    When queryArchivedUnidades is called
+    Then the query should be routed to the "unidades" parquet snapshot
+
+  Scenario: queryArchivedFornecedores requests the fornecedores parquet snapshot
+    Given the IA manifest resolves to a parquet url for every table
+    When queryArchivedFornecedores is called
+    Then the query should be routed to the "fornecedores" parquet snapshot
 
   Scenario: Malformed manifest rows are skipped with a warning
     Given the IA manifest endpoint returns a CSV with a valid contratos row and a malformed row missing parquet_url

--- a/web/features/atas.feature
+++ b/web/features/atas.feature
@@ -18,7 +18,7 @@ Feature: Atas de Registro de Preços Browser
     Given the URL has objeto "papel A4"
     And the archive lookup is pending
     When the atas view mounts
-    Then I should see an aria-busy element
+    Then I should see a loading skeleton
 
   Scenario: Archive failure shows AlertBanner
     Given the URL has objeto "papel A4"

--- a/web/features/city-detail.feature
+++ b/web/features/city-detail.feature
@@ -11,7 +11,7 @@ Feature: City Detail View
     Given the URL has ibge "1721000"
     And the fetch is pending
     When the city detail view mounts
-    Then I should see an aria-busy element
+    Then I should see a loading skeleton
 
   Scenario: Fetch error shows AlertBanner
     Given the URL has ibge "1721000"

--- a/web/features/contract-detail.feature
+++ b/web/features/contract-detail.feature
@@ -11,7 +11,7 @@ Feature: Contract Detail View
     Given the URL has id "00000000000191-1-000001/2024"
     And the fetch is pending
     When the contract detail view mounts
-    Then I should see an aria-busy element
+    Then I should see a loading skeleton
 
   Scenario: Fetch error shows AlertBanner
     Given the URL has id "00000000000191-1-000001/2024"

--- a/web/features/dashboard.feature
+++ b/web/features/dashboard.feature
@@ -21,4 +21,4 @@ Feature: Dashboard Stats
   Scenario: Skeleton cards not visible after data loads
     Given the fetch returns valid stats
     When the dashboard has finished loading
-    Then I should not see any aria-busy element
+    Then I should not see a loading skeleton

--- a/web/features/duckdb-explorer.feature
+++ b/web/features/duckdb-explorer.feature
@@ -8,39 +8,39 @@ Feature: DuckDB SQL Explorer
     And the SQL textarea should contain "SELECT"
 
   Scenario: Featured query chip inserts SQL into textarea
-    When the explorer mounts
-    And the user clicks a featured query chip
+    Given the explorer has mounted
+    When the user clicks a featured query chip
     Then the SQL textarea should contain the chip's SQL
 
   Scenario: IA_URL placeholder shows warning and disables button
-    When the explorer mounts
-    And the user clicks a featured query chip that still contains "IA_URL"
+    Given the explorer has mounted
+    When the user clicks a featured query chip that still contains "IA_URL"
     Then I should see a placeholder warning
     And the explore button should be disabled
 
   Scenario: Valid SQL executes and renders results
     Given DuckDB returns one row with column "n" equal to 1
-    When the explorer mounts
-    And the user clicks "Explorar Dados"
+    And the explorer has mounted
+    When the user clicks "Explorar Dados"
     Then I should see a results table with "n" as a column header
 
   Scenario: Resolved IA URL replaces IA_URL placeholder in featured query chips
     Given the IA manifest resolves to "https://archive.org/download/baliza-pncp-2025-01/contratos-2025-01.parquet"
-    When the explorer mounts
-    And the user clicks a featured query chip
+    And the explorer has mounted
+    When the user clicks a featured query chip
     Then the SQL textarea should contain the resolved parquet URL
     And the SQL textarea should not contain "IA_URL"
 
   Scenario: Single quotes in resolved URL are escaped to prevent SQL injection
     Given the IA manifest resolves to a URL containing a single quote
-    When the explorer mounts
-    And the user clicks a featured query chip
+    And the explorer has mounted
+    When the user clicks a featured query chip
     Then the SQL textarea should contain the URL with doubled single quotes
 
   Scenario: Active query is backfilled when IA URL resolves after a chip click
     Given the IA manifest is slow to resolve to "https://archive.org/download/baliza-pncp-2025-01/contratos-2025-01.parquet"
-    When the explorer mounts
-    And the user clicks a featured query chip before the manifest resolves
-    And the manifest finishes resolving
+    And the explorer has mounted
+    And the user clicked a featured query chip before the manifest resolved
+    When the manifest finishes resolving
     Then the SQL textarea should contain the resolved parquet URL
     And the explore button should be enabled

--- a/web/features/duckdb-explorer.feature
+++ b/web/features/duckdb-explorer.feature
@@ -1,6 +1,9 @@
 @journey3 @journey5 @journey6 @green
 Feature: DuckDB SQL Explorer
-  The explorer lets analysts run SQL against Parquet files from Internet Archive.
+  Journalists, researchers, and developer integrators can run ad-hoc SQL
+  against Baliza's archived contract snapshots directly in the browser —
+  no download, no installation — so the same dataset that powers the
+  public views is reproducibly inspectable from anyone's machine.
 
   Scenario: Initial state shows explore button and default query
     When the explorer mounts

--- a/web/features/homepage.feature
+++ b/web/features/homepage.feature
@@ -31,4 +31,4 @@ Feature: Homepage Dashboard
   Scenario: No skeleton visible after data loads
     Given the fetch returns valid stats
     When the dashboard has finished loading
-    Then I should not see any aria-busy element
+    Then I should not see a loading skeleton

--- a/web/features/journeys/03_investigative_journalist.feature
+++ b/web/features/journeys/03_investigative_journalist.feature
@@ -26,7 +26,7 @@ Feature: Journey 3 — Investigative journalist
 
   @green @export
   Scenario: Export a result list as Markdown
-    # Covered by SearchHero data-testid="export-markdown" → clipboard GFM table.
+    # Covered by SearchHero "Exportar Markdown" button → clipboard GFM table.
     Given a search result list is visible for "hospital municipal"
     When the user clicks "Exportar Markdown"
     Then the clipboard contains a Markdown table with headers and rows

--- a/web/features/journeys/04_informed_citizen.feature
+++ b/web/features/journeys/04_informed_citizen.feature
@@ -21,7 +21,7 @@ Feature: Journey 4 — Informed citizen
 
   @green @plain-language
   Scenario: Detail page renders a plain-language summary above the schema dump
-    # Covered by ContractDetailView data-testid="plain-language-summary".
+    # Covered by ContractDetailView plain-language summary block.
     Given the user opens "/contratacao?id=00000000000191-1-000001/2024"
     Then the user sees a one-paragraph summary that names the buyer, supplier, value and what was bought
 

--- a/web/features/journeys/05_academic_researcher.feature
+++ b/web/features/journeys/05_academic_researcher.feature
@@ -27,7 +27,7 @@ Feature: Journey 5 — Academic researcher
 
   @green @citation
   Scenario: Generate a citable reference block for the current snapshot
-    # Covered by CitationBlock on /sobre (data-testid=open-citation, bibtex-block, citation-meta).
+    # Covered by CitationBlock on /sobre (citation trigger, BibTeX block, citation metadata).
     Given the user opens "/sobre"
     When the user clicks "Gerar citação acadêmica"
     Then a BibTeX block is rendered with the snapshot date and Internet Archive item URL

--- a/web/features/journeys/07_auditor_watchdog.feature
+++ b/web/features/journeys/07_auditor_watchdog.feature
@@ -38,7 +38,7 @@ Feature: Journey 7 — Auditor and watchdog
 
   @green @alerts
   Scenario: Subscribe to a CNPJ from its agency or supplier page
-    # Covered by AgencyDetailView data-testid="subscribe-agency" → saveWatch kind=cnpj-agency.
+    # Covered by AgencyDetailView "Receber alertas deste órgão" button → saveWatch kind=cnpj-agency.
     Given the user opens "/orgao?cnpj=00000000000191"
     When the user clicks "Receber alertas deste órgão"
     Then a watch is created with the agency CNPJ as the filter

--- a/web/features/local-bids.feature
+++ b/web/features/local-bids.feature
@@ -41,4 +41,4 @@ Feature: Local Bids Geolocation
     Given geolocation succeeds with IBGE "1721000"
     And the PNCP fetch is pending
     When the user activates the locator
-    Then I should see a skeleton loader with aria-busy
+    Then I should see a loading skeleton

--- a/web/features/pncp-id.feature
+++ b/web/features/pncp-id.feature
@@ -12,25 +12,17 @@ Feature: PNCP ID canonical parsing
     And the result should have sequencial "000001"
     And the result should have ano "2024"
 
-  Scenario: Hyphen-only ID is rejected
-    Given the PNCP ID "12345678000195-1-000001-1"
+  Scenario Outline: Non-canonical PNCP IDs are rejected
+    Given the PNCP ID "<input>"
     When it is parsed
     Then the result should be null
 
-  Scenario: Missing year segment is rejected
-    Given the PNCP ID "12345678000195-1-000001"
-    When it is parsed
-    Then the result should be null
-
-  Scenario: Three-digit year is rejected
-    Given the PNCP ID "12345678000195-1-000001/202"
-    When it is parsed
-    Then the result should be null
-
-  Scenario: Lowercase letters are rejected
-    Given the PNCP ID "abcdefghijklmn-1-000001/2024"
-    When it is parsed
-    Then the result should be null
+    Examples:
+      | input                        |
+      | 12345678000195-1-000001-1    |
+      | 12345678000195-1-000001      |
+      | 12345678000195-1-000001/202  |
+      | abcdefghijklmn-1-000001/2024 |
 
   Scenario: ContractDetailView renders a targeted EntityNotFound for non-canonical IDs
     Given the URL has id "12345678000195-1-000001-1"

--- a/web/features/search-hero.feature
+++ b/web/features/search-hero.feature
@@ -22,17 +22,15 @@ Feature: Search Hero
     Given the user types "12345678000195-1-000001/2024" into the search box
     Then I should see "Ver Contratação" as a jump suggestion
 
-  Scenario: Reject PNCP ID with missing year segment
-    Given the user types "12345678000195-1-000001" into the search box
+  Scenario Outline: Non-canonical PNCP IDs show no jump suggestion
+    Given the user types "<input>" into the search box
     Then I should not see any jump suggestion
 
-  Scenario: Reject PNCP ID with 3-digit year
-    Given the user types "12345678000195-1-000001/202" into the search box
-    Then I should not see any jump suggestion
-
-  Scenario: Reject hyphen-only PNCP ID
-    Given the user types "12345678000195-1-000001-1" into the search box
-    Then I should not see any jump suggestion
+    Examples:
+      | input                       |
+      | 12345678000195-1-000001     |
+      | 12345678000195-1-000001/202 |
+      | 12345678000195-1-000001-1   |
 
   Scenario: Short query shows no jump suggestion
     Given the user types "ab" into the search box

--- a/web/features/supplier-detail.feature
+++ b/web/features/supplier-detail.feature
@@ -12,7 +12,7 @@ Feature: Supplier Detail View
     Given the URL has cnpj "12345678000195"
     And the archive lookup is pending
     When the supplier detail view mounts
-    Then I should see an aria-busy element
+    Then I should see a loading skeleton
 
   Scenario: Archive failure shows AlertBanner
     Given the URL has cnpj "12345678000195"

--- a/web/features/theme-toggle.feature
+++ b/web/features/theme-toggle.feature
@@ -1,6 +1,7 @@
 @journey3 @journey4 @journey5 @journey7 @green
 Feature: Theme Toggle
-  O usuário pode alternar entre tema claro e escuro.
+  A visitor can toggle between light and dark themes, and their choice
+  sticks across reloads and respects system preferences on first visit.
 
   Scenario: Theme toggle persists choice across reloads
     Given the page loads with no stored theme preference

--- a/web/src/components/__steps__/agency-detail.steps.ts
+++ b/web/src/components/__steps__/agency-detail.steps.ts
@@ -56,7 +56,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await tick();
     });
 
-    Then('I should see an aria-busy element', async () => {
+    Then('I should see a loading skeleton', async () => {
       await waitFor(() =>
         expect(document.querySelector('[aria-busy="true"]')).toBeTruthy(),
       );

--- a/web/src/components/__steps__/archive-fallback.steps.ts
+++ b/web/src/components/__steps__/archive-fallback.steps.ts
@@ -326,23 +326,38 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
   });
 
-  Scenario('prefetchArchive warms the manifest without booting DuckDB', ({ Given, When, Then, And }) => {
-    Given('prefetchArchive was called for "contratos"', async () => {
+  Scenario('prefetchArchive warms the manifest without booting DuckDB', ({ Given, When, Then }) => {
+    Given('the IA manifest resolves to a parquet url', () => {
+      fetchSpy = installManifestFetch(200, manifestCsvAllTables());
+      queryMock.mockResolvedValue({
+        toArray: () => [{ toJSON: () => ({ numero_controle_pncp: 'x' }) }],
+      });
+    });
+    When('prefetchArchive is called for "contratos"', async () => {
+      const { prefetchArchive } = await import('../../lib/parquetFallback');
+      prefetchArchive('contratos');
+      // Let the fire-and-forget manifest fetch settle before the assertion.
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    Then('DuckDB should not have been initialized', () => {
+      expect(duckdbInitCount).toBe(0);
+      expect(getDuckDBSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  Scenario('A later queryArchivedTable after prefetchArchive reuses the warmed manifest', ({ Given, When, Then, And }) => {
+    Given('prefetchArchive has warmed the manifest for "contratos"', async () => {
       fetchSpy = installManifestFetch(200, manifestCsvAllTables());
       queryMock.mockResolvedValue({
         toArray: () => [{ toJSON: () => ({ numero_controle_pncp: 'x' }) }],
       });
       const { prefetchArchive } = await import('../../lib/parquetFallback');
       prefetchArchive('contratos');
-      // Let the fire-and-forget manifest fetch settle before the "later" query.
       await new Promise((r) => setTimeout(r, 0));
       await new Promise((r) => setTimeout(r, 0));
     });
-    Then('DuckDB should not have been initialized yet', () => {
-      expect(duckdbInitCount).toBe(0);
-      expect(getDuckDBSpy).not.toHaveBeenCalled();
-    });
-    When('the caller later invokes queryArchivedTable for "contratos" filtered by "cnpj_orgao"', async () => {
+    When('queryArchivedTable is called for "contratos" filtered by "cnpj_orgao"', async () => {
       result = await callArchive('contratos', 'cnpj_orgao');
     });
     Then('the IA manifest should have been fetched exactly once', () => {
@@ -395,38 +410,65 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     );
   });
 
-  Scenario('Multi-table wrappers route through the table allow-list', ({ When, And, Then }) => {
-    const calls: Array<{ table: string; sql: string }> = [];
+  function detectTable(sql: string): string {
+    const entry = Object.entries(PARQUET_URL_BY_TABLE).find(([, url]) =>
+      sql.includes(url),
+    );
+    return entry ? entry[0] : 'unknown';
+  }
 
+  function installManifestAndCapture(): Array<{ table: string; sql: string }> {
+    const calls: Array<{ table: string; sql: string }> = [];
+    fetchSpy = installManifestFetch(200, manifestCsvAllTables());
+    queryMock.mockImplementation(async (sql: string) => {
+      calls.push({ table: detectTable(sql), sql });
+      return { toArray: () => [{ toJSON: () => ({ cnpj: '00' }) }] };
+    });
+    return calls;
+  }
+
+  Scenario('queryArchivedOrgaos requests the orgaos parquet snapshot', ({ Given, When, Then }) => {
+    let calls: Array<{ table: string; sql: string }>;
+    Given('the IA manifest resolves to a parquet url for every table', () => {
+      calls = installManifestAndCapture();
+    });
     When('queryArchivedOrgaos is called', async () => {
-      fetchSpy = installManifestFetch(200, manifestCsvAllTables());
-      queryMock.mockImplementation(async (sql: string) => {
-        calls.push({ table: detectTable(sql), sql });
-        return { toArray: () => [{ toJSON: () => ({ cnpj: '00' }) }] };
-      });
       const { queryArchivedOrgaos } = await import('../../lib/parquetFallback');
       await queryArchivedOrgaos('cnpj', '00000000000191');
     });
-    And('queryArchivedUnidades is called', async () => {
+    Then('the query should be routed to the "orgaos" parquet snapshot', () => {
+      expect(calls).toHaveLength(1);
+      expect(calls[0].table).toBe('orgaos');
+    });
+  });
+
+  Scenario('queryArchivedUnidades requests the unidades parquet snapshot', ({ Given, When, Then }) => {
+    let calls: Array<{ table: string; sql: string }>;
+    Given('the IA manifest resolves to a parquet url for every table', () => {
+      calls = installManifestAndCapture();
+    });
+    When('queryArchivedUnidades is called', async () => {
       const { queryArchivedUnidades } = await import('../../lib/parquetFallback');
       await queryArchivedUnidades('codigo_unidade', '1');
     });
-    And('queryArchivedFornecedores is called', async () => {
+    Then('the query should be routed to the "unidades" parquet snapshot', () => {
+      expect(calls).toHaveLength(1);
+      expect(calls[0].table).toBe('unidades');
+    });
+  });
+
+  Scenario('queryArchivedFornecedores requests the fornecedores parquet snapshot', ({ Given, When, Then }) => {
+    let calls: Array<{ table: string; sql: string }>;
+    Given('the IA manifest resolves to a parquet url for every table', () => {
+      calls = installManifestAndCapture();
+    });
+    When('queryArchivedFornecedores is called', async () => {
       const { queryArchivedFornecedores } = await import('../../lib/parquetFallback');
       await queryArchivedFornecedores('ni_fornecedor', '00000000000191');
     });
-    Then('each call should request its own parquet snapshot from the manifest', () => {
-      expect(calls).toHaveLength(3);
-      expect(calls.map((c) => c.table).sort()).toEqual(
-        ['fornecedores', 'orgaos', 'unidades'].sort(),
-      );
+    Then('the query should be routed to the "fornecedores" parquet snapshot', () => {
+      expect(calls).toHaveLength(1);
+      expect(calls[0].table).toBe('fornecedores');
     });
-
-    function detectTable(sql: string): string {
-      const entry = Object.entries(PARQUET_URL_BY_TABLE).find(([, url]) =>
-        sql.includes(url),
-      );
-      return entry ? entry[0] : 'unknown';
-    }
   });
 });

--- a/web/src/components/__steps__/archive-fallback.steps.ts
+++ b/web/src/components/__steps__/archive-fallback.steps.ts
@@ -471,4 +471,29 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       expect(calls[0].table).toBe('fornecedores');
     });
   });
+
+  // Exercises the non-contamination invariant: invoking the three wrappers
+  // in one runtime sequence (no BeforeEachScenario reset between them) must
+  // still route each call to its own parquet snapshot. Guards against a
+  // regression where ia-manifest or parquetFallback caches become keyed
+  // too broadly and a later wrapper reuses an earlier wrapper's URL.
+  Scenario('Consecutive wrapper calls each hit their own parquet snapshot', ({ Given, When, Then }) => {
+    let calls: Array<{ table: string; sql: string }>;
+    Given('the IA manifest resolves to a parquet url for every table', () => {
+      calls = installManifestAndCapture();
+    });
+    When('queryArchivedOrgaos, queryArchivedUnidades and queryArchivedFornecedores are called in sequence', async () => {
+      const { queryArchivedOrgaos, queryArchivedUnidades, queryArchivedFornecedores } =
+        await import('../../lib/parquetFallback');
+      await queryArchivedOrgaos('cnpj', '00000000000191');
+      await queryArchivedUnidades('codigo_unidade', '1');
+      await queryArchivedFornecedores('ni_fornecedor', '00000000000191');
+    });
+    Then('each wrapper should route to its own parquet snapshot', () => {
+      expect(calls).toHaveLength(3);
+      expect(calls.map((c) => c.table).sort()).toEqual(
+        ['fornecedores', 'orgaos', 'unidades'],
+      );
+    });
+  });
 });

--- a/web/src/components/__steps__/atas.steps.ts
+++ b/web/src/components/__steps__/atas.steps.ts
@@ -93,7 +93,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await tick();
     });
 
-    Then('I should see an aria-busy element', async () => {
+    Then('I should see a loading skeleton', async () => {
       await waitFor(() =>
         expect(document.querySelector('[aria-busy="true"]')).toBeTruthy(),
       );

--- a/web/src/components/__steps__/city-detail.steps.ts
+++ b/web/src/components/__steps__/city-detail.steps.ts
@@ -56,7 +56,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await tick();
     });
 
-    Then('I should see an aria-busy element', async () => {
+    Then('I should see a loading skeleton', async () => {
       await waitFor(() =>
         expect(document.querySelector('[aria-busy="true"]')).toBeTruthy(),
       );

--- a/web/src/components/__steps__/contract-detail.steps.ts
+++ b/web/src/components/__steps__/contract-detail.steps.ts
@@ -91,7 +91,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await tick();
     });
 
-    Then('I should see an aria-busy element', async () => {
+    Then('I should see a loading skeleton', async () => {
       await waitFor(() =>
         expect(document.querySelector('[aria-busy="true"]')).toBeTruthy(),
       );

--- a/web/src/components/__steps__/dashboard.steps.ts
+++ b/web/src/components/__steps__/dashboard.steps.ts
@@ -78,7 +78,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
 
     When('the dashboard has finished loading', () => {});
 
-    Then('I should not see any aria-busy element', () => {
+    Then('I should not see a loading skeleton', () => {
       expect(document.querySelector('[aria-busy="true"]')).toBeNull();
     });
   });

--- a/web/src/components/__steps__/duckdb-explorer.steps.ts
+++ b/web/src/components/__steps__/duckdb-explorer.steps.ts
@@ -42,15 +42,15 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
   });
 
-  Scenario("Featured query chip inserts SQL into textarea", ({ When, And, Then }) => {
-    When('the explorer mounts', async () => {
+  Scenario("Featured query chip inserts SQL into textarea", ({ Given, When, Then }) => {
+    Given('the explorer has mounted', async () => {
       render(DuckDBExplorer);
       await tick();
     });
 
     let picked: { label: string; sql: string } | null = null;
 
-    And('the user clicks a featured query chip', async () => {
+    When('the user clicks a featured query chip', async () => {
       picked = FEATURED_QUERIES[0];
       await fireEvent.click(screen.getByText(picked.label));
       await tick();
@@ -62,13 +62,13 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
   });
 
-  Scenario('IA_URL placeholder shows warning and disables button', ({ When, And, Then }) => {
-    When('the explorer mounts', async () => {
+  Scenario('IA_URL placeholder shows warning and disables button', ({ Given, When, Then, And }) => {
+    Given('the explorer has mounted', async () => {
       render(DuckDBExplorer);
       await tick();
     });
 
-    And('the user clicks a featured query chip that still contains "IA_URL"', async () => {
+    When('the user clicks a featured query chip that still contains "IA_URL"', async () => {
       const fq = chipThatNeedsIaUrl();
       await fireEvent.click(screen.getByText(fq.label));
       await tick();
@@ -84,7 +84,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
   });
 
-  Scenario('Valid SQL executes and renders results', ({ Given, When, And, Then }) => {
+  Scenario('Valid SQL executes and renders results', ({ Given, And, When, Then }) => {
     Given('DuckDB returns one row with column "n" equal to 1', () => {
       vi.spyOn(duckdbModule, 'getDuckDB').mockResolvedValue({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -98,12 +98,12 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       });
     });
 
-    When('the explorer mounts', async () => {
+    And('the explorer has mounted', async () => {
       render(DuckDBExplorer);
       await tick();
     });
 
-    And('the user clicks "Explorar Dados"', async () => {
+    When('the user clicks "Explorar Dados"', async () => {
       const textarea = getTextarea();
       await fireEvent.input(textarea, { target: { value: 'SELECT 1 AS n' } });
       await tick();
@@ -123,7 +123,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
 
   Scenario(
     'Resolved IA URL replaces IA_URL placeholder in featured query chips',
-    ({ Given, When, And, Then }) => {
+    ({ Given, And, When, Then }) => {
       const resolvedUrl =
         'https://archive.org/download/baliza-pncp-2025-01/contratos-2025-01.parquet';
 
@@ -136,12 +136,12 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
         },
       );
 
-      When('the explorer mounts', async () => {
+      And('the explorer has mounted', async () => {
         render(DuckDBExplorer);
         await tick();
       });
 
-      And('the user clicks a featured query chip', async () => {
+      When('the user clicks a featured query chip', async () => {
         const fq = FEATURED_QUERIES.find((q) => q.sql.includes("'IA_URL'"));
         if (!fq) throw new Error('No featured query contains IA_URL');
         await waitFor(() => screen.getByText(fq.label));
@@ -166,7 +166,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
 
   Scenario(
     'Single quotes in resolved URL are escaped to prevent SQL injection',
-    ({ Given, When, And, Then }) => {
+    ({ Given, And, When, Then }) => {
       const maliciousUrl = "https://example.com/evil'; DROP TABLE x; --";
 
       Given('the IA manifest resolves to a URL containing a single quote', () => {
@@ -175,12 +175,12 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
         );
       });
 
-      When('the explorer mounts', async () => {
+      And('the explorer has mounted', async () => {
         render(DuckDBExplorer);
         await tick();
       });
 
-      And('the user clicks a featured query chip', async () => {
+      When('the user clicks a featured query chip', async () => {
         const fq = FEATURED_QUERIES.find((q) => q.sql.includes("'IA_URL'"));
         if (!fq) throw new Error('No featured query contains IA_URL');
         await waitFor(() => screen.getByText(fq.label));
@@ -204,7 +204,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
 
   Scenario(
     'Active query is backfilled when IA URL resolves after a chip click',
-    ({ Given, When, And, Then }) => {
+    ({ Given, And, When, Then }) => {
       const resolvedUrl =
         'https://archive.org/download/baliza-pncp-2025-01/contratos-2025-01.parquet';
       let resolveManifest: (url: string | null) => void = () => {};
@@ -221,13 +221,13 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
         },
       );
 
-      When('the explorer mounts', async () => {
+      And('the explorer has mounted', async () => {
         render(DuckDBExplorer);
         await tick();
       });
 
       And(
-        'the user clicks a featured query chip before the manifest resolves',
+        'the user clicked a featured query chip before the manifest resolved',
         async () => {
           const fq = FEATURED_QUERIES.find((q) => q.sql.includes("'IA_URL'"));
           if (!fq) throw new Error('No featured query contains IA_URL');
@@ -237,7 +237,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
         },
       );
 
-      And('the manifest finishes resolving', async () => {
+      When('the manifest finishes resolving', async () => {
         resolveManifest(resolvedUrl);
         await tick();
         await tick();

--- a/web/src/components/__steps__/homepage.steps.ts
+++ b/web/src/components/__steps__/homepage.steps.ts
@@ -113,7 +113,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
 
     When('the dashboard has finished loading', () => {});
 
-    Then('I should not see any aria-busy element', () => {
+    Then('I should not see a loading skeleton', () => {
       expect(document.querySelector('[aria-busy="true"]')).toBeNull();
     });
   });

--- a/web/src/components/__steps__/local-bids.steps.ts
+++ b/web/src/components/__steps__/local-bids.steps.ts
@@ -309,7 +309,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await fireEvent.click(screen.getByText('Ativar Localizador'));
     });
 
-    Then('I should see a skeleton loader with aria-busy', async () => {
+    Then('I should see a loading skeleton', async () => {
       await waitFor(
         () => {
           const busy = document.querySelector('[aria-busy="true"]');

--- a/web/src/components/__steps__/pncp-id.steps.ts
+++ b/web/src/components/__steps__/pncp-id.steps.ts
@@ -13,7 +13,7 @@ function setUrlQuery(qs: string) {
   window.history.replaceState({}, '', qs ? `/?${qs}` : '/');
 }
 
-describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
+describeFeature(feature, ({ Scenario, ScenarioOutline, BeforeEachScenario }) => {
   let raw = '';
   let parsed: PncpId | null = null;
 
@@ -46,53 +46,20 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
   });
 
-  Scenario('Hyphen-only ID is rejected', ({ Given, When, Then }) => {
-    Given('the PNCP ID "12345678000195-1-000001-1"', () => {
-      raw = '12345678000195-1-000001-1';
-    });
-    When('it is parsed', () => {
-      parsed = parsePncpId(raw);
-    });
-    Then('the result should be null', () => {
-      expect(parsed).toBeNull();
-    });
-  });
-
-  Scenario('Missing year segment is rejected', ({ Given, When, Then }) => {
-    Given('the PNCP ID "12345678000195-1-000001"', () => {
-      raw = '12345678000195-1-000001';
-    });
-    When('it is parsed', () => {
-      parsed = parsePncpId(raw);
-    });
-    Then('the result should be null', () => {
-      expect(parsed).toBeNull();
-    });
-  });
-
-  Scenario('Three-digit year is rejected', ({ Given, When, Then }) => {
-    Given('the PNCP ID "12345678000195-1-000001/202"', () => {
-      raw = '12345678000195-1-000001/202';
-    });
-    When('it is parsed', () => {
-      parsed = parsePncpId(raw);
-    });
-    Then('the result should be null', () => {
-      expect(parsed).toBeNull();
-    });
-  });
-
-  Scenario('Lowercase letters are rejected', ({ Given, When, Then }) => {
-    Given('the PNCP ID "abcdefghijklmn-1-000001/2024"', () => {
-      raw = 'abcdefghijklmn-1-000001/2024';
-    });
-    When('it is parsed', () => {
-      parsed = parsePncpId(raw);
-    });
-    Then('the result should be null', () => {
-      expect(parsed).toBeNull();
-    });
-  });
+  ScenarioOutline(
+    'Non-canonical PNCP IDs are rejected',
+    ({ Given, When, Then }, vars) => {
+      Given('the PNCP ID "<input>"', () => {
+        raw = String(vars.input);
+      });
+      When('it is parsed', () => {
+        parsed = parsePncpId(raw);
+      });
+      Then('the result should be null', () => {
+        expect(parsed).toBeNull();
+      });
+    },
+  );
 
   Scenario('ContractDetailView renders a targeted EntityNotFound for non-canonical IDs', ({ Given, When, Then, And }) => {
     Given('the URL has id "12345678000195-1-000001-1"', () => {

--- a/web/src/components/__steps__/search-hero.steps.ts
+++ b/web/src/components/__steps__/search-hero.steps.ts
@@ -24,7 +24,7 @@ function stubLocationAssign() {
   return assign;
 }
 
-describeFeature(feature, ({ Scenario, BeforeEachScenario, AfterEachScenario }) => {
+describeFeature(feature, ({ Scenario, ScenarioOutline, BeforeEachScenario, AfterEachScenario }) => {
   const originalInnerWidth = window.innerWidth;
 
   BeforeEachScenario(async () => {
@@ -213,41 +213,20 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario, AfterEachScenario }) =
     });
   });
 
-  Scenario('Reject PNCP ID with missing year segment', ({ Given, Then }) => {
-    Given('the user types "12345678000195-1-000001" into the search box', async () => {
-      render(SearchHero);
-      await tick();
-      await typeInSearch('12345678000195-1-000001');
-    });
+  ScenarioOutline(
+    'Non-canonical PNCP IDs show no jump suggestion',
+    ({ Given, Then }, vars) => {
+      Given('the user types "<input>" into the search box', async () => {
+        render(SearchHero);
+        await tick();
+        await typeInSearch(String(vars.input));
+      });
 
-    Then('I should not see any jump suggestion', () => {
-      expect(screen.queryByText(/Ver Contratação/)).toBeNull();
-    });
-  });
-
-  Scenario('Reject PNCP ID with 3-digit year', ({ Given, Then }) => {
-    Given('the user types "12345678000195-1-000001/202" into the search box', async () => {
-      render(SearchHero);
-      await tick();
-      await typeInSearch('12345678000195-1-000001/202');
-    });
-
-    Then('I should not see any jump suggestion', () => {
-      expect(screen.queryByText(/Ver Contratação/)).toBeNull();
-    });
-  });
-
-  Scenario('Reject hyphen-only PNCP ID', ({ Given, Then }) => {
-    Given('the user types "12345678000195-1-000001-1" into the search box', async () => {
-      render(SearchHero);
-      await tick();
-      await typeInSearch('12345678000195-1-000001-1');
-    });
-
-    Then('I should not see any jump suggestion', () => {
-      expect(screen.queryByText(/Ver Contratação/)).toBeNull();
-    });
-  });
+      Then('I should not see any jump suggestion', () => {
+        expect(screen.queryByText(/Ver Contratação/)).toBeNull();
+      });
+    },
+  );
 
   Scenario('Free text triggers a PNCP search and renders results listbox', ({ Given, When, Then, And }) => {
     Given('the PNCP search API returns two results for "hospital"', () => {

--- a/web/src/components/__steps__/supplier-detail.steps.ts
+++ b/web/src/components/__steps__/supplier-detail.steps.ts
@@ -69,7 +69,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await tick();
     });
 
-    Then('I should see an aria-busy element', async () => {
+    Then('I should see a loading skeleton', async () => {
       await waitFor(() =>
         expect(document.querySelector('[aria-busy="true"]')).toBeTruthy(),
       );


### PR DESCRIPTION
## Summary
Refactored BDD test scenarios across archive-fallback and duckdb-explorer features to strictly follow the Given-When-Then pattern, improving test clarity and maintainability.

## Key Changes

### archive-fallback.steps.ts
- Split "prefetchArchive warms the manifest without booting DuckDB" scenario into two focused scenarios:
  - First scenario validates that prefetchArchive doesn't initialize DuckDB
  - New scenario "A later queryArchivedTable after prefetchArchive reuses the warmed manifest" tests the subsequent behavior
- Refactored "Multi-table wrappers route through the table allow-list" into three separate scenarios:
  - "queryArchivedOrgaos requests the orgaos parquet snapshot"
  - "queryArchivedUnidades requests the unidades parquet snapshot"
  - "queryArchivedFornecedores requests the fornecedores parquet snapshot"
- Extracted helper functions `detectTable()` and `installManifestAndCapture()` to reduce duplication
- Corrected step keywords to match proper Given-When-Then flow

### duckdb-explorer.steps.ts
- Reorganized step keywords across multiple scenarios to follow Given-When-Then order:
  - Changed "When the explorer mounts" to "Given the explorer has mounted"
  - Adjusted subsequent steps to use appropriate When/And keywords
  - Updated step descriptions to use past tense where appropriate (e.g., "has mounted", "clicked", "resolved")

### Feature files
- Updated corresponding .feature files to match the refactored step implementations
- Improved scenario descriptions to be more specific and focused on single behaviors

## Benefits
- Clearer test intent with proper Given (setup) → When (action) → Then (assertion) flow
- Reduced test duplication through helper function extraction
- Each scenario now tests a single behavior, improving maintainability
- Better alignment between feature files and step implementations

https://claude.ai/code/session_013vfhWrhB1nXMhhy63yr5AU