### PR TITLE
Improve city detail error title for archive outages

### DIFF
--- a/web/src/components/CityDetailView.svelte
+++ b/web/src/components/CityDetailView.svelte
@@ -95,6 +95,12 @@
   const data = $derived(cityQuery.data);
   const loading = $derived(cityQuery.isFetching);
   const error = $derived(cityQuery.error instanceof Error ? cityQuery.error : null);
+  const errorTitle = $derived.by(() => {
+    if (!error) return 'Erro ao carregar município';
+    return error.message.includes('Arquivo histórico indisponível')
+      ? 'Dados do município indisponíveis no momento'
+      : 'Município não encontrado';
+  });
 </script>
 
 <div class="city-detail container">
@@ -111,7 +117,7 @@
     </div>
   {:else if error}
     <div class="error-wrap">
-      <AlertBanner title="Município não encontrado" message={error.message} level="error" />
+      <AlertBanner title={errorTitle} message={error.message} level="error" />
       <div class="back-row">
         <a href="/baliza/" class="btn btn-outline">Voltar à busca</a>
       </div>


### PR DESCRIPTION
### Motivation
- Prevent showing a misleading “Município não encontrado” banner when the PNCP/IA fallback fails, so users see a clearer message during archive or network outages.

### Description
- Add a derived `errorTitle` in `web/src/components/CityDetailView.svelte` that returns `Dados do município indisponíveis no momento` when the error message includes `Arquivo histórico indisponível` and otherwise returns `Município não encontrado`, and wire it into the `AlertBanner` used in the city error state.

### Testing
- Ran `npm -C web run test -- src/lib/cityContext.test.ts`, which passed (all tests in that file succeeded). 
- Ran `npm -C web run check:full` which could not complete in this environment because Astro requires Node `>=22.12.0` while the runtime provides Node `20.19.6` (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9106ae8248325a3c5a39d2755f6a5)