### PR TITLE
feat(web): update ux copy and tag beta tools

### DIFF
--- a/web/src/components/Dashboard.svelte
+++ b/web/src/components/Dashboard.svelte
@@ -46,7 +46,7 @@
     <StatCard
       title="Contratos citáveis"
       value={formatInteger(stats.total_contracts)}
-      hint="cada um com permalink e snapshot imutável"
+      hint="cada um com permalink e snapshot arquivado"
     />
     <StatCard
       title="Dias no Internet Archive"

--- a/web/src/components/Metadata.astro
+++ b/web/src/components/Metadata.astro
@@ -13,7 +13,7 @@ interface Props {
 
 const {
   title,
-  description = "Baliza: Memória imutável das contratações públicas brasileiras. Transparência, preservação e dados abertos do PNCP.",
+  description = "Baliza: Monitoramento diário das contratações públicas brasileiras. Transparência, preservação e dados abertos do PNCP.",
   image = "/baliza/og-image.png",
   canonicalURL = new URL(Astro.url.pathname, Astro.site),
 } = Astro.props;

--- a/web/src/components/TrustStrip.astro
+++ b/web/src/components/TrustStrip.astro
@@ -6,7 +6,7 @@ const PILLARS = [
   {
     kicker: 'Arquivo',
     title: 'Snapshots diários no Internet Archive',
-    body: 'Cada dia de contratações vira um Parquet imutável fora do alcance de qualquer servidor único. Mesmo que o PNCP saia do ar, o dia de ontem segue consultável.',
+    body: 'Cada dia de contratações vira um Parquet aberto fora do alcance de qualquer servidor único. Mesmo que o PNCP saia do ar, o dia de ontem segue consultável.',
     cta: { label: 'Metodologia', href: 'sobre' },
   },
   {

--- a/web/src/pages/desenvolvedores.astro
+++ b/web/src/pages/desenvolvedores.astro
@@ -25,7 +25,7 @@ import ManifestTable from '../components/ManifestTable.svelte';
         <a class="manifest-link" href={IA_MANIFEST_URL} target="_blank" rel="noopener">{IA_MANIFEST_URL}</a>
       </p>
       <p>
-        Colunas: <code>data_particao</code>, <code>table_name</code>, <code>parquet_url</code>, <code>sha256</code>, <code>row_group_size</code>. Cada linha do manifesto é imutável no endereço que anuncia — se o conteúdo mudar, a URL muda.
+        Colunas: <code>data_particao</code>, <code>table_name</code>, <code>parquet_url</code>, <code>sha256</code>, <code>row_group_size</code>. Cada linha do manifesto é arquivada no endereço que anuncia — se o conteúdo mudar, a URL muda.
       </p>
       <ManifestTable client:load />
     </section>
@@ -77,7 +77,7 @@ console.log(res.toArray());`}</code></pre>
     <section class="method-box">
       <h2>Princípios de contrato</h2>
       <ul>
-        <li><strong>URLs estáveis.</strong> Cada partição tem um endereço imutável no Internet Archive.</li>
+        <li><strong>URLs estáveis.</strong> Cada partição tem um endereço estável no Internet Archive.</li>
         <li><strong>Sem chave.</strong> Fetch direto, CORS aberto, sem rate-limit do nosso lado.</li>
         <li><strong>Schema versionado.</strong> Mudanças de esquema são anunciadas com um novo nome de coluna, não com mutação silenciosa.</li>
         <li><strong>Sem garantia de serviço.</strong> Baliza é mantido por uma pessoa. Se você precisa de SLA, espelhe o Parquet.</li>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -18,7 +18,7 @@ const TOOLS: Array<{
   external?: boolean;
 }> = [
   {
-    label: 'Explorador SQL',
+    label: 'Explorador SQL (Beta)',
     blurb: 'Consultas abertas sobre os Parquets arquivados, direto no navegador.',
     href: resolve('explorador'),
   },


### PR DESCRIPTION
Completed UX copy audit addressing user constraints.

1.  Replaced "Memória imutável" with "Monitoramento diário" in site metadata.
2.  Replaced "imutável" with "arquivado" or "estável" in `TrustStrip`, `Dashboard`, and developer docs.
3.  Tagged "Explorador SQL" with "(Beta)" in the main tools navigation on the homepage to avoid setting false expectations.

All tests passed successfully, and frontend screenshots and recordings verified the intended visual outcomes.

---
*PR created automatically by Jules for task [15750020182104586815](https://jules.google.com/task/15750020182104586815) started by @franklinbaldo*