### PR TITLE
Use semantic button for glossary trigger and add ARIA relationships

### DIFF
--- a/web/src/components/Glossary.svelte
+++ b/web/src/components/Glossary.svelte
@@ -9,14 +9,24 @@
   let { term, children }: Props = $props();
 
   const entry = $derived(lookupGlossary(term));
+  const tooltipId = $derived.by(() => {
+    const raw = (term ?? entry?.term ?? 'term').toString();
+    const normalized = raw
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '');
+
+    return `glossary-tooltip-${normalized || 'term'}`;
+  });
 </script>
 
 {#if entry}
-  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-  <span class="glossary-wrap" data-testid="glossary-term" tabindex="0">
+  <button class="glossary-wrap" data-testid="glossary-term" type="button" aria-describedby={tooltipId}>
     {#if children}{@render children()}{:else}{term}{/if}
-    <span class="glossary-tooltip" role="tooltip">{entry.plain}</span>
-  </span>
+    <span class="glossary-tooltip" id={tooltipId} role="tooltip">{entry.plain}</span>
+  </button>
 {:else if children}
   {@render children()}
 {:else}
@@ -26,7 +36,15 @@
 <style>
   .glossary-wrap {
     position: relative;
+    display: inline;
+    padding: 0;
+    margin: 0;
+    border: none;
     border-bottom: 1px dotted var(--color-secondary);
+    background: none;
+    color: inherit;
+    font: inherit;
+    text-align: inherit;
     cursor: help;
     outline: none;
   }


### PR DESCRIPTION
### Motivation
- Improve accessibility by replacing a focusable non-interactive `span` and removing the previous a11y suppression.
- Ensure assistive technologies can reliably associate the trigger and the tooltip by adding explicit relationship attributes.
- Preserve existing hover/focus visuals and keyboard behavior while making the markup semantic and correct.

### Description
- Replaced the focusable `<span>` with an unstyled `<button type="button">` and removed the `svelte-ignore a11y_no_noninteractive_tabindex` comment in `web/src/components/Glossary.svelte`.
- Added a derived stable tooltip id (`glossary-tooltip-<normalized-term>`) using `tooltipId` and applied `aria-describedby` on the button and `id` + `role="tooltip"` on the tooltip element.
- Kept the existing CSS-driven show/hide behavior for the tooltip and retained the focus ring, and added button-reset styles (`display:inline`, `border:none`, `background:none`, `font:inherit`, etc.) to preserve inline appearance.

### Testing
- Ran `npm --prefix web run check:full`, which failed in this environment because `astro` (project dev deps) is not installed so the full checks could not run.
- No automated unit tests were added or modified in this change; please run the project test suite and a quick visual review in a browser after installing dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9152958c08325a56d9785325fac3d)