### PR TITLE
Fix spacing regression, grammar, and surface dead watchlist

### DIFF
--- a/web/features/agency-detail.feature
+++ b/web/features/agency-detail.feature
@@ -5,7 +5,7 @@ Feature: Agency Detail View
   Scenario: Missing CNPJ shows EntityNotFound
     Given the URL has no cnpj parameter
     When the agency detail view mounts
-    Then I should see "ÓRGÃO não encontrada"
+    Then I should see "ÓRGÃO não encontrado"
 
   Scenario: Fetch pending shows skeleton
     Given the URL has cnpj "00000000000191"

--- a/web/features/city-detail.feature
+++ b/web/features/city-detail.feature
@@ -5,7 +5,7 @@ Feature: City Detail View
   Scenario: Missing IBGE shows EntityNotFound
     Given the URL has no ibge parameter
     When the city detail view mounts
-    Then I should see "MUNICÍPIO não encontrada"
+    Then I should see "MUNICÍPIO não encontrado"
 
   Scenario: Fetch pending shows skeleton
     Given the URL has ibge "1721000"

--- a/web/features/supplier-detail.feature
+++ b/web/features/supplier-detail.feature
@@ -6,7 +6,7 @@ Feature: Supplier Detail View
   Scenario: Missing CNPJ shows EntityNotFound
     Given the URL has no cnpj parameter
     When the supplier detail view mounts
-    Then I should see "FORNECEDOR não encontrada"
+    Then I should see "FORNECEDOR não encontrado"
 
   Scenario: Archive pending shows skeleton
     Given the URL has cnpj "12345678000195"

--- a/web/src/components/AgencyDetailView.svelte
+++ b/web/src/components/AgencyDetailView.svelte
@@ -6,7 +6,7 @@
   import { prefetchArchive } from '../lib/parquetFallback';
   import type { PNCPContract } from '../lib/pncp';
   import { fetchPublicacaoList } from '../lib/pncpPublicacao';
-  import { formatBRL, formatDate, formatParticao } from '../lib/format';
+  import { formatBRL, formatDate, formatParticao, truncate } from '../lib/format';
   import { resolve } from '../lib/baseUrl';
   import { createListQuery } from '../lib/createListQuery';
   import type { ArchivedContrato } from '../lib/archive/schema';
@@ -315,7 +315,7 @@
               <span class="bid-id">{item.numeroControlePNCP}</span>
               <span class="bid-date">{formatDate(item.dataPublicacaoPncp)}</span>
             </div>
-            <p class="bid-obj">{item.objetoContratacao.substring(0, 150)}...</p>
+            <p class="bid-obj">{truncate(item.objetoContratacao, 150)}</p>
             <div class="bid-footer">
               <span class="valor">{formatBRL(item.valorTotalEstimado)}</span>
             </div>

--- a/web/src/components/CityDetailView.svelte
+++ b/web/src/components/CityDetailView.svelte
@@ -5,7 +5,7 @@
   import { prefetchArchive } from '../lib/parquetFallback';
   import type { PNCPContract } from '../lib/pncp';
   import { fetchPublicacaoList } from '../lib/pncpPublicacao';
-  import { formatBRL, formatDate, formatParticao } from '../lib/format';
+  import { formatBRL, formatDate, formatParticao, truncate } from '../lib/format';
   import { resolve } from '../lib/baseUrl';
   import { createListQuery } from '../lib/createListQuery';
   import type { ArchivedContrato } from '../lib/archive/schema';
@@ -174,7 +174,7 @@
               <span class="bid-id">{item.numeroControlePNCP}</span>
               <span class="bid-date">{formatDate(item.dataPublicacaoPncp)}</span>
             </div>
-            <p class="bid-obj">{item.objetoContratacao.substring(0, 150)}...</p>
+            <p class="bid-obj">{truncate(item.objetoContratacao, 150)}</p>
             <div class="bid-footer">
               <span class="valor">{formatBRL(item.valorTotalEstimado)}</span>
             </div>

