### PR TITLE
ci: enforce lockfile-synced deps for PNCP ETL workflows

### DIFF
--- a/.github/workflows/pncp-backfill.yml
+++ b/.github/workflows/pncp-backfill.yml
@@ -28,6 +28,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
+      - name: Cache uv artifacts
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: uv-${{ runner.os }}-
+      - name: Sync locked dependencies
+        # ETL jobs should run against lockfile-pinned deps for stable production behavior.
+        run: uv sync --locked
       - env:
           IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
           IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}

--- a/.github/workflows/pncp-sync.yml
+++ b/.github/workflows/pncp-sync.yml
@@ -30,6 +30,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
+      - name: Cache uv artifacts
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: uv-${{ runner.os }}-
+      - name: Sync locked dependencies
+        # ETL jobs should run against lockfile-pinned deps for stable production behavior.
+        run: uv sync --locked
       - id: month
         run: echo "key=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5


### PR DESCRIPTION
### Motivation
- Ensure PNCP ETL workflows run with lockfile-pinned dependencies to improve reproducibility and reduce dependency drift in production runs.
- Reduce cold-start time while preserving determinism by optionally caching `uv` artifacts.

### Description
- Added a `Cache uv artifacts` step that caches `~/.cache/uv` keyed by `uv.lock` immediately after `astral-sh/setup-uv@v4` in `.github/workflows/pncp-sync.yml` and `.github/workflows/pncp-backfill.yml`.
- Added a `Sync locked dependencies` step that runs `uv sync --locked` in both workflows and included an inline comment explaining that ETL should run against lockfile-pinned deps for stable production behavior.
- Ensured all existing ETL commands (`uv run baliza ...`) remain after the sync step so the jobs execute against the locked dependency set.

### Testing
- Verified the workflow diffs with `git diff -- .github/workflows/pncp-sync.yml .github/workflows/pncp-backfill.yml` and inspected modified file regions with `nl` to confirm step placement, which succeeded.
- Committed the changes (`git commit`) and confirmed the commit stat with `git show --stat --oneline -1`, which succeeded.
- Created the PR with the updated title/body via the repository helper, which completed successfully; no workflow runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ff8574248325a05046e52104b8dc)