### PR TITLE
Fetch only yesterday's PNCP publications for municipality view

### DIFF
--- a/web/features/city-detail.feature
+++ b/web/features/city-detail.feature
@@ -43,8 +43,9 @@ Feature: City Detail View
     When the city detail view mounts
     Then every PNCP consulta URL should include dataInicial, dataFinal, codigoModalidadeContratacao and pagina
 
-  Scenario: Lookback window dias=30 narrows the publicação date range
-    Given the URL has ibge "1721000" and dias "30"
+  Scenario: City query uses yesterday-only publication window
+    Given the URL has ibge "1721000"
     And the PNCP API returns 0 contracts
     When the city detail view mounts
-    Then every PNCP consulta URL should span 30 days between dataInicial and dataFinal
+    Then every PNCP consulta URL should span 1 day between dataInicial and dataFinal
+    And every PNCP consulta URL should set dataFinal to yesterday

--- a/web/src/components/CityDetailView.svelte
+++ b/web/src/components/CityDetailView.svelte
@@ -12,8 +12,6 @@
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
   import StatCard from './StatCard.svelte';
-  import LookbackWindow from './LookbackWindow.svelte';
-  import { DEFAULT_SINCE_DAYS } from '../lib/pncpPublicacao';
   import { getMunicipalityInfo } from '../lib/geo';
 
   setQueryClientContext(getQueryClient());
@@ -27,24 +25,8 @@
         : ''),
   );
 
