### PR TITLE
Treat empty/invalid PNCP responses as retryable (RetryablePayloadError)

### DIFF
--- a/src/baliza/extractor.py
+++ b/src/baliza/extractor.py
@@ -118,6 +118,8 @@ def _is_retryable_error(exc: BaseException) -> bool:
         return exc.response.status_code == 429 or exc.response.status_code >= 500
     if isinstance(exc, (httpx.ConnectError, httpx.TimeoutException)):
         return True
+    if isinstance(exc, RetryablePayloadError):
+        return True
 
     # DO NOT retry on validation errors
     if isinstance(exc, ValueError):
@@ -130,6 +132,15 @@ def _validate_resource(resource: str):
     """Prevent path traversal and injection by validating resource name."""
     if not re.match(r"^[a-zA-Z0-9_]+$", resource):
         raise ValueError(f"Invalid resource path: {resource}")
+
+
+class RetryablePayloadError(ValueError):
+    """Raised when PNCP returns a syntactically invalid payload.
+
+    We observe occasional empty/HTML upstream bodies with HTTP 200 while the
+    endpoint is under stress. Those payloads are transient in practice and
+    should participate in tenacity retries.
+    """
 
 
 class PNCPExtractor:
@@ -223,7 +234,17 @@ class PNCPExtractor:
                     text=True,
                     check=True,
                 )
-                data = json.loads(result.stdout)
+                payload = result.stdout.strip()
+                if not payload:
+                    raise RetryablePayloadError(
+                        f"Empty response body for {resource} page {page}"
+                    )
+                try:
+                    data = json.loads(payload)
+                except json.JSONDecodeError as e:
+                    raise RetryablePayloadError(
+                        f"Invalid JSON response for {resource} page {page}: {e}"
+                    ) from e
                 self._save_raw(resource, start_date, page, data)
                 return data
             except Exception:
@@ -238,8 +259,15 @@ class PNCPExtractor:
                 content += chunk
                 if len(content) > max_size:
                     raise ValueError(f"Response too large: {len(content)} bytes")
-
-        data = json.loads(content)
+        payload = content.strip()
+        if not payload:
+            raise RetryablePayloadError(f"Empty response body for {resource} page {page}")
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as e:
+            raise RetryablePayloadError(
+                f"Invalid JSON response for {resource} page {page}: {e}"
+            ) from e
         self._save_raw(resource, start_date, page, data)
         return data
 

--- a/tests/unit/test_extractor_v2.py
+++ b/tests/unit/test_extractor_v2.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 from baliza.engine import BalizaEngine
-from baliza.extractor import PAGE_SIZE, PNCPExtractor
+from baliza.extractor import PAGE_SIZE, PNCPExtractor, RetryablePayloadError, _is_retryable_error
 
 
 class TestPNCPExtractorV2(unittest.TestCase):
@@ -206,6 +206,10 @@ class TestPNCPExtractorV2(unittest.TestCase):
                 mock_stream.assert_called_once()
                 self.assertEqual(result, fresh_data)
                 self.assertEqual(json.loads(cache_file.read_text()), fresh_data)
+
+    def test_retryable_payload_error_is_marked_retryable(self):
+        """Malformed upstream payloads should trigger retry logic."""
+        self.assertTrue(_is_retryable_error(RetryablePayloadError("empty body")))
 
     def test_ingest_range_drops_corrupt_cache_files(self):
         """Since fetch_page no longer re-validates cached JSON on every call,


### PR DESCRIPTION
### Motivation
- PNCP sometimes returns HTTP 200 with an empty or non-JSON body, causing immediate `json.JSONDecodeError` and failing mirror/sync runs with messages like `Expecting value: line 1 column 1 (char 0)`.
- Those payloads are transient in practice and should trigger the existing retry/backoff logic rather than fail the month immediately.

### Description
- Added a new exception `RetryablePayloadError` in `src/baliza/extractor.py` to represent syntactically invalid upstream payloads. 
- Updated `_is_retryable_error` to treat `RetryablePayloadError` as retryable so tenacity retries apply. 
- In `PNCPExtractor.fetch_page` (both cURL and `httpx` stream paths) detect empty response bodies and JSON decode failures and raise `RetryablePayloadError` with contextual `resource`+`page` info before saving cache. 
- Added a unit test in `tests/unit/test_extractor_v2.py` asserting `RetryablePayloadError` is classified as retryable and updated imports accordingly.
- Files changed: `src/baliza/extractor.py`, `tests/unit/test_extractor_v2.py`.

### Testing
- Ran unit tests: `pytest -q tests/unit/test_extractor_v2.py` which passed (8 tests, all green).
- The change is limited to retry classification and payload handling; existing tenacity retry policy and test coverage for caching/self-healing remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f36b774c8325a959392333b9d2a1)