--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -363,7 +363,7 @@
   .fq-chip:hover { border-color: var(--color-primary); color: var(--color-primary); }
 
   textarea {
-    width: 100%; height: 120px; background: var(--color-base-200); color: var(--font-mono);
+    width: 100%; height: 120px; background: var(--color-base-200); color: var(--color-base-content);
     border: 1px solid var(--color-base-300); border-radius: var(--radius-sm); padding: var(--space-sm);
     font-family: var(--font-mono); font-size: var(--font-size-sm); resize: vertical; margin-bottom: var(--space-sm);
     outline: none;

--- a/web/src/components/EntityNotFound.svelte
+++ b/web/src/components/EntityNotFound.svelte
@@ -9,13 +9,18 @@
   }
 
   let { id, type, error = "Não encontramos registros para este identificador nas APIs oficiais." }: Props = $props();
+
+  // "contratação" is the only feminine noun among the supported types. The
+  // heading used to read "ÓRGÃO não encontrada", which reads as broken
+  // Portuguese; agree the participle with the gender of the noun.
+  const headingSuffix = $derived(type === 'contratação' ? 'não encontrada' : 'não encontrado');
 </script>
 
 <div class="not-found-container" in:fade>
   <div class="container">
     <div class="error-card">
       <div class="icon">🔍</div>
-      <h2>{type.toUpperCase()} não encontrada</h2>
+      <h2>{type.toUpperCase()} {headingSuffix}</h2>
       <p class="id-display">Identificador: <code>{id}</code></p>
       <p class="message">{error}</p>
       

--- a/web/src/components/LocalBids.svelte
+++ b/web/src/components/LocalBids.svelte
@@ -9,7 +9,7 @@
   import { setCity } from '../lib/cityContext.svelte';
   import type { PNCPContract } from '../lib/pncp';
   import type { ArchivedContrato } from '../lib/archive/schema';
-  import { formatDate, formatParticao } from '../lib/format';
+  import { formatDate, formatParticao, truncate } from '../lib/format';
   import { resolve } from '../lib/baseUrl';
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
@@ -172,7 +172,7 @@
                     <span class="bid-id">#{bid.numeroControlePNCP}</span>
                     <span class="bid-date">{formatDate(bid.dataPublicacaoPncp)}</span>
                   </div>
-                  <p class="bid-obj">{bid.objetoContratacao.substring(0, 100)}...</p>
+                  <p class="bid-obj">{truncate(bid.objetoContratacao, 100)}</p>
                 </a>
               {/each}
             </div>

--- a/web/src/components/SupplierDetailView.svelte
+++ b/web/src/components/SupplierDetailView.svelte
@@ -9,7 +9,7 @@
     queryParquetFallback,
   } from '../lib/parquetFallback';
   import type { PNCPContract } from '../lib/pncp';
-  import { formatBRL, formatDate, formatParticao } from '../lib/format';
+  import { formatBRL, formatDate, formatParticao, truncate } from '../lib/format';
   import { resolve } from '../lib/baseUrl';
   import type { ArchivedContrato } from '../lib/archive/schema';
   import EntityNotFound from './EntityNotFound.svelte';
@@ -273,7 +273,7 @@
               <span class="bid-id">{item.numeroControlePNCP}</span>
               <span class="bid-date">{formatDate(item.dataPublicacaoPncp)}</span>
             </div>
-            <p class="bid-obj">{item.objetoContratacao.substring(0, 150)}...</p>
+            <p class="bid-obj">{truncate(item.objetoContratacao, 150)}</p>
             <div class="bid-footer">
               <span class="buyer">{item.orgaoEntidade.razaoSocial}</span>
               <span class="valor">{formatBRL(item.valorTotalEstimado)}</span>