-  const ALLOWED_DIAS = new Set([30, 90, 180, 365]);
-
-  function readDiasFromUrl(): number {
-    if (typeof window === 'undefined') return DEFAULT_SINCE_DAYS;
-    const raw = new URLSearchParams(window.location.search).get('dias');
-    const parsed = raw ? Number(raw) : NaN;
-    return ALLOWED_DIAS.has(parsed) ? parsed : DEFAULT_SINCE_DAYS;
-  }
-
-  let dias = $state<number>(readDiasFromUrl());
-
-  function updateDias(next: number) {
-    dias = next;
-    if (typeof window === 'undefined') return;
-    const entries = Object.fromEntries(new URLSearchParams(window.location.search));
-    const params = new URLSearchParams({ ...entries, dias: String(next) });
-    window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
-  }
+  const CITY_LOOKBACK_DAYS = 1;
+  const CITY_END_DAYS_AGO = 1;
 
   $effect(() => {
     if (ibge) prefetchArchive('contratos');
@@ -80,7 +62,7 @@
 
   const cityQuery = createQuery(() =>
     createListQuery<CityView | null>({
-      queryKey: QUERY_KEYS.municipio(ibge, dias),
+      queryKey: QUERY_KEYS.municipio(ibge, CITY_LOOKBACK_DAYS),
       enabled: !!ibge,
       archive: {
         column: 'codigo_ibge',
@@ -92,7 +74,7 @@
         if (!ibge) return null;
         const contracts = await fetchPublicacaoList(
           { codigoMunicipioIbge: ibge },
-          { sinceDays: dias },
+          { sinceDays: CITY_LOOKBACK_DAYS, endDaysAgo: CITY_END_DAYS_AGO, tamanhoPagina: 10 },
         );
         const info = getMunicipalityInfo(ibge);
         const cityName = info?.nome || contracts[0]?.municipio?.nomeMunicipio || contracts[0]?.unidadeOrgao?.municipioNome || "Município";
@@ -159,7 +141,6 @@
 
     <div class="stats-row">
       <StatCard title="Contratações Recentes" value={data.contracts.length} />
-      <LookbackWindow value={dias} onchange={updateDias} />
     </div>
 
     {#if data.contracts.length === 0}

--- a/web/src/components/__steps__/city-detail.steps.ts
+++ b/web/src/components/__steps__/city-detail.steps.ts
@@ -243,9 +243,9 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
   });
 
-  Scenario('Lookback window dias=30 narrows the publicação date range', ({ Given, And, When, Then }) => {
-    Given('the URL has ibge "1721000" and dias "30"', () => {
-      setUrlQuery('ibge=1721000&dias=30');
+  Scenario('City query uses yesterday-only publication window', ({ Given, And, When, Then }) => {
+    Given('the URL has ibge "1721000"', () => {
+      setUrlQuery('ibge=1721000');
     });
 
     And('the PNCP API returns 0 contracts', () => {
@@ -259,7 +259,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await tick();
     });
 
-    Then('every PNCP consulta URL should span 30 days between dataInicial and dataFinal', async () => {
+    Then('every PNCP consulta URL should span 1 day between dataInicial and dataFinal', async () => {
       await waitFor(
         () => {
           const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
@@ -269,7 +269,29 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
             const ini = /dataInicial=(\d{8})/.exec(url)?.[1];
             const fim = /dataFinal=(\d{8})/.exec(url)?.[1];
             expect(ini && fim).toBeTruthy();
-            expect(daysBetweenYyyymmdd(ini as string, fim as string)).toBe(30);
+            expect(daysBetweenYyyymmdd(ini as string, fim as string)).toBe(1);
+          }
+        },
+        { timeout: 2000 },
+      );
+    });
+
+    And('every PNCP consulta URL should set dataFinal to yesterday', async () => {
+      await waitFor(
+        () => {
+          const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+          expect(fetchMock.mock.calls.length).toBeGreaterThan(0);
+          const now = new Date();
+          now.setUTCDate(now.getUTCDate() - 1);
+          const expected = [
+            now.getUTCFullYear(),
+            String(now.getUTCMonth() + 1).padStart(2, '0'),
+            String(now.getUTCDate()).padStart(2, '0'),
+          ].join('');
+          for (const call of fetchMock.mock.calls) {
+            const url = typeof call[0] === 'string' ? call[0] : (call[0] as Request).url;
+            const fim = /dataFinal=(\d{8})/.exec(url)?.[1];
+            expect(fim).toBe(expected);
           }
         },
         { timeout: 2000 },

--- a/web/src/lib/pncpPublicacao.ts
+++ b/web/src/lib/pncpPublicacao.ts
@@ -24,6 +24,8 @@ export interface PublicacaoFilters {
 
 export interface PublicacaoOpts {
   sinceDays?: number;
+  /** Shift the query window end date backwards (e.g. 1 = yesterday). */
+  endDaysAgo?: number;
   /**
    * PNCP enforces 10 ≤ tamanhoPagina ≤ 50. Values outside that range are
    * clamped (not rejected) because the call would otherwise 400. Callers
@@ -69,10 +71,17 @@ export async function fetchPublicacaoList(
   filters: PublicacaoFilters,
   opts: PublicacaoOpts = {},
 ): Promise<PNCPContract[]> {
-  const { sinceDays = DEFAULT_SINCE_DAYS, tamanhoPagina = 10, modalidades = DEFAULT_MODALIDADES, now = new Date() } = opts;
+  const {
+    sinceDays = DEFAULT_SINCE_DAYS,
+    endDaysAgo = 0,
+    tamanhoPagina = 10,
+    modalidades = DEFAULT_MODALIDADES,
+    now = new Date(),
+  } = opts;
   const clamped = Math.max(10, Math.min(50, tamanhoPagina));
   const end = new Date(now);
-  const start = new Date(now);
+  end.setUTCDate(end.getUTCDate() - Math.max(0, endDaysAgo));
+  const start = new Date(end);
   start.setUTCDate(start.getUTCDate() - sinceDays);
   const dataInicial = yyyymmdd(start);
   const dataFinal = yyyymmdd(end);


### PR DESCRIPTION
### Motivation
- Users reported the municipality page felt slow and often showed no visible results when querying wide lookback windows. 
- The municipality view should surface the most recent, stable PNCP slice (yesterday) to be faster and more predictable on mobile. 
- Reducing the query window lowers PNCP backend load and avoids heavy multi-day fan-outs for the municipality hub.

### Description
- Extended `fetchPublicacaoList` to accept `endDaysAgo` and compute the date window relative to that shifted end date so callers can request ranges that end on yesterday. 
- Changed `CityDetailView` to use a fixed window of `sinceDays: 1`, `endDaysAgo: 1` and `tamanhoPagina: 10`, removed the `LookbackWindow` control, and updated the query key accordingly. 
- Preserved existing fan-out, dedupe and sort behavior in `fetchPublicacaoList`; only the date computation and caller options changed. 
- Updated BDD feature and step definitions (`web/features/city-detail.feature` and `web/src/components/__steps__/city-detail.steps.ts`) to assert the new 1-day window and that `dataFinal` is set to yesterday.

### Testing
- Ran the city-detail BDD suite with `cd web && npm run test -- src/components/__steps__/city-detail.steps.ts` and verified the updated scenarios pass (32 tests passed). 
- Observed only a Svelte CSS warning (`Unused CSS selector ".type-badge"`) during tests which did not cause failures. 
- All modified BDD assertions were exercised and validated in the automated steps run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e102f0c48325a40bc9a37f611592)