### PR TITLE
harden: add CSP + referrer meta, npm audit gate, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,10 @@ jobs:
         run: npm ci
         working-directory: web
 
+      - name: Audit runtime dependencies
+        run: npm audit --omit=dev --audit-level=high
+        working-directory: web
+
       - name: Lint & Check
         run: |
           npm run lint
@@ -44,9 +48,6 @@ jobs:
       - name: Build Portal
         run: npm run build
         working-directory: web
-        env:
-          IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
-          IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
 
       - name: Upload artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/web/scripts/compute-csp-hash.mjs
+++ b/web/scripts/compute-csp-hash.mjs
@@ -58,4 +58,4 @@ for (const [token, meta] of hashes) {
   console.log();
 }
 console.log('# Paste the tokens above into SCRIPT_SRC_HASHES in');
-console.log('# web/src/components/SecurityHeaders.astro.');
+console.log('# web/src/lib/security-headers.ts.');

--- a/web/scripts/compute-csp-hash.mjs
+++ b/web/scripts/compute-csp-hash.mjs
@@ -1,0 +1,61 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Walks web/dist/**\/*.html, extracts every inline <script> (no src attr),
+ * computes sha256 base64, and prints:
+ *   - a deduped set of `'sha256-...'` tokens ready to paste into script-src
+ *   - per-hash sample of the first 120 chars of the hashed body
+ *
+ * Run after `npm run build`. Re-run whenever Layout.astro's inline script or
+ * any other build-time inline script changes, and paste the resulting tokens
+ * into the SCRIPT_SRC_HASHES array in SecurityHeaders.astro.
+ */
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const distDir = join(here, '..', 'dist');
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) out.push(...walk(full));
+    else if (name.endsWith('.html')) out.push(full);
+  }
+  return out;
+}
+
+const INLINE_SCRIPT = /<script(?![^>]*\ssrc=)[^>]*>([\s\S]*?)<\/script>/g;
+
+const hashes = new Map();
+for (const file of walk(distDir)) {
+  const html = readFileSync(file, 'utf8');
+  let m;
+  while ((m = INLINE_SCRIPT.exec(html)) !== null) {
+    const body = m[1];
+    if (body.trim() === '') continue;
+    const hash = createHash('sha256').update(body, 'utf8').digest('base64');
+    const token = `'sha256-${hash}'`;
+    if (!hashes.has(token)) {
+      hashes.set(token, {
+        sample: body.slice(0, 120).replace(/\s+/g, ' ').trim(),
+        firstSeenIn: relative(distDir, file),
+      });
+    }
+  }
+}
+
+console.log('# CSP script-src hashes for inline scripts in dist/');
+console.log(`# Found ${hashes.size} unique inline script(s).`);
+console.log();
+for (const [token, meta] of hashes) {
+  console.log(token);
+  console.log(`  first seen in: ${meta.firstSeenIn}`);
+  console.log(`  sample: ${meta.sample}`);
+  console.log();
+}
+console.log('# Paste the tokens above into SCRIPT_SRC_HASHES in');
+console.log('# web/src/components/SecurityHeaders.astro.');

--- a/web/src/components/SecurityHeaders.astro
+++ b/web/src/components/SecurityHeaders.astro
@@ -1,0 +1,20 @@
+---
+/**
+ * Renders the site's <meta> security policies. Must be the first child of
+ * <head> so the browser parses the CSP before evaluating any inline script.
+ *
+ * Not enforced here (meta tag is ignored by the spec for these, and GitHub
+ * Pages doesn't let us set real HTTP headers):
+ *   - Content-Security-Policy: frame-ancestors
+ *   - X-Frame-Options
+ *   - Permissions-Policy
+ * The site intentionally stays embeddable — third-party iframes use
+ * ?embed=true — so losing frame-ancestors is acceptable.
+ */
+import { buildCsp, REFERRER_POLICY } from '../lib/security-headers';
+
+const csp = buildCsp();
+---
+
+<meta http-equiv="Content-Security-Policy" content={csp} />
+<meta name="referrer" content={REFERRER_POLICY} />

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import '../styles/global.css';
 import { ClientRouter } from 'astro:transitions';
 import Navigation from '../components/Navigation.astro';
 import Metadata from '../components/Metadata.astro';
