### PR TITLE
[codex] Clamp PNCP sync to known data start

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ Baliza V2 collapses the pipeline into a single omnibus command. The scheduled Gi
 ### `sync` — Extract missing months, upload to IA, consolidate
 
 ```bash
-baliza sync --start-date 2023-01-01
+baliza sync --start-date 2021-09-01
 ```
 
 Walks backwards from the previous month to `--start-date`, skipping months already present on Internet Archive (source of truth is the remote `manifest.csv`). For each missing month it extracts from PNCP, uploads the monthly Parquet snapshot to IA, and — once the run finishes with new data — rebuilds the annual consolidated archives.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--start-date` | `2023-01-01` | Oldest date to backfill to |
+| `--start-date` | `2021-09-01` | Oldest date to backfill to. `contratos` data starts on 2021-09-06, so earlier dates are clamped to the 2021-09 monthly partition. |
 | `--batch-size, -n` | all pending | Max months to sync in one run |
 | `--force-month` | — | Target a specific month (YYYY-MM) regardless of manifest |
 | `--limit-minutes` | `0` (no limit) | Stop after N minutes (for CI deadlines) |

--- a/src/baliza/builder.py
+++ b/src/baliza/builder.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import httpx
 import structlog
 
-from .constants import clamp_to_known_data_start_month
+from .constants import RESOURCE_CONTRATOS, clamp_to_known_data_start_month
 from .daily_exporter import SCHEMA_VERSION
 from .engine import BalizaEngine
 from .extractor import PNCPExtractor
@@ -29,6 +29,7 @@ def _pending_build_months(
     start_date: date,
     batch_size: int | None,
     *,
+    resource: str = RESOURCE_CONTRATOS,
     backfill: bool = False,
 ) -> list[date]:
     """Return months that need a Parquet build, newest-first.
@@ -45,7 +46,7 @@ def _pending_build_months(
     raw_manifest = read_manifest_from_ia()  # strict: raises ManifestReadError on failure
     today = date.today()
     last_month = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
-    start = clamp_to_known_data_start_month("contratos", start_date)
+    start = clamp_to_known_data_start_month(resource, start_date)
 
     pending_set: set[date] = set()
     for row in raw_manifest:

--- a/src/baliza/builder.py
+++ b/src/baliza/builder.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import httpx
 import structlog
 
+from .constants import clamp_to_known_data_start_month
 from .daily_exporter import SCHEMA_VERSION
 from .engine import BalizaEngine
 from .extractor import PNCPExtractor
@@ -44,7 +45,7 @@ def _pending_build_months(
     raw_manifest = read_manifest_from_ia()  # strict: raises ManifestReadError on failure
     today = date.today()
     last_month = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
-    start = start_date.replace(day=1)
+    start = clamp_to_known_data_start_month("contratos", start_date)
 
     pending_set: set[date] = set()
     for row in raw_manifest:

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -32,6 +32,7 @@ from rich.progress import (
 from .builder import _pending_build_months, build_month
 from .consolidator import IAConsolidator
 from .constants import (
+    RESOURCE_CONTRATOS,
     clamp_to_known_data_start_month,
     known_data_start_month,
     month_predates_known_data,
@@ -49,6 +50,7 @@ console = Console()
 
 
 def _forced_month_or_empty(resource: str, force_month: str) -> list[date]:
+    """Return a one-month batch, or an intentional no-op for pre-history months."""
     forced = datetime.strptime(force_month, "%Y-%m").date()
     if month_predates_known_data(resource, forced):
         console.print(
@@ -105,7 +107,7 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
     try:
         # Default resource for sync is 'contratos' inside PNCPExtractor
         # But we check it here if needed.
-        _validate_resource("contratos")
+        _validate_resource(RESOURCE_CONTRATOS)
     except ValueError as e:
         print(str(e))
         sys.stdout.flush()
@@ -123,7 +125,7 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
     # (if enabled) the up-front consolidation catch-up below.
     raw_manifest: list[dict] = []
     if force_month:
-        batch = _forced_month_or_empty("contratos", force_month)
+        batch = _forced_month_or_empty(RESOURCE_CONTRATOS, force_month)
         uploaded: set[str] = set()
     else:
         with console.status("[bold green]Checking IA manifest for pending months...[/bold green]"):
@@ -145,9 +147,9 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
                 uploaded = set()
 
             start = clamp_to_known_data_start_month(
-                "contratos", datetime.strptime(start_date, "%Y-%m-%d").date()
+                RESOURCE_CONTRATOS, datetime.strptime(start_date, "%Y-%m-%d").date()
             )
-            
+
             today = date.today()
             # End is the previous month
             last_month_end = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
@@ -158,7 +160,7 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
                 month_key = curr.strftime("%Y-%m")
                 if month_key not in uploaded:
                     pending_months.append(curr)
-                
+
                 # Advance to next month
                 if curr.month == 12:
                     curr = curr.replace(year=curr.year + 1, month=1)
@@ -237,7 +239,7 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
         overall_task = progress.add_task(
             "[bold white]Overall Sync Progress (Months)[/bold white]", total=len(batch)
         )
-        
+
         month_tasks: dict[str, TaskID] = {}
 
         # Use pool for parallel scraping
@@ -246,7 +248,7 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
 
             def process_month_full(start_of_month: date):  # noqa: PLR0912, PLR0915
                 nonlocal total_records, quarantine_count, error_count
-                
+
                 month_str = start_of_month.strftime("%Y-%m")
                 # Calculate end of month
                 if start_of_month.month == 12:
@@ -257,11 +259,11 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
 
                 # THREAD-SAFE ENGINE: Each worker gets its own connection
                 thread_engine = engine.connect_thread_safe()
-                
+
                 # 1. Lifecycle Progress Bar Start
                 tid = progress.add_task(f"Month {month_str} [Probing]", total=3, completed=0)
                 month_tasks[month_str] = tid
-                
+
                 try:
                     raw_month_dir = Path("data/raw") / month_str
                     sentinel = raw_month_dir / FETCHED_SENTINEL
@@ -357,7 +359,7 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
 
                         if total_pages is None:
                             res = extractor.probe_range(
-                                "contratos", month_start_dt, month_end_dt
+                                RESOURCE_CONTRATOS, month_start_dt, month_end_dt
                             )
                             total_pages = res["total_pages"]
 
@@ -416,7 +418,7 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
                                     description=f"Month {month_str} [Pages {i}/{len(missing_pages)}]",
                                 )
                                 extractor.fetch_page(
-                                    "contratos", month_start_dt, month_end_dt, p
+                                    RESOURCE_CONTRATOS, month_start_dt, month_end_dt, p
                                 )
                                 progress.update(tid, advance=1)
 
@@ -447,13 +449,13 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
                                 )
                         else:
                             progress.console.log(f"[yellow]Dry-run: {month_str} verified ({stats['valid']} records)[/yellow]")
-                        
+
                         # Step complete
                         progress.update(tid, advance=1)
 
                         if q_csv.exists():
                             q_csv.unlink()
-                            
+
                     progress.update(overall_task, advance=1)
                 except ValueError as e:
                     if "Invalid resource path" in str(e):
@@ -543,14 +545,14 @@ def mirror_cmd(  # noqa: PLR0913
         raise typer.Exit(1)
 
     if force_month:
-        batch = _forced_month_or_empty("contratos", force_month)
+        batch = _forced_month_or_empty(RESOURCE_CONTRATOS, force_month)
     else:
         start = clamp_to_known_data_start_month(
-            "contratos", datetime.strptime(start_date, "%Y-%m-%d").date()
+            RESOURCE_CONTRATOS, datetime.strptime(start_date, "%Y-%m-%d").date()
         )
         try:
             with console.status("[bold green]Checking IA manifest for pending months...[/bold green]"):
-                batch = _pending_mirror_months(start, batch_size)
+                batch = _pending_mirror_months(start, batch_size, resource=RESOURCE_CONTRATOS)
         except Exception as e:
             console.print(f"[red]✗ Cannot read IA manifest: {e}[/red]")
             raise typer.Exit(1) from None
@@ -643,14 +645,16 @@ def build_cmd(  # noqa: PLR0913, PLR0915
         raise typer.Exit(1)
 
     if force_month:
-        batch = _forced_month_or_empty("contratos", force_month)
+        batch = _forced_month_or_empty(RESOURCE_CONTRATOS, force_month)
     else:
         start = clamp_to_known_data_start_month(
-            "contratos", datetime.strptime(start_date, "%Y-%m-%d").date()
+            RESOURCE_CONTRATOS, datetime.strptime(start_date, "%Y-%m-%d").date()
         )
         try:
             with console.status("[bold green]Checking IA manifest for months to build...[/bold green]"):
-                batch = _pending_build_months(start, batch_size, backfill=backfill)
+                batch = _pending_build_months(
+                    start, batch_size, resource=RESOURCE_CONTRATOS, backfill=backfill
+                )
         except Exception as e:
             console.print(f"[red]✗ Cannot read IA manifest: {e}[/red]")
             raise typer.Exit(1) from None
@@ -716,7 +720,9 @@ def build_cmd(  # noqa: PLR0913, PLR0915
 
 @app.command("verify")
 def verify(
-    resource: str = typer.Option("contratos", "--resource", "-r", help="Resource to verify"),
+    resource: str = typer.Option(
+        RESOURCE_CONTRATOS, "--resource", "-r", help="Resource to verify"
+    ),
     start: str = typer.Option(..., "--start", help="Start date (YYYY-MM-DD)"),
     end: str = typer.Option(..., "--end", help="End date (YYYY-MM-DD)"),
 ) -> None:
@@ -746,7 +752,7 @@ def verify(
             month_key = curr.strftime("%Y-%m")
             if month_key not in uploaded_months:
                 gaps.append(month_key)
-            
+
             # Next month
             if curr.month == 12:
                 curr = curr.replace(year=curr.year + 1, month=1)

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -31,6 +31,11 @@ from rich.progress import (
 
 from .builder import _pending_build_months, build_month
 from .consolidator import IAConsolidator
+from .constants import (
+    clamp_to_known_data_start_month,
+    known_data_start_month,
+    month_predates_known_data,
+)
 from .engine import BalizaEngine
 from .extractor import FETCHED_SENTINEL, PNCPExtractor, _validate_resource
 from .ia_uploader import IAUploader
@@ -41,6 +46,17 @@ logger = structlog.get_logger()
 
 app = typer.Typer()
 console = Console()
+
+
+def _forced_month_or_empty(resource: str, force_month: str) -> list[date]:
+    forced = datetime.strptime(force_month, "%Y-%m").date()
+    if month_predates_known_data(resource, forced):
+        console.print(
+            f"[yellow]⚠ Requested month predates known PNCP {resource} data "
+            f"({known_data_start_month(resource).strftime('%Y-%m')}), skipping.[/yellow]"
+        )
+        return []
+    return [forced]
 
 
 @app.callback()
@@ -58,7 +74,7 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
     batch_size: int | None = typer.Option(
         None, "--batch-size", "-n", help="Max months to sync (None for all)"
     ),
-    start_date: str = typer.Option("2023-01-01", "--start-date", help="Oldest date to backfill"),
+    start_date: str = typer.Option("2021-09-01", "--start-date", help="Oldest date to backfill"),
     db_path: Path | None = typer.Option(
         None, "--duckdb", help="DuckDB file (optional, defaults to :memory:)"
     ),
@@ -107,7 +123,7 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
     # (if enabled) the up-front consolidation catch-up below.
     raw_manifest: list[dict] = []
     if force_month:
-        batch = [datetime.strptime(force_month, "%Y-%m").date()]
+        batch = _forced_month_or_empty("contratos", force_month)
         uploaded: set[str] = set()
     else:
         with console.status("[bold green]Checking IA manifest for pending months...[/bold green]"):
@@ -128,9 +144,9 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
                 )
                 uploaded = set()
 
-            start = datetime.strptime(start_date, "%Y-%m-%d").date()
-            # Month-based start (first day of its month)
-            start = start.replace(day=1)
+            start = clamp_to_known_data_start_month(
+                "contratos", datetime.strptime(start_date, "%Y-%m-%d").date()
+            )
             
             today = date.today()
             # End is the previous month
@@ -503,7 +519,7 @@ def mirror_cmd(  # noqa: PLR0913
     batch_size: int | None = typer.Option(
         None, "--batch-size", "-n", help="Max months to mirror (None for all)"
     ),
-    start_date: str = typer.Option("2023-01-01", "--start-date", help="Oldest date to backfill"),
+    start_date: str = typer.Option("2021-09-01", "--start-date", help="Oldest date to backfill"),
     force_month: str | None = typer.Option(
         None, "--force-month", help="Target a specific month (YYYY-MM) regardless of manifest"
     ),
@@ -527,9 +543,11 @@ def mirror_cmd(  # noqa: PLR0913
         raise typer.Exit(1)
 
     if force_month:
-        batch = [datetime.strptime(force_month, "%Y-%m").date()]
+        batch = _forced_month_or_empty("contratos", force_month)
     else:
-        start = datetime.strptime(start_date, "%Y-%m-%d").date()
+        start = clamp_to_known_data_start_month(
+            "contratos", datetime.strptime(start_date, "%Y-%m-%d").date()
+        )
         try:
             with console.status("[bold green]Checking IA manifest for pending months...[/bold green]"):
                 batch = _pending_mirror_months(start, batch_size)
@@ -598,7 +616,7 @@ def build_cmd(  # noqa: PLR0913, PLR0915
     batch_size: int | None = typer.Option(
         None, "--batch-size", "-n", help="Max months to build (None for all)"
     ),
-    start_date: str = typer.Option("2023-01-01", "--start-date", help="Oldest date to backfill"),
+    start_date: str = typer.Option("2021-09-01", "--start-date", help="Oldest date to backfill"),
     force_month: str | None = typer.Option(
         None, "--force-month", help="Target a specific month (YYYY-MM) regardless of manifest"
     ),
@@ -625,9 +643,11 @@ def build_cmd(  # noqa: PLR0913, PLR0915
         raise typer.Exit(1)
 
     if force_month:
-        batch = [datetime.strptime(force_month, "%Y-%m").date()]
+        batch = _forced_month_or_empty("contratos", force_month)
     else:
-        start = datetime.strptime(start_date, "%Y-%m-%d").date()
+        start = clamp_to_known_data_start_month(
+            "contratos", datetime.strptime(start_date, "%Y-%m-%d").date()
+        )
         try:
             with console.status("[bold green]Checking IA manifest for months to build...[/bold green]"):
                 batch = _pending_build_months(start, batch_size, backfill=backfill)
@@ -703,7 +723,9 @@ def verify(
     """Verify data coverage by checking the REMOTE IA manifest."""
     try:
         _validate_resource(resource)
-        start_date = datetime.strptime(start, "%Y-%m-%d").date()
+        start_date = clamp_to_known_data_start_month(
+            resource, datetime.strptime(start, "%Y-%m-%d").date()
+        )
         # end_date is used for validation during parsing
         datetime.strptime(end, "%Y-%m-%d").date()
 

--- a/src/baliza/constants.py
+++ b/src/baliza/constants.py
@@ -27,9 +27,16 @@ def known_data_start_month(resource: str) -> date:
 
 
 def clamp_to_known_data_start_month(resource: str, start: date) -> date:
-    """Clamp a requested start date to the first possible source-data month."""
+    """Clamp a requested start date to the first possible source-data month.
+
+    If no data-start is configured for the resource, returns the month-normalised
+    start unchanged so callers never crash on resources not yet in the registry.
+    """
     start_month = start.replace(day=1)
-    return max(start_month, known_data_start_month(resource))
+    floor = PNCP_RESOURCE_DATA_STARTS.get(resource)
+    if floor is None:
+        return start_month
+    return max(start_month, floor.replace(day=1))
 
 
 def month_predates_known_data(resource: str, month: date) -> bool:

--- a/src/baliza/constants.py
+++ b/src/baliza/constants.py
@@ -2,22 +2,27 @@ from __future__ import annotations
 
 from datetime import date
 
+RESOURCE_CONTRATOS = "contratos"
+
 # PNCP's contratos endpoint has no data before 2021-09-06. Treat this as
 # immutable product-domain knowledge so backfills never waste runs probing
 # months that cannot contain source records.
 PNCP_RESOURCE_DATA_STARTS: dict[str, date] = {
-    "contratos": date(2021, 9, 6),
+    RESOURCE_CONTRATOS: date(2021, 9, 6),
 }
 
 
-def known_data_start(resource: str) -> date:
+def _known_data_start(resource: str) -> date:
     """Return the first known source-data date for a PNCP resource."""
-    return PNCP_RESOURCE_DATA_STARTS[resource]
+    try:
+        return PNCP_RESOURCE_DATA_STARTS[resource]
+    except KeyError as e:
+        raise ValueError(f"No known PNCP data start configured for resource: {resource}") from e
 
 
 def known_data_start_month(resource: str) -> date:
     """Return the first monthly partition that can contain PNCP source data."""
-    start = known_data_start(resource)
+    start = _known_data_start(resource)
     return start.replace(day=1)
 
 

--- a/src/baliza/constants.py
+++ b/src/baliza/constants.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import date
+
+# PNCP's contratos endpoint has no data before 2021-09-06. Treat this as
+# immutable product-domain knowledge so backfills never waste runs probing
+# months that cannot contain source records.
+PNCP_RESOURCE_DATA_STARTS: dict[str, date] = {
+    "contratos": date(2021, 9, 6),
+}
+
+
+def known_data_start(resource: str) -> date:
+    """Return the first known source-data date for a PNCP resource."""
+    return PNCP_RESOURCE_DATA_STARTS[resource]
+
+
+def known_data_start_month(resource: str) -> date:
+    """Return the first monthly partition that can contain PNCP source data."""
+    start = known_data_start(resource)
+    return start.replace(day=1)
+
+
+def clamp_to_known_data_start_month(resource: str, start: date) -> date:
+    """Clamp a requested start date to the first possible source-data month."""
+    start_month = start.replace(day=1)
+    return max(start_month, known_data_start_month(resource))
+
+
+def month_predates_known_data(resource: str, month: date) -> bool:
+    """Return True when a monthly partition cannot contain source data."""
+    return month.replace(day=1) < known_data_start_month(resource)

--- a/src/baliza/mirror.py
+++ b/src/baliza/mirror.py
@@ -14,14 +14,19 @@ from pathlib import Path
 
 import structlog
 
-from .constants import clamp_to_known_data_start_month
+from .constants import RESOURCE_CONTRATOS, clamp_to_known_data_start_month
 from .extractor import FETCHED_SENTINEL, PNCPExtractor, _validate_resource
 from .ia_uploader import IAUploader, read_manifest_from_ia
 
 logger = structlog.get_logger()
 
 
-def _pending_mirror_months(start_date: date, batch_size: int | None) -> list[date]:
+def _pending_mirror_months(
+    start_date: date,
+    batch_size: int | None,
+    *,
+    resource: str = RESOURCE_CONTRATOS,
+) -> list[date]:
     """Return months not yet mirrored (no raw_zip_url in manifest), newest-first."""
     raw_manifest = read_manifest_from_ia()  # strict: raises ManifestReadError on failure
     # A month is "mirrored" if it has a non-empty raw_zip_url in its canonical row.
@@ -33,7 +38,7 @@ def _pending_mirror_months(start_date: date, batch_size: int | None) -> list[dat
 
     today = date.today()
     last_month = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
-    start = clamp_to_known_data_start_month("contratos", start_date)
+    start = clamp_to_known_data_start_month(resource, start_date)
 
     pending: list[date] = []
     curr = start
@@ -71,7 +76,7 @@ def mirror_month(  # noqa: PLR0912, PLR0913, PLR0915
     Returns:
         Dict with keys: ``month``, ``pages_fetched``, ``pages_cached``, ``uploaded``.
     """
-    _validate_resource("contratos")
+    _validate_resource(RESOURCE_CONTRATOS)
 
     month_str = start_of_month.strftime("%Y-%m")
     if start_of_month.month == 12:
@@ -147,7 +152,7 @@ def mirror_month(  # noqa: PLR0912, PLR0913, PLR0915
                     pass
 
         if total_pages is None:
-            res = extractor.probe_range("contratos", month_start_dt, month_end_dt)
+            res = extractor.probe_range(RESOURCE_CONTRATOS, month_start_dt, month_end_dt)
             total_pages = res["total_pages"]
 
         missing_pages = [p for p in range(1, total_pages + 1) if not _page_is_cached(p)]
@@ -167,7 +172,7 @@ def mirror_month(  # noqa: PLR0912, PLR0913, PLR0915
                 pass
 
         for p in missing_pages:
-            extractor.fetch_page("contratos", month_start_dt, month_end_dt, p)
+            extractor.fetch_page(RESOURCE_CONTRATOS, month_start_dt, month_end_dt, p)
             result["pages_fetched"] = int(result["pages_fetched"]) + 1
             _emit(f"{month_str} page {p}/{total_pages}")
 

--- a/src/baliza/mirror.py
+++ b/src/baliza/mirror.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import structlog
 
+from .constants import clamp_to_known_data_start_month
 from .extractor import FETCHED_SENTINEL, PNCPExtractor, _validate_resource
 from .ia_uploader import IAUploader, read_manifest_from_ia
 
@@ -32,7 +33,7 @@ def _pending_mirror_months(start_date: date, batch_size: int | None) -> list[dat
 
     today = date.today()
     last_month = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
-    start = start_date.replace(day=1)
+    start = clamp_to_known_data_start_month("contratos", start_date)
 
     pending: list[date] = []
     curr = start

--- a/tests/step_defs/test_sync.py
+++ b/tests/step_defs/test_sync.py
@@ -137,12 +137,23 @@ def clear_ia_keys(monkeypatch):
 def manifest_lists_every_month(mock_ia_manifest):
     from datetime import date
 
+    from baliza.constants import known_data_start_month
+
     today = date.today()
     rows = []
-    for year in range(2023, today.year + 1):
+    first_month = known_data_start_month("contratos")
+    for year in range(first_month.year, today.year + 1):
         last_month = 12 if year < today.year else today.month
-        for m in range(1, last_month + 1):
-            rows.append({"data_particao": f"{year}-{m:02d}", "table_name": "contratos"})
+        first_month_for_year = first_month.month if year == first_month.year else 1
+        for m in range(first_month_for_year, last_month + 1):
+            month = f"{year}-{m:02d}"
+            rows.append(
+                {
+                    "data_particao": month,
+                    "table_name": "contratos",
+                    "parquet_url": f"https://example.invalid/contratos-{month}.parquet",
+                }
+            )
     mock_ia_manifest(rows)
 
 
@@ -178,6 +189,7 @@ def run_sync_happy(
             "--no-curl",
             "--workers",
             "1",
+            "--no-consolidate",
             "--duckdb",
             str(tmp_path / "sync.duckdb"),
         ],
@@ -198,6 +210,7 @@ def run_sync_no_force(monkeypatch, tmp_path: Path, mock_ia_upload):
             "--no-curl",
             "--workers",
             "1",
+            "--no-consolidate",
             "--duckdb",
             str(tmp_path / "sync.duckdb"),
         ],
@@ -228,6 +241,7 @@ def run_sync_dry_run(
             "--no-curl",
             "--workers",
             "1",
+            "--no-consolidate",
             "--duckdb",
             str(tmp_path / "sync.duckdb"),
         ],
@@ -250,6 +264,7 @@ def run_sync_missing_keys(monkeypatch, tmp_path: Path, mock_ia_upload):
             "--no-curl",
             "--workers",
             "1",
+            "--no-consolidate",
             "--duckdb",
             str(tmp_path / "sync.duckdb"),
         ],

--- a/tests/step_defs/test_sync.py
+++ b/tests/step_defs/test_sync.py
@@ -137,11 +137,11 @@ def clear_ia_keys(monkeypatch):
 def manifest_lists_every_month(mock_ia_manifest):
     from datetime import date
 
-    from baliza.constants import known_data_start_month
+    from baliza.constants import RESOURCE_CONTRATOS, known_data_start_month
 
     today = date.today()
     rows = []
-    first_month = known_data_start_month("contratos")
+    first_month = known_data_start_month(RESOURCE_CONTRATOS)
     for year in range(first_month.year, today.year + 1):
         last_month = 12 if year < today.year else today.month
         first_month_for_year = first_month.month if year == first_month.year else 1
@@ -150,7 +150,7 @@ def manifest_lists_every_month(mock_ia_manifest):
             rows.append(
                 {
                     "data_particao": month,
-                    "table_name": "contratos",
+                    "table_name": RESOURCE_CONTRATOS,
                     "parquet_url": f"https://example.invalid/contratos-{month}.parquet",
                 }
             )

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -1,0 +1,36 @@
+from datetime import date
+
+import pytest
+
+from baliza.constants import (
+    RESOURCE_CONTRATOS,
+    clamp_to_known_data_start_month,
+    known_data_start_month,
+    month_predates_known_data,
+)
+
+
+def test_known_data_start_month_for_contratos():
+    assert known_data_start_month(RESOURCE_CONTRATOS) == date(2021, 9, 1)
+
+
+def test_clamp_to_known_data_start_month_clamps_pre_history_date():
+    assert clamp_to_known_data_start_month(RESOURCE_CONTRATOS, date(2020, 1, 1)) == date(
+        2021, 9, 1
+    )
+
+
+def test_clamp_to_known_data_start_month_normalizes_later_date_to_month_start():
+    assert clamp_to_known_data_start_month(RESOURCE_CONTRATOS, date(2022, 3, 15)) == date(
+        2022, 3, 1
+    )
+
+
+def test_month_predates_known_data():
+    assert month_predates_known_data(RESOURCE_CONTRATOS, date(2021, 8, 1)) is True
+    assert month_predates_known_data(RESOURCE_CONTRATOS, date(2021, 9, 1)) is False
+
+
+def test_unknown_resource_raises_descriptive_error():
+    with pytest.raises(ValueError, match="No known PNCP data start configured"):
+        known_data_start_month("atas")

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -34,3 +34,7 @@ def test_month_predates_known_data():
 def test_unknown_resource_raises_descriptive_error():
     with pytest.raises(ValueError, match="No known PNCP data start configured"):
         known_data_start_month("atas")
+
+
+def test_clamp_to_known_data_start_month_unknown_resource_passes_through():
+    assert clamp_to_known_data_start_month("atas", date(2020, 1, 15)) == date(2020, 1, 1)


### PR DESCRIPTION
## Summary

Adds a central PNCP data-start constant for `contratos` and clamps monthly planning so Baliza does not probe months that predate known PNCP source data.

## Why

The PNCP `contratos` endpoint has no data before 2021-09-06. Treating that as domain knowledge avoids wasted sync/mirror/build runs and prevents forced dry-runs for old months from hitting PNCP and failing on empty/no-content responses.

## Changes

- Adds `PNCP_RESOURCE_DATA_STARTS` and helper functions in `src/baliza/constants.py`.
- Updates `sync`, `mirror`, `build`, and `verify` planning to clamp requested starts to the first known source-data month.
- Makes `--force-month` before 2021-09 skip cleanly.
- Updates sync tests to match the current manifest rule: a month is complete only when `parquet_url` is present.
- Documents the new `2021-09-01` default in the README.

## Validation

- `uv run ruff check src/baliza/constants.py src/baliza/cli_simple.py src/baliza/mirror.py src/baliza/builder.py tests/step_defs/test_sync.py`
- `uv run pytest tests/step_defs/test_sync.py -q -s`
- Manual dry-run check: `baliza sync --force-month 1900-01 --dry-run --no-consolidate --no-curl --workers 1 --duckdb /tmp/baliza-sync-local/prestart.duckdb`
