### PR TITLE
Normalize navigational hrefs using BASE_URL resolver

### DIFF
--- a/web/src/components/AgencyDetailView.svelte
+++ b/web/src/components/AgencyDetailView.svelte
@@ -7,6 +7,7 @@
   import type { PNCPContract } from '../lib/pncp';
   import { fetchPublicacaoList } from '../lib/pncpPublicacao';
   import { formatBRL, formatDate, formatParticao } from '../lib/format';
+  import { resolve } from '../lib/baseUrl';
   import { createListQuery } from '../lib/createListQuery';
   import type { ArchivedContrato } from '../lib/archive/schema';
   import EntityNotFound from './EntityNotFound.svelte';
@@ -214,7 +215,7 @@
     <div class="error-wrap">
       <AlertBanner title="Órgão não encontrado" message={error.message} level="error" />
       <div class="back-row">
-        <a href="/baliza/" class="btn btn-outline">Voltar à busca</a>
+        <a href={resolve('')} class="btn btn-outline">Voltar à busca</a>
       </div>
     </div>
   {:else if data}
@@ -252,7 +253,7 @@
       <EmptyState
         title="Nenhuma contratação recente"
         message="O PNCP não retornou contratações recentes para este CNPJ."
-        actionHref="/baliza/"
+        actionHref={resolve('')}
         actionLabel="Voltar à busca"
       />
     {:else}
@@ -301,7 +302,7 @@
           <LookbackWindow value={dias} onchange={updateDias} />
         </div>
         {#each data.contracts as item (item.numeroControlePNCP)}
-          <a href={`/baliza/contratacao?id=${item.numeroControlePNCP}`} class="bid-link-card">
+          <a href={resolve(`contratacao?id=${item.numeroControlePNCP}`)} class="bid-link-card">
             <div class="bid-header">
               <span class="bid-id">{item.numeroControlePNCP}</span>
               <span class="bid-date">{formatDate(item.dataPublicacaoPncp)}</span>

--- a/web/src/components/AtasView.svelte
+++ b/web/src/components/AtasView.svelte
@@ -9,6 +9,7 @@
   } from '../lib/parquetFallback';
   import type { ArchivedContrato } from '../lib/archive/schema';
   import { formatBRL, formatDate } from '../lib/format';
+  import { resolve } from '../lib/baseUrl';
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
 