+import SecurityHeaders from '../components/SecurityHeaders.astro';
 
 interface Props {
   title: string;
@@ -16,6 +17,7 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 <!DOCTYPE html>
 <html lang="pt-BR" data-theme="dark">
   <head>
+    <SecurityHeaders />
     <script is:inline>
       (function () {
         // Stored preference wins, but a throw from localStorage (private mode,

--- a/web/src/lib/security-headers.test.ts
+++ b/web/src/lib/security-headers.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  CSP_DIRECTIVES,
+  CONNECT_SRC,
+  SCRIPT_SRC_HASHES,
+  buildCsp,
+} from './security-headers';
+
+describe('buildCsp', () => {
+  it('emits every declared directive exactly once', () => {
+    const csp = buildCsp();
+    for (const name of Object.keys(CSP_DIRECTIVES)) {
+      const occurrences = csp.split('; ').filter((p) => p.startsWith(`${name} `));
+      expect(occurrences, `directive ${name}`).toHaveLength(1);
+    }
+  });
+
+  it('ends with upgrade-insecure-requests', () => {
+    expect(buildCsp().split('; ').at(-1)).toBe('upgrade-insecure-requests');
+  });
+
+  it('forbids unsafe-eval and unsafe-inline in script-src', () => {
+    const scriptSrc = CSP_DIRECTIVES['script-src'];
+    expect(scriptSrc).not.toContain("'unsafe-eval'");
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+    // WASM instantiation needs wasm-unsafe-eval (DuckDB-wasm).
+    expect(scriptSrc).toContain("'wasm-unsafe-eval'");
+  });
+
+  it('pins at least one script hash so inline scripts work without unsafe-inline', () => {
+    expect(SCRIPT_SRC_HASHES.length).toBeGreaterThan(0);
+    for (const h of SCRIPT_SRC_HASHES) {
+      expect(h).toMatch(/^'sha256-[A-Za-z0-9+/=]+='$/);
+    }
+  });
+});
+
+describe('connect-src covers every external origin the client code contacts', () => {
+  // Keep this test lightweight: scan every .ts/.svelte under src/lib/ plus the
+  // components that do their own fetching, extract any https:// hostnames that
+  // look like they are being contacted, and require each one to appear in the
+  // CSP connect-src allow-list (directly or via a wildcard).
+  // Walk the whole src/ tree — catches any fetch() that lands outside src/lib.
+  const srcDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+  function walk(dir: string): string[] {
+    const out: string[] = [];
+    for (const name of readdirSync(dir, { withFileTypes: true })) {
+      // Skip Cucumber/BDD step files — they carry example URLs that are not
+      // contacted at runtime and would poison the allow-list check.
+      if (name.isDirectory()) {
+        if (name.name === '__steps__') continue;
+        out.push(...walk(join(dir, name.name)));
+        continue;
+      }
+      const full = join(dir, name.name);
+      if (!name.isFile()) continue;
+      if (!(name.name.endsWith('.ts') || name.name.endsWith('.svelte'))) continue;
+      if (name.name.endsWith('.test.ts')) continue;
+      out.push(full);
+    }
+    return out;
+  }
+
+  const urlRe = /https:\/\/([a-z0-9.\-*]+)/gi;
+  const foundHosts = new Set<string>();
+  for (const file of walk(srcDir)) {
+    const src = readFileSync(file, 'utf8');
+    let m: RegExpExecArray | null;
+    while ((m = urlRe.exec(src)) !== null) {
+      foundHosts.add(m[1].toLowerCase());
+    }
+  }
+
+  function isAllowed(host: string): boolean {
+    for (const entry of CONNECT_SRC) {
+      if (!entry.startsWith('https://')) continue;
+      const allowed = entry.slice('https://'.length).toLowerCase();
+      if (allowed === host) return true;
+      if (allowed.startsWith('*.')) {
+        const suffix = allowed.slice(1); // ".archive.org"
+        if (host.endsWith(suffix)) return true;
+      }
+    }
+    return false;
+  }
+
+  // Hosts that show up in comments/docstrings but aren't contacted at runtime.
+  // Keep this list as small as possible — prefer updating CONNECT_SRC instead.
+  const IGNORED_HOSTS = new Set<string>([
+    'github.com',
+    'franklinbaldo.github.io',
+    'astro.build',
+    'github.io',
+  ]);
+
+  for (const host of foundHosts) {
+    if (IGNORED_HOSTS.has(host)) continue;
+    it(`allows ${host} in connect-src`, () => {
+      expect(
+        isAllowed(host),
+        `Host ${host} was referenced in src/lib/** but is not covered by CONNECT_SRC in security-headers.ts. ` +
+          `Add it to CONNECT_SRC or, if it is only mentioned in documentation, to IGNORED_HOSTS in this test.`,
+      ).toBe(true);
+    });
+  }
+});

--- a/web/src/lib/security-headers.test.ts
+++ b/web/src/lib/security-headers.test.ts
@@ -71,7 +71,7 @@ describe('connect-src covers every external origin the client code contacts', ()
     return out;
   }
 
-  const urlRe = /https:\/\/([a-z0-9.\-*]+)/gi;
+  const urlRe = /https:\/\/([a-z0-9.*-]+)/gi;
   const foundHosts = new Set<string>();
   for (const file of walk(srcDir)) {
     const src = readFileSync(file, 'utf8');
@@ -132,7 +132,7 @@ describe('style-src covers every external origin referenced from CSS', () => {
     return out;
   }
 
-  const importRe = /@import\s+url\(\s*["']?(https:\/\/([a-z0-9.\-]+)[^"')]*)["']?\s*\)/gi;
+  const importRe = /@import\s+url\(\s*["']?(https:\/\/([a-z0-9.-]+)[^"')]*)["']?\s*\)/gi;
   const cssHosts = new Set<string>();
   for (const file of findCssFiles(stylesDir)) {
     const src = readFileSync(file, 'utf8');

--- a/web/src/lib/security-headers.test.ts
+++ b/web/src/lib/security-headers.test.ts
@@ -9,6 +9,8 @@ import {
   buildCsp,
 } from './security-headers';
 
+const SELF_FILE = 'security-headers.ts';
+
 describe('buildCsp', () => {
   it('emits every declared directive exactly once', () => {
     const csp = buildCsp();
@@ -60,6 +62,10 @@ describe('connect-src covers every external origin the client code contacts', ()
       if (!name.isFile()) continue;
       if (!(name.name.endsWith('.ts') || name.name.endsWith('.svelte'))) continue;
       if (name.name.endsWith('.test.ts')) continue;
+      // The policy file itself references every allow-listed host as string
+      // literals — skipping it avoids circular self-checks (those hosts are
+      // covered via style-src/font-src/script-src, not connect-src).
+      if (name.name === SELF_FILE) continue;
       out.push(full);
     }
     return out;
@@ -104,6 +110,44 @@ describe('connect-src covers every external origin the client code contacts', ()
         isAllowed(host),
         `Host ${host} was referenced in src/lib/** but is not covered by CONNECT_SRC in security-headers.ts. ` +
           `Add it to CONNECT_SRC or, if it is only mentioned in documentation, to IGNORED_HOSTS in this test.`,
+      ).toBe(true);
+    });
+  }
+});
+
+describe('style-src covers every external origin referenced from CSS', () => {
+  // CSS @import / url() hits are subject to style-src, not connect-src. A
+  // missing allow-list entry here makes Google Fonts (or any other web font
+  // provider wired in via @import) silently fall back to system fonts in
+  // production.
+  const stylesDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'styles');
+
+  function findCssFiles(dir: string): string[] {
+    const out: string[] = [];
+    for (const name of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, name.name);
+      if (name.isDirectory()) out.push(...findCssFiles(full));
+      else if (name.isFile() && name.name.endsWith('.css')) out.push(full);
+    }
+    return out;
+  }
+
+  const importRe = /@import\s+url\(\s*["']?(https:\/\/([a-z0-9.\-]+)[^"')]*)["']?\s*\)/gi;
+  const cssHosts = new Set<string>();
+  for (const file of findCssFiles(stylesDir)) {
+    const src = readFileSync(file, 'utf8');
+    let m: RegExpExecArray | null;
+    while ((m = importRe.exec(src)) !== null) cssHosts.add(m[2].toLowerCase());
+  }
+
+  const styleSrc = CSP_DIRECTIVES['style-src'];
+  for (const host of cssHosts) {
+    it(`allows ${host} in style-src`, () => {
+      expect(
+        styleSrc.includes(`https://${host}`),
+        `Host ${host} is @imported from a CSS file under src/styles/ but is not covered by style-src ` +
+          `in security-headers.ts. Add https://${host} to style-src, and if the import chain references ` +
+          `other hosts (e.g. font files), add them to font-src too.`,
       ).toBe(true);
     });
   }

--- a/web/src/lib/security-headers.ts
+++ b/web/src/lib/security-headers.ts
@@ -1,0 +1,71 @@
+/**
+ * Single source of truth for the site's Content-Security-Policy and
+ * Referrer-Policy meta tags.
+ *
+ * GitHub Pages does not let us set HTTP response headers, so we emit these
+ * policies via <meta http-equiv>/<meta name> from every page. A handful of
+ * directives the browser only honors via real headers (frame-ancestors,
+ * X-Frame-Options, Permissions-Policy) are therefore NOT enforced — the site
+ * stays embeddable, which matches the existing ?embed=true flow.
+ *
+ * Origins the allow-list covers are established by the client code under
+ * web/src/lib/. If a new external origin is added there, update CONNECT_SRC
+ * below and rerun the CSP regression test — it will fail otherwise.
+ */
+
+// Inline <script> bodies are hashed so we don't need 'unsafe-inline'. The
+// list includes Layout.astro's theme/embed script plus the island-hydration
+// scripts Astro emits into dist HTML. Regenerate via:
+//
+//   cd web && npm run build && node scripts/compute-csp-hash.mjs
+//
+// Rerun whenever Layout.astro's inline <script is:inline> changes, or after
+// any Astro version bump that may alter the emitted hydration shims.
+export const SCRIPT_SRC_HASHES: readonly string[] = [
+  // Layout.astro theme + embed-mode bootstrap
+  "'sha256-K96mJKERDTEDZoWSoTH10KVLSr3yV1otHUDGMm7jEsY='",
+  // Astro island hydration shims (client:load/only/idle/visible/media)
+  "'sha256-QzWFZi+FLIx23tnm9SBU4aEgx4x8DsuASP07mfqol/c='",
+  "'sha256-QJZDUlo/qa5AJCrG6vHyWcatjwCeWidEHQfJc601lzw='",
+  "'sha256-eIXWvAmxkr251LJZkjniEK5LcPF3NkapbJepohwYRIc='",
+  "'sha256-Q2BPg90ZMplYY+FSdApNErhpWafg2hcRRbndmvxuL/Q='",
+  "'sha256-BF0290pkb3jxQsE7z00xR8Imp8X34FLC88L0lkMnrGw='",
+];
+
+// External origins the client contacts. Keep in sync with:
+//   web/src/lib/ia-manifest.ts     (archive.org)
+//   web/src/lib/duckdb.ts          (archive.org via httpfs, cdn.jsdelivr.net fallback)
+//   web/src/lib/pncpPublicacao.ts  (pncp.gov.br)
+//   web/src/lib/geo.ts             (nominatim.openstreetmap.org, servicodados.ibge.gov.br)
+export const CONNECT_SRC: readonly string[] = [
+  "'self'",
+  'https://archive.org',
+  'https://*.archive.org',
+  'https://pncp.gov.br',
+  'https://nominatim.openstreetmap.org',
+  'https://servicodados.ibge.gov.br',
+  'https://cdn.jsdelivr.net',
+];
+
+export const CSP_DIRECTIVES: Record<string, readonly string[]> = {
+  'default-src': ["'self'"],
+  'script-src': ["'self'", "'wasm-unsafe-eval'", 'https://cdn.jsdelivr.net', ...SCRIPT_SRC_HASHES],
+  'style-src': ["'self'", "'unsafe-inline'"],
+  'img-src': ["'self'", 'data:', 'https:'],
+  'font-src': ["'self'"],
+  'connect-src': CONNECT_SRC,
+  'worker-src': ["'self'", 'blob:'],
+  'object-src': ["'none'"],
+  'base-uri': ["'self'"],
+  'form-action': ["'self'"],
+};
+
+export function buildCsp(): string {
+  const parts = Object.entries(CSP_DIRECTIVES).map(
+    ([name, values]) => `${name} ${values.join(' ')}`,
+  );
+  parts.push('upgrade-insecure-requests');
+  return parts.join('; ');
+}
+
+export const REFERRER_POLICY = 'strict-origin-when-cross-origin';

--- a/web/src/lib/security-headers.ts
+++ b/web/src/lib/security-headers.ts
@@ -50,9 +50,11 @@ export const CONNECT_SRC: readonly string[] = [
 export const CSP_DIRECTIVES: Record<string, readonly string[]> = {
   'default-src': ["'self'"],
   'script-src': ["'self'", "'wasm-unsafe-eval'", 'https://cdn.jsdelivr.net', ...SCRIPT_SRC_HASHES],
-  'style-src': ["'self'", "'unsafe-inline'"],
+  // Google Fonts: global.css @imports fonts.googleapis.com, which itself
+  // references font files from fonts.gstatic.com via @font-face rules.
+  'style-src': ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
   'img-src': ["'self'", 'data:', 'https:'],
-  'font-src': ["'self'"],
+  'font-src': ["'self'", 'https://fonts.gstatic.com'],
   'connect-src': CONNECT_SRC,
   'worker-src': ["'self'", 'blob:'],
   'object-src': ["'none'"],


### PR DESCRIPTION
## Summary

Browser-enforced security baseline for the static Astro site, plus CI-side dependency surveillance.

- **CSP + Referrer-Policy on every page** via a new `SecurityHeaders.astro` partial rendered as the first child of `<head>`. Directives built by `web/src/lib/security-headers.ts`:
  - `script-src` uses `sha256` hashes of the six inline scripts (Layout.astro theme/embed + Astro island-hydration shims) — neither `'unsafe-inline'` nor `'unsafe-eval'` is permitted; only `'wasm-unsafe-eval'` for DuckDB-wasm.
  - `connect-src` allow-lists only the origins the client actually contacts (`archive.org`, `*.archive.org`, `pncp.gov.br`, `nominatim.openstreetmap.org`, `servicodados.ibge.gov.br`, `cdn.jsdelivr.net`).
  - `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, `worker-src 'self' blob:`, `upgrade-insecure-requests`.
  - `<meta name="referrer" content="strict-origin-when-cross-origin">`.
- **Hash regeneration helper** at `web/scripts/compute-csp-hash.mjs` — walks `dist/**/*.html` after a build and prints the deduped token list for pasting back into `SCRIPT_SRC_HASHES`. Rerun on any Astro version bump or inline-script change.
- **CI deploy pipeline** (`.github/workflows/deploy.yml`):
  - Adds `npm audit --omit=dev --audit-level=high` right after dependency install.
  - Drops `IA_ACCESS_KEY` / `IA_SECRET_KEY` from the web build step; they were unused (only the Python sync CLI consumes them).
- **Dependabot** (`.github/dependabot.yml`) weekly for `npm` (/web), `pip` (/), and `github-actions`, grouping minor/patch updates.
- **Regression test** (`web/src/lib/security-headers.test.ts`) walks `src/**/*.{ts,svelte}` for `https://` hostnames and fails if any appear outside `CONNECT_SRC`; also asserts `'unsafe-inline'` / `'unsafe-eval'` never appear in `script-src`.

### Caveats
GitHub Pages cannot set real HTTP headers, so `frame-ancestors`, `X-Frame-Options`, and `Permissions-Policy` are **not** enforced. The site intentionally stays embeddable — third-party iframes use `?embed=true` — so losing `frame-ancestors` is acceptable.

### Out of scope (per planning discussion)
- Keeping the DuckDB-wasm jsDelivr CDN fallback in `web/src/lib/duckdb.ts` (allow-listed in CSP).
- Leaving `?sql=` + `?embed=true` auto-execute behavior in `DuckDBExplorer.svelte` unchanged.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm run check:full` / `astro check` — 0 errors, 0 warnings (8 pre-existing deprecation hints in `pncp.ts`, untouched).
- [x] `npm test` — 497 passing + 10 new in `security-headers.test.ts`, 64 skipped (unchanged).
- [x] `npm run build` — bundle at 283.4 KB (budget 302.7 KB), same as baseline.
- [x] CSP `<meta>` verified in `dist/{index,explorador/index,404,sobre/index}.html`.
- [x] `astro preview` smoke test: served HTML carries `Content-Security-Policy` and `referrer` meta tags.
- [x] `npm audit --omit=dev --audit-level=high` — exit 0 (one unrelated moderate `yaml` advisory transitive through `@astrojs/check`; does not fail the gate).
- [ ] Post-merge: confirm GitHub Pages still deploys (no functional change to the artifact, just added tags).
