### PR TITLE
Add focus-visible parity for hover affordances in homepage cards/links

### DIFF
--- a/web/src/components/CityNavLink.svelte
+++ b/web/src/components/CityNavLink.svelte
@@ -33,4 +33,8 @@
     color: var(--bulcao-accent);
     border-bottom-color: var(--bulcao-accent);
   }
+  .city-nav-link:focus-visible {
+    color: var(--bulcao-accent);
+    border-bottom-color: var(--bulcao-accent);
+  }
 </style>

--- a/web/src/components/CityPulse.svelte
+++ b/web/src/components/CityPulse.svelte
@@ -348,7 +348,8 @@
     color: inherit;
   }
   .col-list li:last-child a { border-bottom: none; }
-  .col-list a:hover {
+  .col-list a:hover,
+  .col-list a:focus-visible {
     color: var(--bulcao-accent);
   }
   .row-meta {
@@ -411,7 +412,8 @@
     border-bottom: 2px solid transparent;
     padding: 2px 0;
   }
-  .col-more:hover {
+  .col-more:hover,
+  .col-more:focus-visible {
     border-bottom-color: var(--bulcao-accent);
   }
   .pulse-col--actions .col-head { border-bottom-color: var(--bulcao-support); }
@@ -429,7 +431,8 @@
     border: 1px solid var(--neutral-100);
     color: inherit;
   }
-  .action-list a:hover {
+  .action-list a:hover,
+  .action-list a:focus-visible {
     border-color: var(--bulcao-support);
     background: var(--neutral-0);
   }

--- a/web/src/components/LocalBids.svelte
+++ b/web/src/components/LocalBids.svelte
@@ -254,6 +254,10 @@
     background: var(--neutral-100);
     border-color: var(--bulcao-accent);
   }
+  .bid-card:focus-visible {
+    background: var(--neutral-100);
+    border-color: var(--bulcao-accent);
+  }
 
   .bid-meta {
     display: flex;

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -179,6 +179,10 @@ const TOOLS: Array<{
   .tool-card a:hover {
     border-left-color: var(--bulcao-accent);
   }
+  .tool-card a:focus-visible {
+    border-left-color: var(--bulcao-accent);
+    background: var(--neutral-50);
+  }
   .tool-label {
     font-family: var(--font-display);
     font-weight: 500;


### PR DESCRIPTION
### Motivation
- Keyboard users lacked equivalent visual affordances where styles changed only on `:hover`, reducing discoverability and accessibility of interactive cards and links.
- Provide matching focus-visible cues that mirror hover contrast and border treatments while preserving the global focus ring defined in `web/src/styles/global.css`.
- Avoid motion-heavy changes: focus styles should match hover contrast without adding transforms or animations.

### Description
- Added `:focus-visible` rules to the homepage tool cards in `web/src/pages/index.astro` to mirror the `.tool-card a:hover` left-border accent and card contrast.
- Added `:focus-visible` to `.bid-card` in `web/src/components/LocalBids.svelte` to match the hover background and border color.
- Added `:focus-visible` to the city navigation link in `web/src/components/CityNavLink.svelte` to mirror hover text color and underline/border behavior.
- Added `:focus-visible` parity for `.col-list a`, `.col-more`, and `.action-list a` in `web/src/components/CityPulse.svelte` so list-item anchors and action cards show the same emphasis as hover.
- Focus styles were inserted adjacent to existing hover rules and do not modify the global `*:focus-visible` outline or component logic.

### Testing
- Ran `git diff` to validate the CSS changes were applied to `web/src/pages/index.astro`, `web/src/components/LocalBids.svelte`, `web/src/components/CityNavLink.svelte`, and `web/src/components/CityPulse.svelte` (diff confirmed).
- Listed available npm scripts with `npm run` to discover project check commands (succeeded).
- Attempted `npm run check` which failed because the `check` script is not defined in this environment (automated check not run).
- Attempted `npm run check:full` which failed due to missing `astro` binary in the execution environment (static checks could not be completed).
- No unit/integration test suites were executed in this environment; changes are CSS-only and low risk, and can be validated by running `npm run check:full` and the test suite (`npm test` / `vitest run`) in a developer environment with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e915213eec83259b494f9fc1111e5c)