@@ -124,7 +125,7 @@
     <section class="atas-list" data-testid="atas-list">
       {#each rows as row (row.numero_controle_pncp ?? `${row.cnpj_orgao}-${row.sequencial_contrato}`)}
         <a
-          href={`/baliza/contratacao?id=${row.numero_controle_pncp ?? ''}`}
+          href={resolve(`contratacao?id=${row.numero_controle_pncp ?? ''}`)}
           class="ata-card"
         >
           <div class="ata-header">

--- a/web/src/components/CityDetailView.svelte
+++ b/web/src/components/CityDetailView.svelte
@@ -6,6 +6,7 @@
   import type { PNCPContract } from '../lib/pncp';
   import { fetchPublicacaoList } from '../lib/pncpPublicacao';
   import { formatBRL, formatDate, formatParticao } from '../lib/format';
+  import { resolve } from '../lib/baseUrl';
   import { createListQuery } from '../lib/createListQuery';
   import type { ArchivedContrato } from '../lib/archive/schema';
   import EntityNotFound from './EntityNotFound.svelte';
@@ -113,7 +114,7 @@
     <div class="error-wrap">
       <AlertBanner title="Município não encontrado" message={error.message} level="error" />
       <div class="back-row">
-        <a href="/baliza/" class="btn btn-outline">Voltar à busca</a>
+        <a href={resolve('')} class="btn btn-outline">Voltar à busca</a>
       </div>
     </div>
   {:else if data}
@@ -147,14 +148,14 @@
       <EmptyState
         title="Nenhuma contratação recente"
         message="O PNCP não retornou contratações recentes para este município."
-        actionHref="/baliza/"
+        actionHref={resolve('')}
         actionLabel="Voltar à busca"
       />
     {:else}
       <section class="recent-list">
         <h3>Contratações Recentes neste Município</h3>
         {#each data.contracts as item (item.numeroControlePNCP)}
-          <a href={`/baliza/contratacao?id=${item.numeroControlePNCP}`} class="bid-link-card">
+          <a href={resolve(`contratacao?id=${item.numeroControlePNCP}`)} class="bid-link-card">
             <div class="bid-header">
               <span class="bid-id">{item.numeroControlePNCP}</span>
               <span class="bid-date">{formatDate(item.dataPublicacaoPncp)}</span>

--- a/web/src/components/CityHero.svelte
+++ b/web/src/components/CityHero.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import CityPicker from './CityPicker.svelte';
   import { cityState, hydrateCityContext } from '../lib/cityContext.svelte';
-
-  const BASE = '/baliza/';
+  import { resolve } from '../lib/baseUrl';
 
   hydrateCityContext();
 
   let pickerOpen = $state(false);
-  const dashboardHref = $derived(`${BASE}municipio?ibge=${cityState.ibge}`);
+  const dashboardHref = $derived(resolve(`municipio?ibge=${cityState.ibge}`));
   const sourceLabel = $derived(
     cityState.source === 'default'
       ? 'Cidade inicial · trocar para a sua'

--- a/web/src/components/CityNavLink.svelte
+++ b/web/src/components/CityNavLink.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { cityState, hydrateCityContext } from '../lib/cityContext.svelte';
+  import { resolve } from '../lib/baseUrl';
 
   let { isActive = false } = $props();
 
-  const BASE = '/baliza/';
   hydrateCityContext();
 
-  const href = $derived(`${BASE}municipio?ibge=${cityState.ibge}`);
+  const href = $derived(resolve(`municipio?ibge=${cityState.ibge}`));
   const label = $derived(
     cityState.nome
       ? `Município · ${cityState.nome}${cityState.uf ? '/' + cityState.uf : ''}`

--- a/web/src/components/CityPulse.svelte
+++ b/web/src/components/CityPulse.svelte
@@ -9,10 +9,9 @@
   import type { ArchivedContrato } from '../lib/archive/schema';
   import { formatDate, formatParticao } from '../lib/format';
   import { cityState, hydrateCityContext } from '../lib/cityContext.svelte';
+  import { resolve } from '../lib/baseUrl';
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
-
-  const BASE = '/baliza/';
 
   setQueryClientContext(getQueryClient());
   hydrateCityContext();
@@ -169,7 +168,7 @@
             <ul class="col-list">
               {#each recent as bid (bid.numeroControlePNCP)}
                 <li>
-                  <a href={`${BASE}contratacao?id=${bid.numeroControlePNCP}`}>
+                  <a href={resolve(`contratacao?id=${bid.numeroControlePNCP}`)}>
                     <span class="row-meta">
                       <span class="row-date">{formatDate(bid.dataPublicacaoPncp)}</span>
                       {#if bid.modalidadeNome}
@@ -184,7 +183,7 @@
             </ul>
           {/if}
           <footer class="col-foot">
-            <a class="col-more" href={`${BASE}municipio?ibge=${ibge}`}>
+            <a class="col-more" href={resolve(`municipio?ibge=${ibge}`)}>
               Ver painel completo →
             </a>
           </footer>
@@ -201,7 +200,7 @@
             <ul class="col-list">
               {#each topOrgaos as org (org.cnpj)}
                 <li>
-                  <a href={`${BASE}orgao?cnpj=${org.cnpj}`}>
+                  <a href={resolve(`orgao?cnpj=${org.cnpj}`)}>
                     <span class="row-count">{org.count}</span>
                     <span class="row-obj">{org.razaoSocial}</span>
                     <span class="row-org">CNPJ {org.cnpj}</span>
@@ -214,7 +213,7 @@
             </p>
           {/if}
           <footer class="col-foot">
-            <a class="col-more" href={`${BASE}explorador`}>
+            <a class="col-more" href={resolve('explorador')}>
               Comparar no explorador →
             </a>
           </footer>

--- a/web/src/components/ContractDetailView.svelte
+++ b/web/src/components/ContractDetailView.svelte
@@ -11,6 +11,7 @@
   import { parsePncpId, PNCP_ID_EXAMPLE } from '../lib/pncpId';
   import { getLatestParquetInfo } from '../lib/ia-manifest';
   import { addWatch, isWatched, hydrateWatches } from '../lib/watchStore.svelte';
+  import { resolve } from '../lib/baseUrl';
   import EntityNotFound from './EntityNotFound.svelte';
   import AlertBanner from './AlertBanner.svelte';
   import Glossary from './Glossary.svelte';
@@ -137,7 +138,7 @@
     <div class="error-wrap">
       <AlertBanner title="Contratação não encontrada" message={error.message} level="error" />
       <div class="back-row">
-        <a href="/baliza/" class="btn btn-outline">Voltar à busca</a>
+        <a href={resolve('')} class="btn btn-outline">Voltar à busca</a>
       </div>
     </div>
   {:else if data}
@@ -221,7 +222,7 @@
             <dt>Razão Social</dt>
             <dd>
               {#if data.orgaoEntidade?.cnpj}
-                <a href={`/baliza/orgao?cnpj=${data.orgaoEntidade.cnpj}`} class="inline-link">
+                <a href={resolve(`orgao?cnpj=${data.orgaoEntidade.cnpj}`)} class="inline-link">
                   {data.orgaoEntidade.razaoSocial || '—'}
                 </a>
               {:else}
@@ -235,7 +236,7 @@
             <dt>Município</dt>
             <dd>
               {#if data.unidadeOrgao?.codigoMunicipioIbge}
-                <a href={`/baliza/municipio?ibge=${data.unidadeOrgao.codigoMunicipioIbge}`} class="inline-link">
+                <a href={resolve(`municipio?ibge=${data.unidadeOrgao.codigoMunicipioIbge}`)} class="inline-link">
                   {data.unidadeOrgao?.municipioNome || '—'}{data.unidadeOrgao?.ufSigla ? ` / ${data.unidadeOrgao.ufSigla}` : ''}
                 </a>
               {:else}

--- a/web/src/components/Dashboard.svelte
+++ b/web/src/components/Dashboard.svelte
@@ -3,6 +3,7 @@
   import AlertBanner from './AlertBanner.svelte';
   import { SyncStatsSchema, type SyncStats } from '../schema';
   import { formatInteger, formatRelativeTime } from '../lib/format';
+  import { resolve } from '../lib/baseUrl';
   import { onMount } from 'svelte';
 
   let stats = $state<SyncStats | null>(null);
@@ -13,7 +14,7 @@
     loading = true;
     error = null;
     try {
-      const res = await fetch('/baliza/data/sync_stats.json');
+      const res = await fetch(resolve('data/sync_stats.json'));
       if (!res.ok) throw new Error('Falha ao obter os dados pré-compilados pelo DuckDB.');
       const raw = await res.json();
       stats = SyncStatsSchema.parse(raw);
@@ -58,7 +59,7 @@
       value={formatInteger(stats.total_quarantine)}
       tone="warning"
       hint="anomalias sinalizadas — entenda o critério"
-      href="/baliza/sobre#quarentena"
+      href={resolve('sobre#quarentena')}
     />
   </div>
 {/if}

--- a/web/src/components/EntityNotFound.svelte
+++ b/web/src/components/EntityNotFound.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { fade } from 'svelte/transition';
+  import { resolve } from '../lib/baseUrl';
 
   interface Props {
     id: string;
@@ -19,8 +20,8 @@
       <p class="message">{error}</p>
       
       <div class="actions">
-        <a href="/baliza/" class="btn btn-primary">Voltar para a Busca</a>
-        <a href="/baliza/sobre" class="btn btn-outline">Metodologia e Dados</a>
+        <a href={resolve('')} class="btn btn-primary">Voltar para a Busca</a>
+        <a href={resolve('sobre')} class="btn btn-outline">Metodologia e Dados</a>
       </div>
     </div>
   </div>

--- a/web/src/components/LocalBids.svelte
+++ b/web/src/components/LocalBids.svelte
@@ -10,6 +10,7 @@
   import type { PNCPContract } from '../lib/pncp';
   import type { ArchivedContrato } from '../lib/archive/schema';
   import { formatDate, formatParticao } from '../lib/format';
+  import { resolve } from '../lib/baseUrl';
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
 
@@ -122,7 +123,7 @@
       <EmptyState
         title="Acesso à localização negado"
         message="Para usar o Radar Local, permita o acesso à localização nas configurações do navegador."
-        actionHref="/baliza/"
+        actionHref={resolve('')}
         actionLabel="Buscar manualmente"
       />
 
@@ -166,7 +167,7 @@
           {:else}
             <div class="bids-list">
               {#each data.contracts as bid (bid.numeroControlePNCP)}
-                <a href={`/baliza/contratacao?id=${bid.numeroControlePNCP}`} class="bid-card">
+                <a href={resolve(`contratacao?id=${bid.numeroControlePNCP}`)} class="bid-card">
                   <div class="bid-meta">
                     <span class="bid-id">#{bid.numeroControlePNCP}</span>
                     <span class="bid-date">{formatDate(bid.dataPublicacaoPncp)}</span>

--- a/web/src/components/SupplierDetailView.svelte
+++ b/web/src/components/SupplierDetailView.svelte
@@ -10,6 +10,7 @@
   } from '../lib/parquetFallback';
   import type { PNCPContract } from '../lib/pncp';
   import { formatBRL, formatDate, formatParticao } from '../lib/format';
+  import { resolve } from '../lib/baseUrl';
   import type { ArchivedContrato } from '../lib/archive/schema';
   import EntityNotFound from './EntityNotFound.svelte';
   import AlertBanner from './AlertBanner.svelte';
@@ -195,7 +196,7 @@
     <div class="error-wrap">
       <AlertBanner title="Fornecedor não encontrado" message={error.message} level="error" />
       <div class="back-row">
-        <a href="/baliza/" class="btn btn-outline">Voltar à busca</a>
+        <a href={resolve('')} class="btn btn-outline">Voltar à busca</a>
       </div>
     </div>
   {:else if data}
@@ -222,7 +223,7 @@
       <EmptyState
         title="Nenhum contrato arquivado"
         message="O arquivo consolidado não registra contratos para este CNPJ de fornecedor."
-        actionHref="/baliza/"
+        actionHref={resolve('')}
         actionLabel="Voltar à busca"
       />
     {:else}
@@ -259,7 +260,7 @@
           <h3>Histórico de contratações (últimos 50 do arquivo)</h3>
         </div>
         {#each data.contracts as item (item.numeroControlePNCP)}
-          <a href={`/baliza/contratacao?id=${item.numeroControlePNCP}`} class="bid-link-card">
+          <a href={resolve(`contratacao?id=${item.numeroControlePNCP}`)} class="bid-link-card">
             <div class="bid-header">
               <span class="bid-id">{item.numeroControlePNCP}</span>
               <span class="bid-date">{formatDate(item.dataPublicacaoPncp)}</span>

--- a/web/src/lib/baseUrl.ts
+++ b/web/src/lib/baseUrl.ts
@@ -1,0 +1,5 @@
+export const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
+
+export function resolve(href: string): string {
+  return `${BASE}${href.replace(/^\/+/, '')}`;
+}

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import { resolve } from '../lib/baseUrl';
 ---
 
 <Layout title="404: Não Encontrado" description="Ops! Esta página não existe no radar do Baliza.">
@@ -9,7 +10,7 @@ import Layout from '../layouts/Layout.astro';
     <p>A página que você procura não foi localizada ou foi movida para uma nova órbita de transparência.</p>
     
     <div class="actions">
-      <a href="/baliza/" class="btn btn-primary">Voltar ao Radar</a>
+      <a href={resolve('')} class="btn btn-primary">Voltar ao Radar</a>
     </div>
   </div>
 </Layout>


### PR DESCRIPTION
### Motivation
- Remove hardcoded `/baliza/...` paths so the app works when deployed under different base URLs.  
- Centralize base-path handling to avoid repeated string manipulation across components.  
- Make internal link construction consistent and maintainable across reusable components and pages.

### Description
- Added `web/src/lib/baseUrl.ts` exporting `BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/')` and `resolve(href: string)` which trims leading slashes and prefixes `BASE`.  
- Replaced hardcoded `/baliza/...` hrefs/actionHref values in multiple components and pages to use `resolve(...)`, including `CityHero`, `CityPulse`, `CityNavLink`, `EntityNotFound`, `CityDetailView`, `AgencyDetailView`, `SupplierDetailView`, `ContractDetailView`, `LocalBids`, `AtasView`, `Dashboard`, and `pages/404.astro`.  
- Updated the dashboard data fetch to `fetch(resolve('data/sync_stats.json'))` so asset paths also respect the configured base URL.

### Testing
- Ran a repository check via `npm run check:full`, which failed in this environment because `astro` is not available on PATH (test environment issue).  
- Verified with `rg`/search that modified target files no longer contain hardcoded `/baliza/` usages.  
- Changes were committed (13 files changed, new `web/src/lib/baseUrl.ts`) and are ready for review; recommend running the full `npm`/build pipeline in CI where `astro` is installed to validate the site build and runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9151d0ce48325b34db7ffe11f5543)