--- a/web/src/components/WatchList.svelte
+++ b/web/src/components/WatchList.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import {
+    hydrateWatches,
+    removeWatch,
+    watchState,
+    type WatchEntry,
+  } from '../lib/watchStore.svelte';
+  import { resolve } from '../lib/baseUrl';
+
+  // Mirror state lazily so SSR renders an empty list instead of leaking
+  // whichever entries exist on the build machine (always empty today, but
+  // keeps the invariant "no localStorage reads on the server").
+  let mounted = $state(false);
+  onMount(() => {
+    hydrateWatches();
+    mounted = true;
+  });
+
+  const entries = $derived(mounted ? watchState.entries : []);
+
+  function labelForType(type: WatchEntry['type']): string {
+    if (type === 'agency') return 'Órgão';
+    if (type === 'supplier') return 'Fornecedor';
+    return 'Consulta';
+  }
+
+  function linkFor(entry: WatchEntry): string | null {
+    if (entry.type === 'agency') return resolve(`orgao?cnpj=${entry.filter}`);
+    if (entry.type === 'supplier') return resolve(`fornecedor?cnpj=${entry.filter}`);
+    return null;
+  }
+</script>
+
+{#if entries.length > 0}
+  <section class="watch-list" aria-labelledby="watch-title">
+    <div class="container">
+      <header class="watch-head">
+        <span class="kicker">Você está acompanhando</span>
+        <h2 id="watch-title">
+          {entries.length === 1 ? '1 item salvo' : `${entries.length} itens salvos`}
+        </h2>
+        <p class="watch-sub">
+          Salvos neste navegador. Baliza não envia alertas por e-mail — abra esta página
+          quando quiser revisitar os órgãos e fornecedores que você marcou.
+        </p>
+      </header>
+
+      <ul class="watch-grid">
+        {#each entries as entry (entry.id)}
+          <li class="watch-card">
+            <div class="watch-meta">
+              <span class="watch-type">{labelForType(entry.type)}</span>
+              <span class="watch-cnpj">{entry.filter}</span>
+            </div>
+            <p class="watch-label">{entry.label}</p>
+            <div class="watch-actions">
+              {#if linkFor(entry)}
+                <a class="watch-open" href={linkFor(entry)!}>Abrir painel →</a>
+              {/if}
+              <button
+                type="button"
+                class="watch-remove"
+                onclick={() => removeWatch(entry.id)}
+                aria-label={`Remover ${entry.label} da lista`}
+              >
+                Remover
+              </button>
+            </div>
+          </li>
+        {/each}
+      </ul>
+    </div>
+  </section>
+{/if}
+
+<style>
+  .watch-list {
+    padding: var(--space-7) 0;
+    background: var(--neutral-0);
+    border-top: 1px solid var(--neutral-100);
+    border-bottom: 1px solid var(--neutral-100);
+  }
+  .watch-head {
+    max-width: 640px;
+    display: grid;
+    gap: var(--space-2);
+    margin-bottom: var(--space-5);
+  }
+  .watch-head h2 {
+    font-family: var(--font-display);
+    font-weight: 300;
+    font-size: clamp(24px, 2.4vw, 32px);
+    letter-spacing: -0.02em;
+  }
+  .watch-sub {
+    color: var(--neutral-500);
+    font-size: var(--text-sm);
+    line-height: 1.6;
+  }
+  .watch-grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: var(--space-3);
+  }
+  .watch-card {
+    display: grid;
+    gap: var(--space-2);
+    padding: var(--space-4);
+    background: var(--neutral-0);
+    border: 1px solid var(--neutral-100);
+    border-left: 3px solid var(--bulcao-support);
+  }
+  .watch-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: var(--space-3);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: 0.06em;
+    color: var(--neutral-500);
+  }
+  .watch-type {
+    text-transform: uppercase;
+    color: var(--bulcao-support);
+  }
+  .watch-cnpj {
+    color: var(--neutral-500);
+  }
+  .watch-label {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: var(--text-md);
+    line-height: 1.3;
+    color: var(--bulcao-fg);
+    overflow-wrap: anywhere;
+  }
+  .watch-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-3);
+    padding-top: var(--space-2);
+    border-top: 1px solid var(--neutral-100);
+  }
+  .watch-open {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--bulcao-accent);
+    border-bottom: 2px solid transparent;
+    padding: 2px 0;
+  }
+  .watch-open:hover,
+  .watch-open:focus-visible {
+    border-bottom-color: var(--bulcao-accent);
+  }
+  .watch-remove {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--neutral-500);
+    padding: 2px 4px;
+    border: 1px solid transparent;
+  }
+  .watch-remove:hover {
+    color: var(--bulcao-accent);
+    border-color: var(--bulcao-accent);
+  }
+</style>

