### PR TITLE
feat: two-phase pipeline — mirror (fetch+zip) and build (ingest+parquet)

### DIFF
--- a/.github/workflows/pncp-backfill.yml
+++ b/.github/workflows/pncp-backfill.yml
@@ -1,0 +1,85 @@
+name: PNCP Backfill
+
+# Regenerate Parquet files from existing raw ZIPs on Internet Archive.
+# Run this when the Parquet schema changes (SCHEMA_VERSION bump) to rebuild
+# all historical months from the raw JSON mirror without re-fetching from PNCP.
+#
+# Runs independently from the regular cron — trigger manually via workflow_dispatch.
+on:
+  workflow_dispatch:
+    inputs:
+      start_year:
+        description: 'Earliest year to backfill (e.g. 2023)'
+        required: false
+        default: '2023'
+      dry_run:
+        description: 'Ingest and validate without uploading'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: pncp-backfill
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  backfill:
+    name: Backfill Parquet from raw ZIPs
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - name: Run backfill
+        env:
+          IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
+          IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
+        run: |
+          DRY_RUN_FLAG=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          uv run baliza build \
+            --backfill \
+            --start-date "${{ inputs.start_year }}-01-01" \
+            --workers 2 \
+            $DRY_RUN_FLAG
+
+  report-failure:
+    name: Report backfill failure
+    if: ${{ failure() }}
+    needs: backfill
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open issue for failure
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const runId = context.runId;
+            const runUrl = `${context.payload.repository.html_url}/actions/runs/${runId}`;
+            const identifier = `run_id:${runId}`;
+
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} "${identifier}" state:open type:issue`
+            });
+            if (search.data.total_count > 0) return;
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: `🚨 Falha no workflow "PNCP Backfill" (run #${context.runNumber})`,
+              body: [
+                '@codex há uma falha no workflow de backfill.',
+                '',
+                `- **Workflow**: PNCP Backfill`,
+                `- **Execução**: [#${context.runNumber}](${runUrl})`,
+                `- **Identificador**: ${identifier}`,
+              ].join('\n'),
+              labels: ['ci-failure']
+            });

--- a/.github/workflows/pncp-backfill.yml
+++ b/.github/workflows/pncp-backfill.yml
@@ -1,10 +1,5 @@
 name: PNCP Backfill
 
-# Regenerate Parquet files from existing raw ZIPs on Internet Archive.
-# Run this when the Parquet schema changes (SCHEMA_VERSION bump) to rebuild
-# all historical months from the raw JSON mirror without re-fetching from PNCP.
-#
-# Runs independently from the regular cron — trigger manually via workflow_dispatch.
 on:
   workflow_dispatch:
     inputs:
@@ -28,58 +23,17 @@ permissions:
 
 jobs:
   backfill:
-    name: Backfill Parquet from raw ZIPs
     runs-on: ubuntu-latest
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
-      - name: Run backfill
-        env:
+      - env:
           IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
           IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
         run: |
-          DRY_RUN_FLAG=""
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            DRY_RUN_FLAG="--dry-run"
-          fi
           uv run baliza build \
             --backfill \
             --start-date "${{ inputs.start_year }}-01-01" \
             --workers 2 \
-            $DRY_RUN_FLAG
-
-  report-failure:
-    name: Report backfill failure
-    if: ${{ failure() }}
-    needs: backfill
-    runs-on: ubuntu-latest
-    steps:
-      - name: Open issue for failure
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { owner, repo } = context.repo;
-            const runId = context.runId;
-            const runUrl = `${context.payload.repository.html_url}/actions/runs/${runId}`;
-            const identifier = `run_id:${runId}`;
-
-            const search = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${owner}/${repo} "${identifier}" state:open type:issue`
-            });
-            if (search.data.total_count > 0) return;
-
-            await github.rest.issues.create({
-              owner,
-              repo,
-              title: `🚨 Falha no workflow "PNCP Backfill" (run #${context.runNumber})`,
-              body: [
-                '@codex há uma falha no workflow de backfill.',
-                '',
-                `- **Workflow**: PNCP Backfill`,
-                `- **Execução**: [#${context.runNumber}](${runUrl})`,
-                `- **Identificador**: ${identifier}`,
-              ].join('\n'),
-              labels: ['ci-failure']
-            });
+            ${{ inputs.dry_run && '--dry-run' || '' }}

--- a/.github/workflows/pncp-sync.yml
+++ b/.github/workflows/pncp-sync.yml
@@ -1,12 +1,5 @@
 name: PNCP Sync
 
-# Two-phase pipeline:
-#   mirror  → fetch PNCP JSON pages, upload monthly ZIPs to IA
-#   build   → download ZIPs from IA, ingest, export and upload Parquet
-#   consolidate → build annual consolidated Parquet from monthly files
-#
-# Jobs are encadeados (mirror → build → consolidate) so each phase runs only
-# after the previous one succeeds. The manifest is the shared source of truth.
 on:
   schedule:
     - cron: '*/30 * * * *'
@@ -31,10 +24,9 @@ permissions:
   issues: write
 
 jobs:
-  mirror:
-    name: Mirror — fetch pages and upload ZIPs
+  sync:
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
@@ -45,52 +37,30 @@ jobs:
           path: data/raw
           key: pncp-raw-${{ steps.month.outputs.key }}-${{ github.run_id }}
           restore-keys: pncp-raw-${{ steps.month.outputs.key }}-
-      - name: Run mirror
-        env:
+      - env:
           IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
           IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
         run: |
           uv run baliza mirror \
             --start-date "${{ inputs.start_date || '2023-01-01' }}" \
-            --limit-minutes 280
-
-  build:
-    name: Build — ingest ZIPs and upload Parquet
-    needs: mirror
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
-      - name: Run build
-        env:
+            --limit-minutes 160
+      - env:
           IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
           IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
         run: |
           uv run baliza build \
             --start-date "${{ inputs.start_date || '2023-01-01' }}" \
