### PR TITLE
Enforce Concretista design system focus and hover states

### DIFF
--- a/web/src/components/AgencyDetailView.svelte
+++ b/web/src/components/AgencyDetailView.svelte
@@ -395,10 +395,10 @@
   .recent-header { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: var(--space-sm); }
   .bid-link-card {
     display: block; text-decoration: none; color: inherit; background: var(--color-base-100);
-    padding: var(--space-md); border-radius: var(--radius-sm); border: 1px solid var(--color-base-300);
-    transition: transform 0.2s, border-color 0.2s;
+    padding: var(--space-md); border-radius: 0; border: 1px solid var(--color-base-300);
+    transition: transform 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-  .bid-link-card:hover { transform: translateX(5px); border-color: var(--color-primary); }
+  .bid-link-card:hover, .bid-link-card:focus-visible { transform: translate(-2px, -2px); border-color: var(--color-primary); box-shadow: 4px 4px 0 var(--color-primary); }
   .bid-header { display: flex; justify-content: space-between; margin-bottom: var(--space-sm); font-size: 0.75rem; font-family: var(--font-mono); color: var(--color-secondary); }
   .bid-obj { font-size: var(--font-size-sm); line-height: 1.5; margin-bottom: var(--space-sm); }
   .bid-footer { text-align: right; font-weight: 800; color: var(--color-primary); }

--- a/web/src/components/AtasView.svelte
+++ b/web/src/components/AtasView.svelte
@@ -175,11 +175,11 @@
     color: inherit;
     background: var(--color-base-100);
     padding: var(--space-md);
-    border-radius: var(--radius-sm);
+    border-radius: 0;
     border: 1px solid var(--color-base-300);
-    transition: transform 0.2s, border-color 0.2s;
+    transition: transform 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-  .ata-card:hover { transform: translateX(5px); border-color: var(--color-primary); }
+  .ata-card:hover, .ata-card:focus-visible { transform: translate(-2px, -2px); border-color: var(--color-primary); box-shadow: 4px 4px 0 var(--color-primary); }
   .ata-header {
     display: flex; justify-content: space-between; align-items: baseline; gap: var(--space-sm);
     font-size: var(--font-size-sm); margin-bottom: var(--space-sm);

--- a/web/src/components/CityDetailView.svelte
+++ b/web/src/components/CityDetailView.svelte
@@ -207,10 +207,10 @@
   .recent-list { display: grid; gap: var(--space-md); }
   .bid-link-card {
     display: block; text-decoration: none; color: inherit; background: var(--color-base-100);
-    padding: var(--space-md); border-radius: var(--radius-sm); border: 1px solid var(--color-base-300);
-    transition: transform 0.2s, border-color 0.2s;
+    padding: var(--space-md); border-radius: 0; border: 1px solid var(--color-base-300);
+    transition: transform 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-  .bid-link-card:hover { transform: translateX(5px); border-color: var(--color-primary); }
+  .bid-link-card:hover, .bid-link-card:focus-visible { transform: translate(-2px, -2px); border-color: var(--color-primary); box-shadow: 4px 4px 0 var(--color-primary); }
   .bid-header { display: flex; justify-content: space-between; margin-bottom: var(--space-sm); font-size: 0.75rem; font-family: var(--font-mono); color: var(--color-secondary); }
   .bid-obj { font-size: var(--font-size-sm); line-height: 1.5; margin-bottom: var(--space-sm); }
   .bid-footer { text-align: right; font-weight: 800; color: var(--color-primary); }

--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -261,13 +261,14 @@
   .schema-toggle {
     background: var(--color-base-200);
     border: 1px solid var(--color-base-300);
-    border-radius: var(--radius-sm);
+    border-radius: 0;
     padding: 4px 10px;
     font-size: var(--font-size-xs);
     cursor: pointer;
     color: var(--color-secondary);
+    transition: all var(--transition-base);
   }
-  .schema-toggle:hover { border-color: var(--color-primary); color: var(--color-primary); }
+  .schema-toggle:hover, .schema-toggle:focus-visible { border-color: var(--color-primary); color: var(--color-primary); transform: translate(-1px, -1px); box-shadow: 2px 2px 0 var(--color-primary); }
 
   .explorer-body {
     display: grid;
@@ -353,14 +354,14 @@
     background: var(--color-base-200);
     border: 1px solid var(--color-base-300);
     padding: 3px 10px;
-    border-radius: var(--radius-full);
+    border-radius: 0;
     cursor: pointer;
     font-size: var(--font-size-xs);
     color: var(--color-secondary);
     font-family: var(--font-sans);
     transition: all var(--transition-base);
   }
-  .fq-chip:hover { border-color: var(--color-primary); color: var(--color-primary); }
+  .fq-chip:hover, .fq-chip:focus-visible { border-color: var(--color-primary); color: var(--color-primary); transform: translate(-1px, -1px); box-shadow: 2px 2px 0 var(--color-primary); }
 
   textarea {
     width: 100%; height: 120px; background: var(--color-base-200); color: var(--color-base-content);

--- a/web/src/components/LocalBids.svelte
+++ b/web/src/components/LocalBids.svelte
@@ -251,18 +251,16 @@
     color: inherit;
     padding: var(--space-4);
     background: var(--neutral-50);
-    border-radius: var(--radius-0);
+    border-radius: 0;
     transition: all var(--duration-fast) var(--ease);
     border: 1px solid transparent;
   }
 
-  .bid-card:hover {
-    background: var(--neutral-100);
+  .bid-card:hover, .bid-card:focus-visible {
+    background: var(--neutral-50);
     border-color: var(--bulcao-accent);
-  }
-  .bid-card:focus-visible {
-    background: var(--neutral-100);
-    border-color: var(--bulcao-accent);
+    transform: translate(-2px, -2px);
+    box-shadow: 4px 4px 0 var(--bulcao-accent);
   }
 
   .bid-meta {

--- a/web/src/components/SupplierDetailView.svelte
+++ b/web/src/components/SupplierDetailView.svelte
@@ -344,10 +344,10 @@
   .recent-header { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: var(--space-sm); }
   .bid-link-card {
     display: block; text-decoration: none; color: inherit; background: var(--color-base-100);
-    padding: var(--space-md); border-radius: var(--radius-sm); border: 1px solid var(--color-base-300);
-    transition: transform 0.2s, border-color 0.2s;
+    padding: var(--space-md); border-radius: 0; border: 1px solid var(--color-base-300);
+    transition: transform 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-  .bid-link-card:hover { transform: translateX(5px); border-color: var(--color-primary); }
+  .bid-link-card:hover, .bid-link-card:focus-visible { transform: translate(-2px, -2px); border-color: var(--color-primary); box-shadow: 4px 4px 0 var(--color-primary); }
   .bid-header { display: flex; justify-content: space-between; margin-bottom: var(--space-sm); font-size: 0.75rem; font-family: var(--font-mono); color: var(--color-secondary); }
   .bid-obj { font-size: var(--font-size-sm); line-height: 1.5; margin-bottom: var(--space-sm); }
   .bid-footer { display: flex; justify-content: space-between; align-items: baseline; font-size: var(--font-size-sm); }

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -187,8 +187,9 @@ hr { border: 0; border-top: 1px solid var(--neutral-200); margin: 0; }
 ::selection { background: var(--bulcao-accent); color: var(--bulcao-bg); }
 
 *:focus-visible {
-  outline: 2px solid var(--color-primary);
+  outline: 2px solid transparent;
   outline-offset: 2px;
+  box-shadow: 4px 4px 0 var(--color-primary);
 }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
This pull request updates the frontend components and global CSS to enforce the strict visual guidelines outlined in the Baliza Design Constitution (Concretista design system).

Key changes:
- `global.css`: Updated `*:focus-visible` to use a 4px 4px architectural offset shadow (`box-shadow`) instead of an outline, with a transparent outline to maintain accessibility for high-contrast modes.
- Replaced `border-radius: var(--radius-sm)` with `border-radius: 0` (sharp geometry) and added the standard hover/focus offset shadow effect (`transform: translate(-2px, -2px); box-shadow: 4px 4px 0 var(--color-primary)`) on interactive cards across the following components:
  - `AgencyDetailView.svelte`
  - `CityDetailView.svelte`
  - `SupplierDetailView.svelte`
  - `AtasView.svelte`
  - `LocalBids.svelte`
  - `DuckDBExplorer.svelte` (for `.fq-chip` and `.schema-toggle`)

The changes were verified using `vitest` unit tests and a custom Playwright user journey execution to ensure visual correctness.

---
*PR created automatically by Jules for task [13900127343707147248](https://jules.google.com/task/13900127343707147248) started by @franklinbaldo*