--- a/web/src/components/__steps__/agency-detail.steps.ts
+++ b/web/src/components/__steps__/agency-detail.steps.ts
@@ -35,9 +35,9 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await tick();
     });
 
-    Then('I should see "ÓRGÃO não encontrada"', async () => {
+    Then('I should see "ÓRGÃO não encontrado"', async () => {
       await waitFor(() =>
-        expect(screen.getByText('ÓRGÃO não encontrada')).toBeTruthy(),
+        expect(screen.getByText('ÓRGÃO não encontrado')).toBeTruthy(),
       );
     });
   });

--- a/web/src/components/__steps__/city-detail.steps.ts
+++ b/web/src/components/__steps__/city-detail.steps.ts
@@ -35,9 +35,9 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await tick();
     });
 
-    Then('I should see "MUNICÍPIO não encontrada"', async () => {
+    Then('I should see "MUNICÍPIO não encontrado"', async () => {
       await waitFor(() =>
-        expect(screen.getByText('MUNICÍPIO não encontrada')).toBeTruthy(),
+        expect(screen.getByText('MUNICÍPIO não encontrado')).toBeTruthy(),
       );
     });
   });

--- a/web/src/components/__steps__/supplier-detail.steps.ts
+++ b/web/src/components/__steps__/supplier-detail.steps.ts
@@ -46,9 +46,9 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       await tick();
     });
 
