### PR TITLE
Fix LocalBids test to check `role="status"` for info banner

### DIFF
--- a/web/src/components/__steps__/local-bids.steps.ts
+++ b/web/src/components/__steps__/local-bids.steps.ts
@@ -276,8 +276,8 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     Then('I should see an info banner about PNCP indisponível', async () => {
       await waitFor(
         () => {
-          const alert = screen.getByRole('alert');
-          expect(alert.textContent).toMatch(/PNCP indisponível/i);
+          const status = screen.getByRole('status');
+          expect(status.textContent).toMatch(/PNCP indisponível/i);
         },
         { timeout: 3000 },
       );


### PR DESCRIPTION
### Motivation
- A BDD step in `Local Bids` expected `role="alert"` but the info banner component renders as `role="status"`, causing a CI failure when the test could not find an `alert`.

### Description
- Updated `web/src/components/__steps__/local-bids.steps.ts` to use `screen.getByRole('status')` instead of `screen.getByRole('alert')` in the step that asserts the PNCP-unavailable informational banner.

### Testing
- Ran the targeted test file with `npm test -- src/components/__steps__/local-bids.steps.ts` and observed all tests in the file pass (`27 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e4f361308325ae89a12df820e52a)