-            --limit-minutes 160
-
-  consolidate:
-    name: Consolidate — build annual Parquet from monthly files
-    needs: build
-    if: ${{ !inputs.no_consolidate }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
-      - name: Run consolidate
+            --limit-minutes 120
+      - if: ${{ !inputs.no_consolidate }}
         env:
           IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
           IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
-        run: |
-          uv run baliza consolidate --start-year 2021
+        run: uv run baliza consolidate --start-year 2021
 
   report-failure:
     name: Report workflow failure
     if: ${{ failure() }}
-    needs: [mirror, build, consolidate]
+    needs: sync
     runs-on: ubuntu-latest
     steps:
       - name: Open issue for failure

--- a/.github/workflows/pncp-sync.yml
+++ b/.github/workflows/pncp-sync.yml
@@ -1,9 +1,12 @@
 name: PNCP Sync
 
-# The single Baliza pipeline: `baliza sync` extracts missing months,
-# uploads them to Internet Archive, and opportunistically consolidates
-# annual archives — all inside the Python code. No other scheduled
-# workflows drive the data pipeline.
+# Two-phase pipeline:
+#   mirror  → fetch PNCP JSON pages, upload monthly ZIPs to IA
+#   build   → download ZIPs from IA, ingest, export and upload Parquet
+#   consolidate → build annual consolidated Parquet from monthly files
+#
+# Jobs are encadeados (mirror → build → consolidate) so each phase runs only
+# after the previous one succeeds. The manifest is the shared source of truth.
 on:
   schedule:
     - cron: '*/30 * * * *'
@@ -28,9 +31,10 @@ permissions:
   issues: write
 
 jobs:
-  sync:
+  mirror:
+    name: Mirror — fetch pages and upload ZIPs
     runs-on: ubuntu-latest
-    timeout-minutes: 360
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
@@ -41,23 +45,52 @@ jobs:
           path: data/raw
           key: pncp-raw-${{ steps.month.outputs.key }}-${{ github.run_id }}
           restore-keys: pncp-raw-${{ steps.month.outputs.key }}-
-      - env:
+      - name: Run mirror
+        env:
           IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
           IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
         run: |
-          CONSOLIDATE_FLAG=""
-          if [ "${{ inputs.no_consolidate }}" = "true" ]; then
-            CONSOLIDATE_FLAG="--no-consolidate"
-          fi
-          uv run baliza sync \
+          uv run baliza mirror \
             --start-date "${{ inputs.start_date || '2023-01-01' }}" \
-            --limit-minutes 340 \
-            $CONSOLIDATE_FLAG
+            --limit-minutes 280
+
+  build:
+    name: Build — ingest ZIPs and upload Parquet
+    needs: mirror
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - name: Run build
+        env:
+          IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
+          IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
+        run: |
+          uv run baliza build \
+            --start-date "${{ inputs.start_date || '2023-01-01' }}" \
+            --limit-minutes 160
+
+  consolidate:
+    name: Consolidate — build annual Parquet from monthly files
+    needs: build
+    if: ${{ !inputs.no_consolidate }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - name: Run consolidate
+        env:
+          IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
+          IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
+        run: |
+          uv run baliza consolidate --start-year 2021
 
   report-failure:
     name: Report workflow failure
     if: ${{ failure() }}
-    needs: sync
+    needs: [mirror, build, consolidate]
     runs-on: ubuntu-latest
     steps:
       - name: Open issue for failure

--- a/src/baliza/builder.py
+++ b/src/baliza/builder.py
@@ -19,7 +19,7 @@ import structlog
 from .daily_exporter import SCHEMA_VERSION
 from .engine import BalizaEngine
 from .extractor import PNCPExtractor
-from .ia_uploader import IAUploader, try_read_manifest_from_ia
+from .ia_uploader import IAUploader, read_manifest_from_ia
 
 logger = structlog.get_logger()
 
@@ -41,7 +41,7 @@ def _pending_build_months(
         (or Parquet missing).  This includes months uploaded via the old monolithic
         ``sync`` command that already have a ZIP on IA.
     """
-    raw_manifest = try_read_manifest_from_ia()
+    raw_manifest = read_manifest_from_ia()  # strict: raises ManifestReadError on failure
     today = date.today()
     last_month = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
     start = start_date.replace(day=1)

--- a/src/baliza/builder.py
+++ b/src/baliza/builder.py
@@ -87,7 +87,7 @@ def _download_raw_zip(item_id: str, month_str: str, dest: Path) -> Path:
     return zip_path
 
 
-def build_month(
+def build_month(  # noqa: PLR0915
     start_of_month: date,
     *,
     ia_access_key: str,
@@ -134,11 +134,16 @@ def build_month(
                 return result
             raise
 
-        # 2. Extract to raw_dir structure
+        # 2. Extract to raw_dir structure — validate member paths to prevent traversal
         raw_dir = tmp_path / "raw" / month_str
         raw_dir.mkdir(parents=True)
+        resolved_raw_dir = raw_dir.resolve()
         with zipfile.ZipFile(zip_path) as zf:
-            zf.extractall(raw_dir)
+            for member in zf.infolist():
+                target = (raw_dir / member.filename).resolve()
+                if not target.is_relative_to(resolved_raw_dir):
+                    raise ValueError(f"Unsafe ZIP entry (path traversal): {member.filename}")
+                zf.extract(member, raw_dir)
 
         # Temporarily move raw_dir to data/raw/{month_str} so PNCPExtractor
         # ingest_range (which hardcodes data/raw/{month_str}) can find the files.

--- a/src/baliza/builder.py
+++ b/src/baliza/builder.py
@@ -1,0 +1,195 @@
+"""Parquet builder: download raw ZIP from IA, ingest into DuckDB, export and upload Parquet.
+
+Reads the ZIP that ``mirror`` deposited on Internet Archive and produces the
+canonical monthly Parquet file.  Engine is created fresh per month (stateless,
+in-memory DuckDB) so this step can run independently of the fetch phase.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import zipfile
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+import httpx
+import structlog
+
+from .daily_exporter import SCHEMA_VERSION
+from .engine import BalizaEngine
+from .extractor import PNCPExtractor
+from .ia_uploader import IAUploader, try_read_manifest_from_ia
+
+logger = structlog.get_logger()
+
+
+def _pending_build_months(
+    start_date: date,
+    batch_size: int | None,
+    *,
+    backfill: bool = False,
+) -> list[date]:
+    """Return months that need a Parquet build, newest-first.
+
+    Normal mode (backfill=False):
+        Months with ``mirror_uploaded_at`` set but ``parquet_uploaded_at`` empty.
+        This covers only months that went through the new two-phase pipeline.
+
+    Backfill mode (backfill=True):
+        Months with ``raw_zip_url`` set and ``parquet_schema_version != SCHEMA_VERSION``
+        (or Parquet missing).  This includes months uploaded via the old monolithic
+        ``sync`` command that already have a ZIP on IA.
+    """
+    raw_manifest = try_read_manifest_from_ia()
+    today = date.today()
+    last_month = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
+    start = start_date.replace(day=1)
+
+    pending: list[date] = []
+    for row in raw_manifest:
+        part = row.get("data_particao") or ""
+        if not part:
+            continue
+        try:
+            month_date = datetime.strptime(part, "%Y-%m").date()
+        except ValueError:
+            continue
+
+        if month_date < start or month_date > last_month:
+            continue
+
+        if not row.get("raw_zip_url"):
+            continue  # no ZIP on IA — nothing to build from
+
+        if backfill:
+            # Rebuild if schema version is absent or outdated
+            if row.get("parquet_schema_version") != SCHEMA_VERSION:
+                pending.append(month_date)
+        else:
+            # Only process months that went through mirror (have mirror_uploaded_at)
+            # but have not yet been built
+            if row.get("mirror_uploaded_at") and not row.get("parquet_uploaded_at"):
+                pending.append(month_date)
+
+    pending.sort(reverse=True)
+    return pending[:batch_size] if batch_size else pending
+
+
+def _download_raw_zip(item_id: str, month_str: str, dest: Path) -> Path:
+    """Download raw-{month_str}.zip from IA to dest directory.  Returns the zip path."""
+    zip_url = f"https://archive.org/download/{item_id}/raw-{month_str}.zip"
+    zip_path = dest / f"raw-{month_str}.zip"
+    with httpx.Client(follow_redirects=True, timeout=120.0) as client:
+        with client.stream("GET", zip_url) as resp:
+            resp.raise_for_status()
+            with open(zip_path, "wb") as f:
+                for chunk in resp.iter_bytes(chunk_size=1 << 20):
+                    f.write(chunk)
+    return zip_path
+
+
+def build_month(
+    start_of_month: date,
+    *,
+    ia_access_key: str,
+    ia_secret_key: str,
+    dry_run: bool = False,
+    log_fn: object = None,
+) -> dict[str, object]:
+    """Download the raw ZIP from IA, ingest into DuckDB, export and upload Parquet.
+
+    Args:
+        start_of_month: First day of the target month.
+        ia_access_key: IA S3-like access key.
+        ia_secret_key: IA S3-like secret key.
+        dry_run: Skip actual upload (ingest and export only).
+        log_fn: Optional callable(str) for progress messages.
+
+    Returns:
+        Dict with keys: ``month``, ``valid``, ``quarantine``, ``uploaded``.
+    """
+    month_str = start_of_month.strftime("%Y-%m")
+    item_id = f"baliza-pncp-{month_str}"
+
+    def _emit(msg: str) -> None:
+        if log_fn is not None:
+            log_fn(msg)
+
+    result: dict[str, object] = {
+        "month": month_str,
+        "valid": 0,
+        "quarantine": 0,
+        "uploaded": False,
+    }
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+
+        # 1. Download ZIP from IA
+        _emit(f"{month_str}: downloading raw ZIP from IA...")
+        try:
+            zip_path = _download_raw_zip(item_id, month_str, tmp_path)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                _emit(f"{month_str}: no raw ZIP on IA (404) — skipping")
+                return result
+            raise
+
+        # 2. Extract to raw_dir structure
+        raw_dir = tmp_path / "raw" / month_str
+        raw_dir.mkdir(parents=True)
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(raw_dir)
+
+        # Temporarily move raw_dir to data/raw/{month_str} so PNCPExtractor
+        # ingest_range (which hardcodes data/raw/{month_str}) can find the files.
+        local_raw = Path("data/raw") / month_str
+        local_raw.parent.mkdir(parents=True, exist_ok=True)
+        if local_raw.exists():
+            shutil.rmtree(local_raw)
+        shutil.move(str(raw_dir), str(local_raw))
+
+        try:
+            # 3. Ingest into fresh in-memory DuckDB
+            _emit(f"{month_str}: ingesting...")
+            engine = BalizaEngine()
+            uploader = IAUploader(engine=engine)
+
+            month_start_dt = datetime.combine(start_of_month, datetime.min.time())
+            with PNCPExtractor(engine=engine) as extractor:
+                stats = extractor.ingest_range(month_start_dt)
+                result["valid"] = stats.get("valid", 0)
+                result["quarantine"] = stats.get("quarantine", 0)
+
+                q_csv = Path(f"data/quarentena-{month_str}.csv")
+                has_q = extractor.export_quarantine(month_start_dt, q_csv)
+
+            if dry_run:
+                _emit(
+                    f"[dry-run] {month_str}: {result['valid']} records, "
+                    f"{result['quarantine']} quarantined"
+                )
+                return result
+
+            # 4. Export Parquet and upload
+            _emit(f"{month_str}: uploading Parquet...")
+            uploaded = uploader.upload_parquet(
+                start_of_month,
+                ia_access_key,
+                ia_secret_key,
+                quarantine_stats=stats,
+                quarantine_csv=q_csv if has_q else None,
+                schema_version=SCHEMA_VERSION,
+            )
+            result["uploaded"] = uploaded
+
+            if q_csv.exists():
+                q_csv.unlink()
+
+        finally:
+            # Always clean up the temp raw pages
+            if local_raw.exists():
+                shutil.rmtree(local_raw)
+
+    return result

--- a/src/baliza/builder.py
+++ b/src/baliza/builder.py
@@ -66,11 +66,9 @@ def _pending_build_months(
             # Rebuild if schema version is absent or outdated
             if row.get("parquet_schema_version") != SCHEMA_VERSION:
                 pending.append(month_date)
-        else:
-            # Only process months that went through mirror (have mirror_uploaded_at)
-            # but have not yet been built
-            if row.get("mirror_uploaded_at") and not row.get("parquet_uploaded_at"):
-                pending.append(month_date)
+        elif row.get("mirror_uploaded_at") and not row.get("parquet_uploaded_at"):
+            # Only process months that went through mirror but have not yet been built
+            pending.append(month_date)
 
     pending.sort(reverse=True)
     return pending[:batch_size] if batch_size else pending

--- a/src/baliza/builder.py
+++ b/src/baliza/builder.py
@@ -46,7 +46,7 @@ def _pending_build_months(
     last_month = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
     start = start_date.replace(day=1)
 
-    pending: list[date] = []
+    pending_set: set[date] = set()
     for row in raw_manifest:
         part = row.get("data_particao") or ""
         if not part:
@@ -65,12 +65,12 @@ def _pending_build_months(
         if backfill:
             # Rebuild if schema version is absent or outdated
             if row.get("parquet_schema_version") != SCHEMA_VERSION:
-                pending.append(month_date)
+                pending_set.add(month_date)
         elif row.get("mirror_uploaded_at") and not row.get("parquet_uploaded_at"):
             # Only process months that went through mirror but have not yet been built
-            pending.append(month_date)
+            pending_set.add(month_date)
 
-    pending.sort(reverse=True)
+    pending = sorted(pending_set, reverse=True)
     return pending[:batch_size] if batch_size else pending
 
 

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -610,9 +610,6 @@ def build_cmd(  # noqa: PLR0913, PLR0915
     backfill: bool = typer.Option(
         False, "--backfill", help="Rebuild all months with outdated schema version"
     ),
-    allow_row_regression: bool = typer.Option(
-        False, "--allow-row-regression", help="Allow row count to decrease during backfill"
-    ),
 ) -> None:
     """Download raw ZIPs from IA, ingest, and upload Parquet (Phase 2 of two-phase pipeline).
 

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -29,11 +29,13 @@ from rich.progress import (
     TimeElapsedColumn,
 )
 
+from .builder import _pending_build_months, build_month
 from .consolidator import IAConsolidator
 from .engine import BalizaEngine
 from .extractor import FETCHED_SENTINEL, PNCPExtractor, _validate_resource
 from .ia_uploader import IAUploader
 from .logging import configure_logging
+from .mirror import _pending_mirror_months, mirror_month
 
 logger = structlog.get_logger()
 
@@ -112,7 +114,14 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
             try:
                 # manifest dates in monthly strategy are strings "YYYY-MM"
                 raw_manifest = uploader._read_manifest_from_ia()
-                uploaded = {row["data_particao"] for row in raw_manifest if row.get("data_particao")}
+                # A month is "done" only when its Parquet is on IA (parquet_url non-empty).
+                # Months that went through `mirror` only have raw_zip_url set — they still
+                # need `build` (or `sync`) to produce the Parquet.
+                uploaded = {
+                    row["data_particao"]
+                    for row in raw_manifest
+                    if row.get("data_particao") and row.get("parquet_url")
+                }
             except Exception as e:
                 console.print(
                     f"[yellow]⚠ Could not read IA manifest (starting fresh): {e}[/yellow]"
@@ -486,6 +495,187 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
     # `report-failure` job fires. Consolidation errors and per-month
     # extraction errors are both sync-level failures.
     if consolidation_error is not None or error_count > 0:
+        raise typer.Exit(1)
+
+
+@app.command("mirror")
+def mirror_cmd(  # noqa: PLR0913
+    batch_size: int | None = typer.Option(
+        None, "--batch-size", "-n", help="Max months to mirror (None for all)"
+    ),
+    start_date: str = typer.Option("2023-01-01", "--start-date", help="Oldest date to backfill"),
+    force_month: str | None = typer.Option(
+        None, "--force-month", help="Target a specific month (YYYY-MM) regardless of manifest"
+    ),
+    limit_minutes: int = typer.Option(
+        0, "--limit-minutes", help="Stop after this many minutes (0 = no limit)"
+    ),
+    workers: int = typer.Option(4, "--workers", "-w", help="Parallel workers"),
+    no_curl: bool = typer.Option(False, "--no-curl", help="Opt-out of system cURL"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Fetch only, skip upload"),
+) -> None:
+    """Fetch PNCP JSON pages and upload monthly ZIPs to IA (no DuckDB, no Parquet).
+
+    Phase 1 of the two-phase pipeline.  Use 'build' to turn the ZIPs into Parquet.
+    """
+    start_time_exec = datetime.now()
+    ia_access_key = os.environ.get("IA_ACCESS_KEY") or os.environ.get("IAS3_ACCESS_KEY")
+    ia_secret_key = os.environ.get("IA_SECRET_KEY") or os.environ.get("IAS3_SECRET_KEY")
+
+    if not dry_run and (not ia_access_key or not ia_secret_key):
+        console.print("[red]✗ Missing IA keys in environment.[/red]")
+        raise typer.Exit(1)
+
+    if force_month:
+        batch = [datetime.strptime(force_month, "%Y-%m").date()]
+    else:
+        start = datetime.strptime(start_date, "%Y-%m-%d").date()
+        with console.status("[bold green]Checking IA manifest for pending months...[/bold green]"):
+            batch = _pending_mirror_months(start, batch_size)
+
+    if not batch:
+        console.print("[green]✓ All months already mirrored.[/green]")
+        return
+
+    console.print(f"[cyan]Mirror: {len(batch)} month(s) to process[/cyan]")
+
+    total_fetched = 0
+    error_count = 0
+
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {}
+        for target_month in batch:
+            elapsed = (datetime.now() - start_time_exec).total_seconds() / 60
+            if limit_minutes and elapsed >= limit_minutes:
+                console.print(f"[yellow]⚠ Time limit ({limit_minutes}m) reached.[/yellow]")
+                break
+            while len(futures) >= workers:
+                done, _ = concurrent.futures.wait(
+                    futures.keys(), timeout=0.1, return_when=concurrent.futures.FIRST_COMPLETED
+                )
+                for f in done:
+                    futures.pop(f)
+            f = executor.submit(
+                mirror_month,
+                target_month,
+                ia_access_key=ia_access_key or "",
+                ia_secret_key=ia_secret_key or "",
+                use_curl=not no_curl,
+                dry_run=dry_run,
+                log_fn=lambda msg: console.log(f"[dim]{msg}[/dim]"),
+            )
+            futures[f] = target_month
+        concurrent.futures.wait(futures.keys())
+        for f, m in futures.items():
+            try:
+                r = f.result()
+                total_fetched += int(r.get("pages_fetched", 0))
+            except Exception as e:
+                error_count += 1
+                console.print(f"[red]✗ {m.strftime('%Y-%m')}: {e}[/red]")
+
+    console.print(
+        f"\n[green]✓ Mirror done[/green] — {total_fetched} pages fetched, "
+        f"{error_count} errors, {(datetime.now() - start_time_exec).total_seconds():.1f}s"
+    )
+    if error_count:
+        raise typer.Exit(1)
+
+
+@app.command("build")
+def build_cmd(  # noqa: PLR0913
+    batch_size: int | None = typer.Option(
+        None, "--batch-size", "-n", help="Max months to build (None for all)"
+    ),
+    start_date: str = typer.Option("2023-01-01", "--start-date", help="Oldest date to backfill"),
+    force_month: str | None = typer.Option(
+        None, "--force-month", help="Target a specific month (YYYY-MM) regardless of manifest"
+    ),
+    limit_minutes: int = typer.Option(
+        0, "--limit-minutes", help="Stop after this many minutes (0 = no limit)"
+    ),
+    workers: int = typer.Option(2, "--workers", "-w", help="Parallel workers (DuckDB is CPU-heavy)"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Ingest only, skip upload"),
+    backfill: bool = typer.Option(
+        False, "--backfill", help="Rebuild all months with outdated schema version"
+    ),
+    allow_row_regression: bool = typer.Option(
+        False, "--allow-row-regression", help="Allow row count to decrease during backfill"
+    ),
+) -> None:
+    """Download raw ZIPs from IA, ingest, and upload Parquet (Phase 2 of two-phase pipeline).
+
+    Normal mode: processes months that were mirrored but not yet built.
+    --backfill: rebuilds all months whose parquet_schema_version differs from the current code.
+    """
+    start_time_exec = datetime.now()
+    ia_access_key = os.environ.get("IA_ACCESS_KEY") or os.environ.get("IAS3_ACCESS_KEY")
+    ia_secret_key = os.environ.get("IA_SECRET_KEY") or os.environ.get("IAS3_SECRET_KEY")
+
+    if not dry_run and (not ia_access_key or not ia_secret_key):
+        console.print("[red]✗ Missing IA keys in environment.[/red]")
+        raise typer.Exit(1)
+
+    if force_month:
+        batch = [datetime.strptime(force_month, "%Y-%m").date()]
+    else:
+        start = datetime.strptime(start_date, "%Y-%m-%d").date()
+        with console.status("[bold green]Checking IA manifest for months to build...[/bold green]"):
+            batch = _pending_build_months(start, batch_size, backfill=backfill)
+
+    if not batch:
+        console.print("[green]✓ Nothing to build.[/green]")
+        return
+
+    mode = "backfill" if backfill else "build"
+    console.print(f"[cyan]{mode.capitalize()}: {len(batch)} month(s) to process[/cyan]")
+
+    total_valid = 0
+    total_quarantine = 0
+    error_count = 0
+
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {}
+        for target_month in batch:
+            elapsed = (datetime.now() - start_time_exec).total_seconds() / 60
+            if limit_minutes and elapsed >= limit_minutes:
+                console.print(f"[yellow]⚠ Time limit ({limit_minutes}m) reached.[/yellow]")
+                break
+            while len(futures) >= workers:
+                done, _ = concurrent.futures.wait(
+                    futures.keys(), timeout=0.1, return_when=concurrent.futures.FIRST_COMPLETED
+                )
+                for f in done:
+                    futures.pop(f)
+            f = executor.submit(
+                build_month,
+                target_month,
+                ia_access_key=ia_access_key or "",
+                ia_secret_key=ia_secret_key or "",
+                dry_run=dry_run,
+                log_fn=lambda msg: console.log(f"[dim]{msg}[/dim]"),
+            )
+            futures[f] = target_month
+        concurrent.futures.wait(futures.keys())
+        for f, m in futures.items():
+            try:
+                r = f.result()
+                total_valid += int(r.get("valid", 0))
+                total_quarantine += int(r.get("quarantine", 0))
+            except Exception as e:
+                error_count += 1
+                console.print(f"[red]✗ {m.strftime('%Y-%m')}: {e}[/red]")
+
+    console.print(
+        f"\n[green]✓ Build done[/green] — {total_valid:,} records, "
+        f"{total_quarantine:,} quarantined, {error_count} errors, "
+        f"{(datetime.now() - start_time_exec).total_seconds():.1f}s"
+    )
+    if error_count:
         raise typer.Exit(1)
 
 

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -530,8 +530,12 @@ def mirror_cmd(  # noqa: PLR0913
         batch = [datetime.strptime(force_month, "%Y-%m").date()]
     else:
         start = datetime.strptime(start_date, "%Y-%m-%d").date()
-        with console.status("[bold green]Checking IA manifest for pending months...[/bold green]"):
-            batch = _pending_mirror_months(start, batch_size)
+        try:
+            with console.status("[bold green]Checking IA manifest for pending months...[/bold green]"):
+                batch = _pending_mirror_months(start, batch_size)
+        except Exception as e:
+            console.print(f"[red]✗ Cannot read IA manifest: {e}[/red]")
+            raise typer.Exit(1) from None
 
     if not batch:
         console.print("[green]✓ All months already mirrored.[/green]")
@@ -590,7 +594,7 @@ def mirror_cmd(  # noqa: PLR0913
 
 
 @app.command("build")
-def build_cmd(  # noqa: PLR0913
+def build_cmd(  # noqa: PLR0913, PLR0915
     batch_size: int | None = typer.Option(
         None, "--batch-size", "-n", help="Max months to build (None for all)"
     ),
@@ -627,8 +631,12 @@ def build_cmd(  # noqa: PLR0913
         batch = [datetime.strptime(force_month, "%Y-%m").date()]
     else:
         start = datetime.strptime(start_date, "%Y-%m-%d").date()
-        with console.status("[bold green]Checking IA manifest for months to build...[/bold green]"):
-            batch = _pending_build_months(start, batch_size, backfill=backfill)
+        try:
+            with console.status("[bold green]Checking IA manifest for months to build...[/bold green]"):
+                batch = _pending_build_months(start, batch_size, backfill=backfill)
+        except Exception as e:
+            console.print(f"[red]✗ Cannot read IA manifest: {e}[/red]")
+            raise typer.Exit(1) from None
 
     if not batch:
         console.print("[green]✓ Nothing to build.[/green]")

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -542,8 +542,6 @@ def mirror_cmd(  # noqa: PLR0913
     total_fetched = 0
     error_count = 0
 
-    import concurrent.futures
-
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
         futures = {}
         for target_month in batch:
@@ -635,8 +633,6 @@ def build_cmd(  # noqa: PLR0913
     total_valid = 0
     total_quarantine = 0
     error_count = 0
-
-    import concurrent.futures
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
         futures = {}

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -542,8 +542,20 @@ def mirror_cmd(  # noqa: PLR0913
     total_fetched = 0
     error_count = 0
 
+    def _collect_mirror(f: concurrent.futures.Future, m: Any) -> None:
+        nonlocal total_fetched, error_count
+        try:
+            r = f.result()
+            total_fetched += int(r.get("pages_fetched", 0))
+            if not dry_run and not r.get("uploaded"):
+                error_count += 1
+                console.print(f"[red]✗ {m.strftime('%Y-%m')}: upload failed (manifest error?)[/red]")
+        except Exception as e:
+            error_count += 1
+            console.print(f"[red]✗ {m.strftime('%Y-%m')}: {e}[/red]")
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = {}
+        futures: dict[concurrent.futures.Future, Any] = {}
         for target_month in batch:
             elapsed = (datetime.now() - start_time_exec).total_seconds() / 60
             if limit_minutes and elapsed >= limit_minutes:
@@ -553,8 +565,8 @@ def mirror_cmd(  # noqa: PLR0913
                 done, _ = concurrent.futures.wait(
                     futures.keys(), timeout=0.1, return_when=concurrent.futures.FIRST_COMPLETED
                 )
-                for f in done:
-                    futures.pop(f)
+                for completed in done:
+                    _collect_mirror(completed, futures.pop(completed))
             f = executor.submit(
                 mirror_month,
                 target_month,
@@ -566,13 +578,8 @@ def mirror_cmd(  # noqa: PLR0913
             )
             futures[f] = target_month
         concurrent.futures.wait(futures.keys())
-        for f, m in futures.items():
-            try:
-                r = f.result()
-                total_fetched += int(r.get("pages_fetched", 0))
-            except Exception as e:
-                error_count += 1
-                console.print(f"[red]✗ {m.strftime('%Y-%m')}: {e}[/red]")
+        for f, m in list(futures.items()):
+            _collect_mirror(f, m)
 
     console.print(
         f"\n[green]✓ Mirror done[/green] — {total_fetched} pages fetched, "
@@ -634,8 +641,21 @@ def build_cmd(  # noqa: PLR0913
     total_quarantine = 0
     error_count = 0
 
+    def _collect_build(f: concurrent.futures.Future, m: Any) -> None:
+        nonlocal total_valid, total_quarantine, error_count
+        try:
+            r = f.result()
+            total_valid += int(r.get("valid", 0))
+            total_quarantine += int(r.get("quarantine", 0))
+            if not dry_run and not r.get("uploaded"):
+                error_count += 1
+                console.print(f"[red]✗ {m.strftime('%Y-%m')}: upload failed (manifest error?)[/red]")
+        except Exception as e:
+            error_count += 1
+            console.print(f"[red]✗ {m.strftime('%Y-%m')}: {e}[/red]")
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = {}
+        futures: dict[concurrent.futures.Future, Any] = {}
         for target_month in batch:
             elapsed = (datetime.now() - start_time_exec).total_seconds() / 60
             if limit_minutes and elapsed >= limit_minutes:
@@ -645,8 +665,8 @@ def build_cmd(  # noqa: PLR0913
                 done, _ = concurrent.futures.wait(
                     futures.keys(), timeout=0.1, return_when=concurrent.futures.FIRST_COMPLETED
                 )
-                for f in done:
-                    futures.pop(f)
+                for completed in done:
+                    _collect_build(completed, futures.pop(completed))
             f = executor.submit(
                 build_month,
                 target_month,
@@ -657,14 +677,8 @@ def build_cmd(  # noqa: PLR0913
             )
             futures[f] = target_month
         concurrent.futures.wait(futures.keys())
-        for f, m in futures.items():
-            try:
-                r = f.result()
-                total_valid += int(r.get("valid", 0))
-                total_quarantine += int(r.get("quarantine", 0))
-            except Exception as e:
-                error_count += 1
-                console.print(f"[red]✗ {m.strftime('%Y-%m')}: {e}[/red]")
+        for f, m in list(futures.items()):
+            _collect_build(f, m)
 
     console.print(
         f"\n[green]✓ Build done[/green] — {total_valid:,} records, "

--- a/src/baliza/extractor.py
+++ b/src/baliza/extractor.py
@@ -137,7 +137,7 @@ class PNCPExtractor:
 
     def __init__(
         self,
-        engine: BalizaEngine,
+        engine: BalizaEngine | None = None,
         base_url: str = "https://pncp.gov.br/api/consulta/v1",
         use_curl: bool = False,
     ):
@@ -320,6 +320,9 @@ class PNCPExtractor:
 
     def ingest_range(self, start_date: datetime) -> dict[str, int]:
         """Validate and ingest all raw JSON files for a specific month/range into the shared engine."""
+        if self.engine is None:
+            raise RuntimeError("ingest_range requires an engine — construct PNCPExtractor(engine=...)")
+
         month_str = start_date.strftime("%Y-%m")
         raw_dir = Path("data/raw") / month_str
 
@@ -370,6 +373,8 @@ class PNCPExtractor:
 
     def export_quarantine(self, extraction_date: datetime, output_path: Path) -> bool:
         """Export session quarantine to CSV if not empty."""
+        if self.engine is None:
+            raise RuntimeError("export_quarantine requires an engine — construct PNCPExtractor(engine=...)")
         try:
             q_table = self.engine.get_table("quarantine", schema="baliza_state")
             # Filter for current date if possible, but in stateless per-day loop,

--- a/src/baliza/ia_uploader.py
+++ b/src/baliza/ia_uploader.py
@@ -441,11 +441,15 @@ class IAUploader:
             for _table, path in exported_files.items():
                 files_to_upload[path.name] = str(path)
 
-            if not files_to_upload:
-                console.print(f"[yellow]⚠ Nothing to upload for {month_str}[/yellow]")
+            parquet_filename = f"contratos-{month_str}.parquet"
+            if parquet_filename not in files_to_upload:
+                # No Parquet produced (zero valid rows) — don't write a broken parquet_url
+                # to the manifest. The quarantine CSV can still be uploaded independently.
+                console.print(
+                    f"[yellow]⚠ No Parquet file produced for {month_str} — skipping upload[/yellow]"
+                )
                 return False
 
-            parquet_filename = f"contratos-{month_str}.parquet"
             parquet_local = files_to_upload.get(parquet_filename)
             parquet_sha256 = ""
             parquet_size = 0

--- a/src/baliza/ia_uploader.py
+++ b/src/baliza/ia_uploader.py
@@ -49,6 +49,12 @@ MANIFEST_FIELDNAMES = [
     "bloom_filter_columns",
     "sha256",
     "file_size_bytes",
+    # v3 fields — two-phase pipeline tracking (mirror then build)
+    "mirror_uploaded_at",
+    "raw_zip_sha256",
+    "raw_zip_size_bytes",
+    "parquet_uploaded_at",
+    "parquet_schema_version",
 ]
 
 
@@ -253,9 +259,9 @@ class MonthlyExporter:
 class IAUploader:
     """Stateless uploader using a remote CSV manifest as source of truth."""
 
-    def __init__(self, engine: BalizaEngine) -> None:
+    def __init__(self, engine: BalizaEngine | None = None) -> None:
         self.engine = engine
-        self.exporter = MonthlyExporter(engine)
+        self.exporter = MonthlyExporter(engine) if engine else None
         self.manifest_item_id = "baliza-pncp-manifest"
 
     def _read_manifest_from_ia(self) -> list[dict[str, Any]]:
@@ -280,6 +286,218 @@ class IAUploader:
                     continue
         return dates
 
+    def _upsert_manifest_row(
+        self,
+        month_str: str,
+        fields: dict[str, Any],
+        access_key: str,
+        secret_key: str,
+    ) -> None:
+        """Read manifest, merge fields into the canonical row for month_str, write back.
+
+        If no canonical row exists for the month, creates one with safe defaults.
+        Existing fields not present in ``fields`` are preserved (merge, not replace).
+        Uses the strict reader — transient read failures abort rather than wipe the live manifest.
+        """
+        manifest = read_manifest_from_ia()
+        item_id = f"baliza-pncp-{month_str}"
+
+        existing_idx: int | None = None
+        for i, row in enumerate(manifest):
+            if (
+                row.get("data_particao") == month_str
+                and row.get("table_name") == "contratos"
+                and row.get("file_type", "") in ("", "monthly_canonical")
+            ):
+                existing_idx = i
+                break
+
+        now = datetime.now().isoformat()
+        if existing_idx is not None:
+            manifest[existing_idx] = {**manifest[existing_idx], **fields}
+        else:
+            new_row: dict[str, Any] = {
+                "data_particao": month_str,
+                "table_name": "contratos",
+                "row_count": 0,
+                "quarantine_count": 0,
+                "ia_item_id": item_id,
+                "raw_zip_url": f"https://archive.org/download/{item_id}/raw-{month_str}.zip",
+                "parquet_url": "",
+                "quarantine_url": "",
+                "uploaded_at": now,
+                "file_type": "monthly_canonical",
+                "uf_sigla": "",
+                "sort_key": _CONTRATOS_SORT_KEY,
+                "row_group_size": PARQUET_ROW_GROUP_SIZE,
+                "bloom_filter_columns": _CONTRATOS_BLOOM_FILTER_COLUMNS,
+                "sha256": "",
+                "file_size_bytes": 0,
+                "mirror_uploaded_at": "",
+                "raw_zip_sha256": "",
+                "raw_zip_size_bytes": 0,
+                "parquet_uploaded_at": "",
+                "parquet_schema_version": "",
+            }
+            new_row.update(fields)
+            manifest.append(new_row)
+
+        write_manifest_to_ia(manifest, access_key, secret_key)
+
+    def upload_raw_zip(
+        self,
+        start_date: date,
+        raw_dir: Path,
+        ia_access_key: str,
+        ia_secret_key: str,
+    ) -> bool:
+        """Zip raw JSON pages and upload to the monthly IA item; update manifest mirror fields.
+
+        Does NOT ingest or export Parquet. Cleans up raw_dir on success so the
+        next run fetches fresh from IA (or GHA cache). Returns True on success.
+        """
+        month_str = start_date.strftime("%Y-%m")
+        item_id = f"baliza-pncp-{month_str}"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            temp_path = Path(tmp_dir)
+            zip_path = temp_path / f"raw-{month_str}.zip"
+            shutil.make_archive(str(zip_path.with_suffix("")), "zip", raw_dir)
+
+            raw_zip_sha256 = _sha256(zip_path)
+            raw_zip_size = zip_path.stat().st_size
+
+            console.print(f"  Uploading raw ZIP for {month_str} to {item_id}...")
+            ia.upload(
+                item_id,
+                files={zip_path.name: str(zip_path)},
+                access_key=ia_access_key,
+                secret_key=ia_secret_key,
+                metadata={
+                    "title": f"Baliza PNCP Data {month_str}",
+                    "description": f"Raw JSON mirror of PNCP contracts - {month_str}",
+                    "mediatype": "data",
+                    "collection": "opensource_media",
+                },
+                retries=3,
+            )
+
+        raw_zip_url = f"https://archive.org/download/{item_id}/raw-{month_str}.zip"
+        now = datetime.now().isoformat()
+        success = False
+        try:
+            self._upsert_manifest_row(
+                month_str,
+                {
+                    "raw_zip_url": raw_zip_url,
+                    "mirror_uploaded_at": now,
+                    "raw_zip_sha256": raw_zip_sha256,
+                    "raw_zip_size_bytes": raw_zip_size,
+                    "uploaded_at": now,
+                },
+                ia_access_key,
+                ia_secret_key,
+            )
+            success = True
+        except Exception as e:
+            console.print(f"[red]✗ Manifest update failed for {month_str}: {e}[/red]")
+
+        if success and raw_dir.exists():
+            shutil.rmtree(raw_dir)
+            console.print(f"[green]✓ {month_str} mirrored and local pages cleaned.[/green]")
+        else:
+            console.print(
+                f"[yellow]⚠ {month_str} ZIP uploaded but NOT cleaned due to manifest error.[/yellow]"
+            )
+        return success
+
+    def upload_parquet(  # noqa: PLR0913
+        self,
+        start_date: date,
+        ia_access_key: str,
+        ia_secret_key: str,
+        quarantine_stats: dict[str, int] | None = None,
+        quarantine_csv: Path | None = None,
+        schema_version: str = "",
+    ) -> bool:
+        """Export Parquet from engine and upload to the monthly IA item; update manifest.
+
+        Requires engine to be set. Does NOT touch raw JSON pages.
+        Returns True on success.
+        """
+        if self.engine is None or self.exporter is None:
+            raise RuntimeError("upload_parquet requires an engine — construct IAUploader(engine=...)")
+
+        month_str = start_date.strftime("%Y-%m")
+        item_id = f"baliza-pncp-{month_str}"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            temp_path = Path(tmp_dir)
+            exported_files = self.exporter.export_month(start_date, temp_path)
+
+            files_to_upload: dict[str, str] = {}
+            if quarantine_csv and quarantine_csv.exists():
+                files_to_upload[quarantine_csv.name] = str(quarantine_csv)
+            for _table, path in exported_files.items():
+                files_to_upload[path.name] = str(path)
+
+            if not files_to_upload:
+                console.print(f"[yellow]⚠ Nothing to upload for {month_str}[/yellow]")
+                return False
+
+            parquet_filename = f"contratos-{month_str}.parquet"
+            parquet_local = files_to_upload.get(parquet_filename)
+            parquet_sha256 = ""
+            parquet_size = 0
+            if parquet_local and Path(parquet_local).exists():
+                parquet_sha256 = _sha256(Path(parquet_local))
+                parquet_size = Path(parquet_local).stat().st_size
+
+            console.print(f"  Uploading Parquet for {month_str} to {item_id}...")
+            ia.upload(
+                item_id,
+                files=files_to_upload,
+                access_key=ia_access_key,
+                secret_key=ia_secret_key,
+                metadata={
+                    "title": f"Baliza PNCP Data {month_str}",
+                    "description": f"Consolidated monthly data for PNCP contracts - {month_str}",
+                    "mediatype": "data",
+                    "collection": "opensource_media",
+                },
+                retries=3,
+            )
+
+        now = datetime.now().isoformat()
+        success = False
+        try:
+            q_count = quarantine_stats.get("quarantine", 0) if quarantine_stats else 0
+            self._upsert_manifest_row(
+                month_str,
+                {
+                    "parquet_url": f"https://archive.org/download/{item_id}/{parquet_filename}",
+                    "sha256": parquet_sha256,
+                    "file_size_bytes": parquet_size,
+                    "row_count": quarantine_stats.get("valid", 0) if quarantine_stats else 0,
+                    "quarantine_count": q_count,
+                    "quarantine_url": (
+                        f"https://archive.org/download/{item_id}/quarentena-{month_str}.csv"
+                        if q_count > 0
+                        else ""
+                    ),
+                    "parquet_uploaded_at": now,
+                    "parquet_schema_version": schema_version,
+                    "uploaded_at": now,
+                },
+                ia_access_key,
+                ia_secret_key,
+            )
+            success = True
+        except Exception as e:
+            console.print(f"[red]✗ Manifest update failed for {month_str}: {e}[/red]")
+
+        return success
+
     def upload_month(  # noqa: PLR0913
         self,
         start_date: date,
@@ -290,6 +508,9 @@ class IAUploader:
         quarantine_csv: Path | None = None,
     ) -> None:
         """Export, Zip, and Upload monthly consolidated data to Internet Archive, then cleanup."""
+        if self.engine is None or self.exporter is None:
+            raise RuntimeError("upload_month requires an engine — construct IAUploader(engine=...)")
+
         month_str = start_date.strftime("%Y-%m")
         item_id = f"baliza-pncp-{month_str}"
 

--- a/src/baliza/mirror.py
+++ b/src/baliza/mirror.py
@@ -15,14 +15,14 @@ from pathlib import Path
 import structlog
 
 from .extractor import FETCHED_SENTINEL, PNCPExtractor, _validate_resource
-from .ia_uploader import IAUploader, try_read_manifest_from_ia
+from .ia_uploader import IAUploader, read_manifest_from_ia
 
 logger = structlog.get_logger()
 
 
 def _pending_mirror_months(start_date: date, batch_size: int | None) -> list[date]:
     """Return months not yet mirrored (no raw_zip_url in manifest), newest-first."""
-    raw_manifest = try_read_manifest_from_ia()
+    raw_manifest = read_manifest_from_ia()  # strict: raises ManifestReadError on failure
     # A month is "mirrored" if it has a non-empty raw_zip_url in its canonical row.
     mirrored: set[str] = {
         row["data_particao"]

--- a/src/baliza/mirror.py
+++ b/src/baliza/mirror.py
@@ -48,7 +48,7 @@ def _pending_mirror_months(start_date: date, batch_size: int | None) -> list[dat
     return pending[:batch_size] if batch_size else pending
 
 
-def mirror_month(
+def mirror_month(  # noqa: PLR0912, PLR0913, PLR0915
     start_of_month: date,
     *,
     ia_access_key: str,

--- a/src/baliza/mirror.py
+++ b/src/baliza/mirror.py
@@ -1,0 +1,186 @@
+"""Raw mirror: fetch PNCP JSON pages and upload monthly ZIPs to Internet Archive.
+
+No DuckDB, no Parquet — purely a data capture step. The resulting ZIP at
+archive.org/download/baliza-pncp-{YYYY-MM}/raw-{YYYY-MM}.zip is a navigable
+mirror of the PNCP API responses (each contratos_p{N}.json accessible as a
+direct URL).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+import structlog
+
+from .extractor import FETCHED_SENTINEL, PNCPExtractor, _validate_resource
+from .ia_uploader import IAUploader, try_read_manifest_from_ia
+
+logger = structlog.get_logger()
+
+
+def _pending_mirror_months(start_date: date, batch_size: int | None) -> list[date]:
+    """Return months not yet mirrored (no raw_zip_url in manifest), newest-first."""
+    raw_manifest = try_read_manifest_from_ia()
+    # A month is "mirrored" if it has a non-empty raw_zip_url in its canonical row.
+    mirrored: set[str] = {
+        row["data_particao"]
+        for row in raw_manifest
+        if row.get("data_particao") and row.get("raw_zip_url")
+    }
+
+    today = date.today()
+    last_month = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
+    start = start_date.replace(day=1)
+
+    pending: list[date] = []
+    curr = start
+    while curr <= last_month:
+        if curr.strftime("%Y-%m") not in mirrored:
+            pending.append(curr)
+        if curr.month == 12:
+            curr = curr.replace(year=curr.year + 1, month=1)
+        else:
+            curr = curr.replace(month=curr.month + 1)
+
+    pending.sort(reverse=True)
+    return pending[:batch_size] if batch_size else pending
+
+
+def mirror_month(
+    start_of_month: date,
+    *,
+    ia_access_key: str,
+    ia_secret_key: str,
+    use_curl: bool = False,
+    dry_run: bool = False,
+    log_fn: object = None,
+) -> dict[str, object]:
+    """Fetch all PNCP JSON pages for a month, zip them, and upload to IA.
+
+    Args:
+        start_of_month: First day of the target month.
+        ia_access_key: IA S3-like access key.
+        ia_secret_key: IA S3-like secret key.
+        use_curl: Use system cURL instead of httpx.
+        dry_run: Skip actual upload (verify only).
+        log_fn: Optional callable(str) for progress messages.
+
+    Returns:
+        Dict with keys: ``month``, ``pages_fetched``, ``pages_cached``, ``uploaded``.
+    """
+    _validate_resource("contratos")
+
+    month_str = start_of_month.strftime("%Y-%m")
+    if start_of_month.month == 12:
+        next_month = start_of_month.replace(year=start_of_month.year + 1, month=1)
+    else:
+        next_month = start_of_month.replace(month=start_of_month.month + 1)
+    end_of_month = next_month - timedelta(days=1)
+
+    month_start_dt = datetime.combine(start_of_month, datetime.min.time())
+    month_end_dt = datetime.combine(end_of_month, datetime.min.time())
+
+    raw_month_dir = Path("data/raw") / month_str
+    sentinel = raw_month_dir / FETCHED_SENTINEL
+
+    def _emit(msg: str) -> None:
+        if log_fn is not None:
+            log_fn(msg)
+
+    result: dict[str, object] = {
+        "month": month_str,
+        "pages_fetched": 0,
+        "pages_cached": 0,
+        "uploaded": False,
+    }
+
+    # engine=None — fetch-only path, no DuckDB
+    with PNCPExtractor(engine=None, use_curl=use_curl) as extractor:
+
+        def _page_is_cached(p: int) -> bool:
+            path = raw_month_dir / f"contratos_p{p}.json"
+            if not path.exists() or path.stat().st_size == 0:
+                return False
+            try:
+                with open(path) as fh:
+                    data = json.load(fh)
+            except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
+                logger.warning("corrupt_cache_found", file=str(path), error=str(e))
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+                return False
+            if isinstance(data, dict) and ("data" in data or "totalPaginas" in data):
+                return True
+            logger.warning(
+                "corrupt_cache_found",
+                file=str(path),
+                error="schema mismatch (no 'data' or 'totalPaginas' key)",
+            )
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            return False
+
+        # Determine total pages (probe or sentinel shortcut)
+        total_pages: int | None = None
+        if sentinel.exists():
+            p1 = raw_month_dir / "contratos_p1.json"
+            if p1.exists() and p1.stat().st_size > 0:
+                try:
+                    with open(p1) as fh:
+                        _d = json.load(fh)
+                    if isinstance(_d, dict) and isinstance(_d.get("totalPaginas"), int):
+                        total_pages = _d["totalPaginas"]
+                except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+                    pass
+            if total_pages is None:
+                logger.warning("sentinel_cache_regressed", month=month_str, reason="page1_bad")
+                try:
+                    sentinel.unlink()
+                except OSError:
+                    pass
+
+        if total_pages is None:
+            res = extractor.probe_range("contratos", month_start_dt, month_end_dt)
+            total_pages = res["total_pages"]
+
+        missing_pages = [p for p in range(1, total_pages + 1) if not _page_is_cached(p)]
+        cached_count = total_pages - len(missing_pages)
+        result["pages_cached"] = cached_count
+
+        if sentinel.exists() and missing_pages:
+            logger.warning(
+                "sentinel_cache_regressed",
+                month=month_str,
+                reason="missing_pages",
+                pages_missing=len(missing_pages),
+            )
+            try:
+                sentinel.unlink()
+            except OSError:
+                pass
+
+        for p in missing_pages:
+            extractor.fetch_page("contratos", month_start_dt, month_end_dt, p)
+            result["pages_fetched"] = int(result["pages_fetched"]) + 1
+            _emit(f"{month_str} page {p}/{total_pages}")
+
+        # Write sentinel so next run can skip probe
+        raw_month_dir.mkdir(parents=True, exist_ok=True)
+        sentinel.touch()
+
+    if dry_run:
+        _emit(f"[dry-run] {month_str}: {total_pages} pages ready for zipping")
+        return result
+
+    uploader = IAUploader(engine=None)
+    uploaded = uploader.upload_raw_zip(
+        start_of_month, raw_month_dir, ia_access_key, ia_secret_key
+    )
+    result["uploaded"] = uploaded
+    return result


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`baliza mirror`** (novo): busca páginas JSON do PNCP, empacota como ZIP mensal e sobe para o item IA (`baliza-pncp-{YYYY-MM}/raw-{YYYY-MM}.zip`). Zero DuckDB. Cada JSON fica imediatamente acessível via URL direta no IA — mirror navegável do PNCP.
- **`baliza build`** (novo): baixa o ZIP do IA, ingere em DuckDB efêmero in-memory, exporta Parquet canônico e sobe. Mudança de schema vira `baliza build --backfill` (lê do IA, não do PNCP).
- **`baliza sync`** mantido sem mudanças funcionais — `sync` agora considera um mês "feito" somente quando `parquet_url` está preenchido, evitando pular meses que passaram só pelo `mirror`.
- **Manifest v3**: cinco campos novos aditivos (`mirror_uploaded_at`, `raw_zip_sha256`, `raw_zip_size_bytes`, `parquet_uploaded_at`, `parquet_schema_version`). Linhas legadas sem esses campos continuam funcionando.
- **GHA**: `pncp-sync.yml` vira três jobs encadeados `mirror → build → consolidate`; novo `pncp-backfill.yml` para rebuilds em massa quando o schema do Parquet muda.

## Arquitectura

```
PNCP API
  ↓  baliza mirror
raw-{YYYY-MM}.zip  →  archive.org/download/baliza-pncp-{YYYY-MM}/contratos_p{N}.json  (mirror navegável)
  ↓  baliza build
contratos-{YYYY-MM}.parquet  →  archive.org/download/baliza-pncp-{YYYY-MM}/contratos-{YYYY-MM}.parquet
  ↓  baliza consolidate
contratos-{YYYY}.parquet  →  archive.org/download/baliza-pncp-consolidated/
```

## Test plan

- [ ] `uv run baliza mirror --help` e `uv run baliza build --help` mostram opções corretas
- [ ] `uv run baliza mirror --force-month 2024-11 --dry-run` termina sem erro
- [ ] `uv run baliza build --force-month 2024-11 --dry-run` termina sem erro (requer ZIP no IA)
- [ ] `uv run baliza sync --force-month 2024-11` continua funcionando igual ao anterior
- [ ] `uv run baliza build --backfill --start-date 2023-01-01 --dry-run` lista todos os meses com raw_zip_url sem regerar
- [ ] 82 testes unitários/de integração passando: `uv run --with pytest --with pytest-bdd pytest tests/ -q`
- [ ] GHA: workflow_dispatch em `pncp-sync.yml` com um `--force-month` recente passa nos três jobs

https://claude.ai/code/session_01AjoeXB7PkYZcT4ixCZGYbt
EOF
)