-    Then('I should see "FORNECEDOR não encontrada"', async () => {
+    Then('I should see "FORNECEDOR não encontrado"', async () => {
       await waitFor(() =>
-        expect(screen.getByText('FORNECEDOR não encontrada')).toBeTruthy(),
+        expect(screen.getByText('FORNECEDOR não encontrado')).toBeTruthy(),
       );
     });
   });

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -66,3 +66,14 @@ export function formatParticao(input: string | null | undefined): string {
 export function normalizeSearchInput(raw: string): string {
   return raw.replace(ZERO_WIDTH, '').trim();
 }
+
+// Only appends the ellipsis when the input is actually longer than the cap.
+// Previous call sites used `s.substring(0, n) + "..."` which produced
+// "Merenda escolar..." for a 15-char string — a sloppy visual tell.
+export function truncate(
+  s: string | null | undefined,
+  max: number,
+): string {
+  if (!s) return '';
+  return s.length > max ? `${s.slice(0, max).trimEnd()}…` : s;
+}

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -6,6 +6,7 @@ import MonitorGrid from '../components/MonitorGrid.astro';
 import TrustStrip from '../components/TrustStrip.astro';
 import OrnamentBand from '../components/OrnamentBand.astro';
 import Dashboard from '../components/Dashboard.svelte';
+import WatchList from '../components/WatchList.svelte';
 import { IA_MANIFEST_URL } from '../lib/ia-manifest';
 
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
@@ -80,7 +81,12 @@ const TOOLS: Array<{
     </div>
   </section>
 
-  <!-- 6. Utilidades avançadas: compact secondary entry points. Demoted link
+  <!-- 6. Watchlist: the "Acompanhar" buttons on detail views save to
+       localStorage; this island surfaces them so the feature isn't invisible
+       after the user clicks it. Renders nothing when the list is empty. -->
+  <WatchList client:only="svelte" />
+
+  <!-- 7. Utilidades avançadas: compact secondary entry points. Demoted link
        grid — no second hero, no second search box. -->
   <section class="tools-strip" aria-labelledby="tools-title">
     <div class="container">

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -92,6 +92,8 @@
 
   --radius-btn: var(--radius-0);
   --radius-box: var(--radius-0);
+  --radius-sm: var(--radius-2);
+  --radius-full: var(--radius-pill);
   --font-sans: var(--font-body);
   --font-serif: var(--font-display);
   --font-size-xs: var(--text-xs);
@@ -102,6 +104,15 @@
   --font-size-xl: var(--text-xl);
   --font-size-2xl: var(--text-2xl);
   --font-size-3xl: var(--text-3xl);
+  /* Legacy t-shirt sized spacing still referenced by detail views. Map onto
+     the 8px scale so padding/margin declarations don't silently drop. */
+  --space-xs:  var(--space-1);
+  --space-sm:  var(--space-3);
+  --space-md:  var(--space-4);
+  --space-lg:  var(--space-5);
+  --space-xl:  var(--space-6);
+  --space-2xl: var(--space-7);
+  --space-3xl: var(--space-8);
   --transition-base: all var(--duration-fast) var(--ease);
 
   --shimmer-gradient: linear-gradient(90deg,


### PR DESCRIPTION
## Summary

I simulated using the web app and audited the user-facing code for real UX problems. Five issues, all fixed in this PR.

### 1. Broken spacing across detail views (silent bug)
`ContractDetailView`, `AgencyDetailView`, `CityDetailView`, `SupplierDetailView`, `AtasView`, `EntityNotFound`, `EmptyState`, `Glossary`, `LookbackWindow`, `DuckDBExplorer`, the 404 page, and several `/pages/*.astro` files reference t-shirt-sized CSS custom properties — `--space-xs/sm/md/lg/xl/2xl/3xl` and `--radius-sm/full` — that were **never defined** in `global.css`. Every declaration using one of them silently drops, so padding/margin on these views collapse. 144 references across the components folder, all broken.

Fix: add compatibility aliases in `global.css` that map the legacy names onto the 8px scale already in use (`--space-sm` → `--space-3`, etc.).

### 2. DuckDBExplorer SQL textarea color bug
`textarea { color: var(--font-mono) }` assigns a font-family value to `color`. Text color fell back to UA default — often unreadable in dark mode. Maps to `--color-base-content` now.

### 3. EntityNotFound grammar
Heading read **"ÓRGÃO não encontrada"** / **"MUNICÍPIO não encontrada"** / **"FORNECEDOR não encontrada"** — all grammatically wrong: those nouns are masculine. Agree the participle with the noun's gender (contratação → "encontrada"; órgão/município/fornecedor → "encontrado"). Feature files and step defs updated to match.

### 4. Bid cards append "..." to short objects
`objetoContratacao.substring(0, 150) + "..."` unconditionally appended the ellipsis even for 15-character strings ("Merenda escolar..."). Added a `truncate()` helper in `format.ts` and used it in `LocalBids`, `AgencyDetailView`, `CityDetailView`, `SupplierDetailView`.

### 5. Dead "Acompanhar" feature
`watchStore.addWatch()` is wired into the "Acompanhar" buttons on the contract and agency detail views. But nothing in the UI ever renders `watchState` or calls `removeWatch()` — users clicked "Acompanhar", the button flipped to "✓ Acompanhando", and then the record vanished into localStorage with no recall path. Added a `WatchList.svelte` island on the home page (below the sync signal strip) that surfaces saved entries with links back to the agency/supplier panels and a remove button. Renders nothing when the list is empty, so it doesn't clutter the hero for first-time visitors.

## Test plan
- [x] `npm test` — 499 passing, 62 planned/wip skipped, 0 failures
- [x] Dev server serves 200 on `/`, `/contratacao`, `/orgao`, `/municipio`, `/fornecedor`, `/atas`, `/explorador`, `/status`, `/desenvolvedores`, `/sobre`
- [x] Gherkin steps for the EntityNotFound scenarios updated in parallel with the feature files
- [ ] Manual browser check of the watchlist round-trip (Acompanhar → home → Remover)

https://claude.ai/code/session_01WkejyqufDWrBLVBRURg3rE

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkejyqufDWrBLVBRURg3rE)_