### PR TITLE
Respect user reduced-motion preference for skeletons and spinners

### DIFF
--- a/web/src/components/LocalBids.svelte
+++ b/web/src/components/LocalBids.svelte
@@ -226,6 +226,11 @@
   }
 
   @keyframes spin { to { transform: rotate(360deg); } }
+  @media (prefers-reduced-motion: reduce) {
+    .spinner {
+      animation: none;
+    }
+  }
 
   .skeleton-wrap { display: grid; gap: var(--space-2); }
   .skeleton-heading { height: 1.25rem; width: 55%; border-radius: var(--radius-0); }

--- a/web/src/components/ManifestTable.svelte
+++ b/web/src/components/ManifestTable.svelte
@@ -98,6 +98,12 @@
     0%, 100% { opacity: 0.6; }
     50% { opacity: 1; }
   }
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton-row {
+      animation: none;
+      opacity: 0.85;
+    }
+  }
   .table-scroll {
     overflow-x: auto;
     border: 1px solid var(--color-base-300);

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -241,6 +241,26 @@ h3 { font-size: var(--text-xl); }
   border-radius: var(--radius-0);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .cg-pulse,
+  .skeleton {
+    animation: none !important;
+    background-image: none;
+  }
+}
+
 /* ============================================================
    ACCESSIBILITY
    ============================================================ */


### PR DESCRIPTION
### Motivation
- Improve accessibility by honoring `prefers-reduced-motion` and avoiding unnecessary motion for users who request reduced animation.
- Ensure decorative effects (shimmer/pulse/spinner) are disabled or simplified while preserving semantic loading indicators (text/`aria-busy`).

### Description
- Added a global `@media (prefers-reduced-motion: reduce)` block in `web/src/styles/global.css` that disables smooth scrolling and forces near-zero animation/transition durations, and turns off decorative `.cg-pulse` and `.skeleton` shimmer backgrounds.
- Updated `web/src/components/ManifestTable.svelte` to disable the local `skeleton-pulse` animation under reduced-motion and provide a static, slightly opaque skeleton state.
- Updated `web/src/components/LocalBids.svelte` to disable the spinner rotation under reduced-motion while keeping `aria-busy` and textual status intact.
- Preserved existing accessibility semantics (loading text and `aria-busy`) so status remains understandable without motion.

### Testing
- Attempted: `npm --prefix web run -s check:full`; this failed in the current environment due to `astro` not being available (`sh: 1: astro: not found`).
- No unit or integration tests were modified or executed as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e915276fc8832587daf7e87e06d7cd)