### PR TITLE
fix: skip consolidation years with 404 source files instead of failing

### DIFF
--- a/src/baliza/consolidator.py
+++ b/src/baliza/consolidator.py
@@ -198,14 +198,24 @@ class IAConsolidator:
             with duckdb.connect(":memory:") as con:
                 con.execute("INSTALL httpfs; LOAD httpfs;")
                 console.print(f"  Merging {len(daily_urls)} files via httpfs...")
-                con.execute(f"""
-                    COPY (
-                        SELECT *
-                        FROM read_parquet([{url_list}])
-                        ORDER BY cnpj_orgao, data_publicacao DESC, numero_controle_pncp
-                    ) TO '{output_path}'
-                    ({DUCKDB_PARQUET_COPY_OPTIONS})
-                """)
+                try:
+                    con.execute(f"""
+                        COPY (
+                            SELECT *
+                            FROM read_parquet([{url_list}])
+                            ORDER BY cnpj_orgao, data_publicacao DESC, numero_controle_pncp
+                        ) TO '{output_path}'
+                        ({DUCKDB_PARQUET_COPY_OPTIONS})
+                    """)
+                except Exception as e:
+                    if "404" in str(e) or "Not Found" in str(e):
+                        console.print(
+                            f"[yellow]⚠ Skipping {year}: one or more source files "
+                            f"returned HTTP 404 (file may have been removed from IA). "
+                            f"Will retry on a future run.[/yellow]"
+                        )
+                        return False
+                    raise
 
                 size_mb = output_path.stat().st_size / 1_048_576
                 console.print(

--- a/src/baliza/consolidator.py
+++ b/src/baliza/consolidator.py
@@ -208,7 +208,7 @@ class IAConsolidator:
                         ({DUCKDB_PARQUET_COPY_OPTIONS})
                     """)
                 except Exception as e:
-                    if "404" in str(e) or "Not Found" in str(e):
+                    if "HTTP 404" in str(e):
                         console.print(
                             f"[yellow]⚠ Skipping {year}: one or more source files "
                             f"returned HTTP 404 (file may have been removed from IA). "


### PR DESCRIPTION
## Summary

- The workflow was failing with exit code 1 because `contratos-2023-04.parquet` at `archive.org/download/baliza-pncp-2023-04/` returned HTTP 404
- DuckDB's httpfs extension throws an exception on 404, which propagated uncaught through `consolidate_year` → `consolidate_all` → the CLI, triggering `sys.exit(1)`
- Fix: wrap the DuckDB `read_parquet` call in a try/except; if the error message contains `"404"` or `"Not Found"`, log a warning and return `False` (skip year) instead of re-raising

## Test plan

- [ ] Run the sync workflow — consolidation for 2023 should now log a yellow warning and skip rather than fail the entire job
- [ ] Verify non-404 DuckDB errors (e.g. network timeouts, parse errors) still propagate and fail loudly
- [ ] Verify consolidation for years with all files present still works end-to-end

https://claude.ai/code/session_01HbELEQuRUZUnGPHwESpuEJ