### PR TITLE
ci: invoke unified `baliza sync` in PNCP workflow

### DIFF
--- a/.github/workflows/pncp-sync.yml
+++ b/.github/workflows/pncp-sync.yml
@@ -41,21 +41,15 @@ jobs:
           IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
           IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
         run: |
-          uv run baliza mirror \
-            --start-date "${{ inputs.start_date || '2023-01-01' }}" \
-            --limit-minutes 160
-      - env:
-          IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
-          IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
-        run: |
-          uv run baliza build \
-            --start-date "${{ inputs.start_date || '2023-01-01' }}" \
-            --limit-minutes 120
-      - if: ${{ !inputs.no_consolidate }}
-        env:
-          IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
-          IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
-        run: uv run baliza consolidate --start-year 2021
+          sync_args=(
+            --start-date "${{ inputs.start_date || '2023-01-01' }}"
+            --limit-minutes 280
+          )
+          if [[ "${{ inputs.no_consolidate }}" == "true" ]]; then
+            sync_args+=(--no-consolidate)
+          fi
+
+          uv run baliza sync "${sync_args[@]}"
 
   report-failure:
     name: Report workflow failure


### PR DESCRIPTION
### Motivation
- Simplify the PNCP GitHub Actions workflow by delegating orchestration to the unified CLI command instead of running `mirror`, `build`, and `consolidate` as separate steps. 
- Keep the workflow inputs and runtime budgeting but centralize behavior in `baliza sync` to avoid duplicated logic and fragile step-level consolidation.

### Description
- Replaced the separate `uv run baliza mirror`, `uv run baliza build`, and conditional `uv run baliza consolidate` steps in `.github/workflows/pncp-sync.yml` with a single `uv run baliza sync` invocation. 
- Mapped workflow inputs to `sync` flags by passing `--start-date` from `start_date`, conditionally appending `--no-consolidate` when `no_consolidate` is true, and preserving a combined `--limit-minutes 280` budget. 
- Built the `sync` arguments in-shell (`sync_args` array) to safely append `--no-consolidate` only when requested and removed the now-redundant step-level consolidation branching, leaving README references unchanged because they already document `baliza sync`.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues and observed no trailing-diff warnings. 
- Validated workflow YAML parsing with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pncp-sync.yml')"`, which succeeded. 
- Committed the change and included the message `ci: run pncp sync workflow via unified sync command` after verification steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ff7c5c908325a2f3d7db4a59ace0)