### PR TITLE
feat(busca): UF + modality filters and accent-tolerant suggestions

### DIFF
--- a/web/features/journeys/01_supplier_prospecting.feature
+++ b/web/features/journeys/01_supplier_prospecting.feature
@@ -12,18 +12,20 @@ Feature: Journey 1 — B2G supplier prospecting
     Then the user lands on a market page summarizing top buyers, top suppliers and price ranges
     And the page shows the number of distinct contracts found
 
-  @planned @search
+  @green @search
   Scenario: Filter contracts by UF and modality recomputes aggregates
-    # Planned: awaits a dedicated /busca page with UF + modality dropdowns
-    # and an aggregate strip (count / total / average).
+    # Covered: BuscaView renders UF + modality dropdowns above the result
+    # list with a count / total / average aggregate strip that recomputes
+    # client-side as the dropdowns change.
     Given a search result list is visible
     When the user picks UF "SP" and modality "Pregão Eletrônico"
     Then the visible aggregates (count, total value, average value) reflect the filtered subset
 
-  @planned @search
+  @green @search
   Scenario: Empty search suggests accent-tolerant alternatives
-    # Planned: an accent-tolerant suggestion surface on the future /busca
-    # page (closed lexicon, ~80 procurement nouns — static-compatible).
+    # Covered: empty-result state on BuscaView consults a closed lexicon
+    # (web/src/lib/accentLexicon.ts, ~80 procurement nouns) to offer the
+    # accented spelling as a clickable suggestion.
     Given the user submits the free-text query "construcao de escola"
     When PNCP returns zero results
     Then the user sees a suggestion to retry with "construção de escola"

--- a/web/scripts/check-bundle-size.mjs
+++ b/web/scripts/check-bundle-size.mjs
@@ -17,15 +17,18 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DIST_DIR = join(__dirname, '..', 'dist', '_astro');
 
-// Current baseline: 310_000 bytes — measured size (~296 KB) plus headroom,
+// Current baseline: 320_000 bytes — measured size (~308 KB) plus headroom,
 // with room absorbed by the SupplierDetailView shipped for Journey 1 @green
-// (/fornecedor?cnpj= supplier prospecting page) and the citizen-first
+// (/fornecedor?cnpj= supplier prospecting page), the citizen-first
 // homepage islands (CityHero + CityPulse + CityNavLink + shared
 // cityContext.svelte rune) that shift the landing fold from project
-// manifesto to "what is my city buying?". When an intentional feature
-// increases the baseline, raise this constant in the same commit and note
-// what landed.
-const BUDGET_BYTES = 310_000;
+// manifesto to "what is my city buying?", and the BuscaView UF + modality
+// filters with aggregate strip (Journey 1 "Filter contracts by UF and
+// modality recomputes aggregates") plus the lazy-loaded accent lexicon
+// behind the zero-result suggestion path ("Empty search suggests accent-
+// tolerant alternatives"). When an intentional feature increases the
+// baseline, raise this constant in the same commit and note what landed.
+const BUDGET_BYTES = 320_000;
 
 function isClientEntryFile(name) {
   if (!name.endsWith('.js')) return false;

--- a/web/src/components/BuscaView.svelte
+++ b/web/src/components/BuscaView.svelte
@@ -24,16 +24,11 @@
   let searchInput = $state(initialQ());
   let submittedQ = $state(initialQ());
 
-  // True while we're about to redirect — used in the template to suppress
-  // the "Nenhuma contratação encontrada" flash that would otherwise render
-  // for one frame before the $effect navigation fires.
+  let selectedUf = $state('');
+  let selectedModality = $state('');
+
   const redirecting = $derived(!!submittedQ && isPncpId(submittedQ));
 
-  // Landing on /busca?q=<canonical PNCP id> jumps straight to the detail
-  // page — same shortcut as handleSubmit, applied for users arriving via
-  // the plain-HTML homepage form that has no JS to pre-detect ids.
-  // navigateReplace replaces the /busca entry so Back skips it entirely and
-  // returns the user to wherever they came from.
   $effect(() => {
     if (submittedQ && isPncpId(submittedQ)) {
       nav.navigateReplace(resolve(`contratacao?id=${submittedQ}`));
@@ -41,8 +36,6 @@
   });
 
   const query = createQuery(() => {
-    // Capture the term up front so a later submit can't mutate the closure
-    // mid-flight and bind the result of one fetch to a different cache key.
     const term = submittedQ;
     return {
       queryKey: QUERY_KEYS.busca(term),
@@ -55,20 +48,84 @@
   const loading = $derived(query.isFetching);
   const error = $derived(query.error as Error | null);
 
+  function uniqSorted(values: Array<string | null | undefined>): string[] {
+    const set = new Set<string>();
+    for (const v of values) {
+      const s = (v ?? '').trim();
+      if (s) set.add(s);
+    }
+    return [...set].sort((a, b) => a.localeCompare(b, 'pt-BR'));
+  }
+
+  const ufOptions = $derived(uniqSorted(results.map((c) => c.unidadeOrgao?.ufSigla)));
+  const modalityOptions = $derived(uniqSorted(results.map((c) => c.modalidadeNome)));
+
+  const filteredResults = $derived(
+    results.filter((c) => {
+      if (selectedUf && c.unidadeOrgao?.ufSigla !== selectedUf) return false;
+      if (selectedModality && c.modalidadeNome !== selectedModality) return false;
+      return true;
+    }),
+  );
+
+  const aggregates = $derived.by(() => {
+    const count = filteredResults.length;
+    const total = filteredResults.reduce(
+      (sum, c) => sum + (typeof c.valorTotalEstimado === 'number' ? c.valorTotalEstimado : 0),
+      0,
+    );
+    const average = count > 0 ? total / count : 0;
+    return { count, total, average };
+  });
+
+  // Accent suggestion is gated behind a zero-result, no-error fetch — i.e.
+  // the rare path. Lazy-loading the ~80-entry lexicon keeps it out of the
+  // main BuscaView chunk so the common search path doesn't pay for it.
+  let suggestion = $state<string | null>(null);
+  $effect(() => {
+    const term = submittedQ;
+    if (
+      !term ||
+      term.length < 3 ||
+      isPncpId(term) ||
+      loading ||
+      error ||
+      results.length > 0
+    ) {
+      suggestion = null;
+      return;
+    }
+    let cancelled = false;
+    import('../lib/accentLexicon').then(({ suggestAccented }) => {
+      if (!cancelled) suggestion = suggestAccented(term);
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  function applySuggestion(): void {
+    if (!suggestion) return;
+    searchInput = suggestion;
+    submittedQ = suggestion;
+    selectedUf = '';
+    selectedModality = '';
+    if (typeof window === 'undefined') return;
+    const qs = `?q=${encodeURIComponent(suggestion)}`;
+    window.history.replaceState({}, '', `${window.location.pathname}${qs}`);
+  }
+
   function handleSubmit(ev: Event) {
     ev.preventDefault();
     const term = searchInput.trim();
-    // PNCP-ID shortcut: skip the search entirely and jump to the permalink.
-    // encodeURIComponent preserves the slash as-is since the detail view
-    // matches the raw id, not a URL-encoded variant.
     if (isPncpId(term)) {
       nav.navigate(resolve(`contratacao?id=${term}`));
       return;
     }
     submittedQ = term;
+    selectedUf = '';
+    selectedModality = '';
     if (typeof window === 'undefined') return;
-    // The scenario locks %20-encoded spaces; URLSearchParams.toString() emits
-    // `+` for spaces, so build the query string via encodeURIComponent.
     const qs = term ? `?q=${encodeURIComponent(term)}` : '';
     window.history.replaceState(
       {},
@@ -127,24 +184,86 @@
       title="Nenhuma contratação encontrada"
       message="Nenhuma publicação recente do PNCP corresponde ao termo pesquisado."
     />
+    {#if suggestion}
+      <p class="suggestion-row">
+        Você quis dizer:
+        <button
+          type="button"
+          class="suggestion-link"
+          data-testid="busca-suggestion"
+          onclick={applySuggestion}
+        >{suggestion}</button>?
+      </p>
+    {/if}
   {:else}
-    <ul role="listbox" class="busca-results" data-testid="busca-results">
-      {#each results as c (c.numeroControlePNCP)}
-        <li role="option" aria-selected="false" data-testid="busca-result-item">
-          <a href={linkFor(c)} class="result-card">
-            <div class="result-head">
-              <span class="agency">{c.orgaoEntidade?.razaoSocial ?? 'Órgão'}</span>
-              <span class="modality">{c.modalidadeNome ?? ''}</span>
-            </div>
-            <p class="objeto">{truncate(c.objetoContratacao, 180)}</p>
-            <div class="result-foot">
-              <span class="date">{formatDate(c.dataPublicacaoPncp ?? '')}</span>
-              <span class="valor">{formatBRL(c.valorTotalEstimado ?? null)}</span>
-            </div>
-          </a>
-        </li>
-      {/each}
-    </ul>
+    <div class="filters" data-testid="busca-filters">
+      <label class="filter">
+        <span>UF</span>
+        <select
+          bind:value={selectedUf}
+          aria-label="Filtrar por UF"
+          data-testid="busca-filter-uf"
+        >
+          <option value="">Todas</option>
+          {#each ufOptions as uf (uf)}
+            <option value={uf}>{uf}</option>
+          {/each}
+        </select>
+      </label>
+      <label class="filter">
+        <span>Modalidade</span>
+        <select
+          bind:value={selectedModality}
+          aria-label="Filtrar por modalidade"
+          data-testid="busca-filter-modality"
+        >
+          <option value="">Todas</option>
+          {#each modalityOptions as mod (mod)}
+            <option value={mod}>{mod}</option>
+          {/each}
+        </select>
+      </label>
+    </div>
+
+    <dl class="aggregates" data-testid="busca-aggregates" aria-label="Resumo dos resultados visíveis">
+      <div class="agg-cell">
+        <dt>Contratos</dt>
+        <dd data-testid="busca-aggregate-count">{aggregates.count}</dd>
+      </div>
+      <div class="agg-cell">
+        <dt>Valor total</dt>
+        <dd data-testid="busca-aggregate-total">{formatBRL(aggregates.total)}</dd>
+      </div>
+      <div class="agg-cell">
+        <dt>Valor médio</dt>
+        <dd data-testid="busca-aggregate-average">{formatBRL(aggregates.average)}</dd>
+      </div>
+    </dl>
+
+    {#if filteredResults.length === 0}
+      <EmptyState
+        title="Nenhum resultado para os filtros selecionados"
+        message="Ajuste a UF ou a modalidade para ver mais contratações."
+      />
+    {:else}
+      <ul role="listbox" class="busca-results" data-testid="busca-results">
+        {#each filteredResults as c (c.numeroControlePNCP)}
+          <li role="option" aria-selected="false" data-testid="busca-result-item">
+            <a href={linkFor(c)} class="result-card">
+              <div class="result-head">
+                <span class="agency">{c.orgaoEntidade?.razaoSocial ?? 'Órgão'}</span>
+                <span class="modality">{c.modalidadeNome ?? ''}</span>
+              </div>
+              <p class="objeto">{truncate(c.objetoContratacao, 180)}</p>
+              <div class="result-foot">
+                <span class="date">{formatDate(c.dataPublicacaoPncp ?? '')}</span>
+                <span class="valor">{formatBRL(c.valorTotalEstimado ?? null)}</span>
+              </div>
+            </a>
+          </li>
+        {/each}
+      </ul>
+    {/if}
   {/if}
 </div>
 
@@ -168,6 +287,51 @@
     position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
     overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
   }
+
+  .filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-md);
+    margin-bottom: var(--space-md);
+  }
+  .filter { display: grid; gap: 4px; font-size: var(--font-size-xs); color: var(--color-secondary); }
+  .filter select {
+    padding: 6px 8px;
+    border: 1px solid var(--color-base-300);
+    border-radius: var(--radius-sm);
+    background: var(--color-base-100);
+    font-size: var(--font-size-sm);
+  }
+
+  .aggregates {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: var(--space-md);
+    margin: 0 0 var(--space-lg);
+    padding: var(--space-md);
+    background: var(--color-base-100);
+    border: 1px solid var(--color-base-300);
+    border-radius: var(--radius-sm);
+  }
+  .agg-cell dt {
+    font-size: var(--font-size-xs);
+    color: var(--color-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .agg-cell dd { margin: 4px 0 0; font-weight: 700; font-size: var(--font-size-md); }
+
+  .suggestion-row { margin-top: var(--space-md); font-size: var(--font-size-sm); }
+  .suggestion-link {
+    background: none;
+    border: 0;
+    padding: 0;
+    color: var(--color-primary);
+    font: inherit;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+  .suggestion-link:hover, .suggestion-link:focus-visible { text-decoration: none; }
 
   .skeleton-wrap { display: grid; gap: var(--space-md); }
   .skeleton-bid { height: 5rem; border-radius: var(--radius-sm); }

--- a/web/src/components/BuscaView.svelte
+++ b/web/src/components/BuscaView.svelte
@@ -74,11 +74,18 @@
 
   const aggregates = $derived.by(() => {
     const count = filteredResults.length;
-    const total = filteredResults.reduce(
-      (sum, c) => sum + (typeof c.valorTotalEstimado === 'number' ? c.valorTotalEstimado : 0),
-      0,
-    );
-    const average = count > 0 ? total / count : 0;
+    // Compute the average over rows that actually carry a numeric estimate
+    // — rows without a value would otherwise drag the mean toward 0 and
+    // misrepresent what the visible buyers are paying.
+    let total = 0;
+    let withValue = 0;
+    for (const c of filteredResults) {
+      if (typeof c.valorTotalEstimado === 'number') {
+        total += c.valorTotalEstimado;
+        withValue += 1;
+      }
+    }
+    const average = withValue > 0 ? total / withValue : 0;
     return { count, total, average };
   });
 

--- a/web/src/components/BuscaView.svelte
+++ b/web/src/components/BuscaView.svelte
@@ -49,12 +49,16 @@
   const error = $derived(query.error as Error | null);
 
   function uniqSorted(values: Array<string | null | undefined>): string[] {
-    const set = new Set<string>();
+    const seen: Record<string, true> = {};
+    const out: string[] = [];
     for (const v of values) {
       const s = (v ?? '').trim();
-      if (s) set.add(s);
+      if (s && !seen[s]) {
+        seen[s] = true;
+        out.push(s);
+      }
     }
-    return [...set].sort((a, b) => a.localeCompare(b, 'pt-BR'));
+    return out.sort((a, b) => a.localeCompare(b, 'pt-BR'));
   }
 
   const ufOptions = $derived(uniqSorted(results.map((c) => c.unidadeOrgao?.ufSigla)));

--- a/web/src/components/__steps__/journeys/01_supplier_prospecting.steps.ts
+++ b/web/src/components/__steps__/journeys/01_supplier_prospecting.steps.ts
@@ -1,12 +1,16 @@
 import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber';
-import { screen, waitFor } from '@testing-library/svelte/pure';
+import { screen, cleanup, waitFor, fireEvent } from '@testing-library/svelte/pure';
 import { vi, expect } from 'vitest';
 import { tick } from 'svelte';
 import { render, noop, plannedStep } from './_shared';
 import SupplierDetailViewRaw from '../../SupplierDetailView.svelte';
+import BuscaViewRaw from '../../BuscaView.svelte';
 import * as parquetFallback from '../../../lib/parquetFallback';
+import * as pncpPublicacao from '../../../lib/pncpPublicacao';
+import type { PNCPContract } from '../../../lib/pncp';
 
 const SupplierDetailView = SupplierDetailViewRaw as unknown as Parameters<typeof render>[0];
+const BuscaView = BuscaViewRaw as unknown as Parameters<typeof render>[0];
 
 const SUPPLIER_ROWS = [
   {
@@ -48,19 +52,104 @@ describeFeature(feature, ({ Scenario }) => {
   });
 
   Scenario('Filter contracts by UF and modality recomputes aggregates', ({ Given, When, Then }) => {
-    Given('a search result list is visible', noop);
-    When('the user picks UF "SP" and modality "Pregão Eletrônico"', noop);
-    Then('the visible aggregates (count, total value, average value) reflect the filtered subset', () =>
-      plannedStep('dedicated search page with UF + modality filters'),
-    );
+    Given('a search result list is visible', async () => {
+      cleanup();
+      vi.restoreAllMocks();
+      window.history.replaceState({}, '', '/busca?q=merenda%20escolar');
+      // Four results spanning two UFs (SP, RJ) and two modalities. The
+      // SP+Pregão Eletrônico subset is two rows whose aggregate matches
+      // the assertions below — count 2, total 3500, average 1750.
+      vi.spyOn(pncpPublicacao, 'fetchPublicacaoPagesForObjeto').mockResolvedValue([
+        {
+          numeroControlePNCP: '00000000000191-1-000001/2024',
+          dataPublicacaoPncp: '2025-01-10T00:00:00',
+          objetoContratacao: 'Merenda escolar — banana e leite',
+          valorTotalEstimado: 1500,
+          modalidadeNome: 'Pregão Eletrônico',
+          orgaoEntidade: { razaoSocial: 'Prefeitura SP-A', cnpj: '00000000000191' },
+          unidadeOrgao: { nomeUnidade: 'Educação', ufSigla: 'SP' },
+        },
+        {
+          numeroControlePNCP: '00000000000191-1-000002/2024',
+          dataPublicacaoPncp: '2025-01-12T00:00:00',
+          objetoContratacao: 'Merenda escolar — pão',
+          valorTotalEstimado: 2000,
+          modalidadeNome: 'Pregão Eletrônico',
+          orgaoEntidade: { razaoSocial: 'Prefeitura SP-B', cnpj: '00000000000192' },
+          unidadeOrgao: { nomeUnidade: 'Educação', ufSigla: 'SP' },
+        },
+        {
+          numeroControlePNCP: '00000000000191-1-000003/2024',
+          dataPublicacaoPncp: '2025-01-13T00:00:00',
+          objetoContratacao: 'Merenda escolar — frutas',
+          valorTotalEstimado: 3000,
+          modalidadeNome: 'Pregão Eletrônico',
+          orgaoEntidade: { razaoSocial: 'Prefeitura RJ', cnpj: '00000000000193' },
+          unidadeOrgao: { nomeUnidade: 'Educação', ufSigla: 'RJ' },
+        },
+        {
+          numeroControlePNCP: '00000000000191-1-000004/2024',
+          dataPublicacaoPncp: '2025-01-14T00:00:00',
+          objetoContratacao: 'Merenda escolar — laticínios',
+          valorTotalEstimado: 5000,
+          modalidadeNome: 'Tomada de Preços',
+          orgaoEntidade: { razaoSocial: 'Prefeitura SP-C', cnpj: '00000000000194' },
+          unidadeOrgao: { nomeUnidade: 'Educação', ufSigla: 'SP' },
+        },
+      ] as unknown as PNCPContract[]);
+      render(BuscaView);
+      await tick();
+      // Wait until the unfiltered aggregate strip has rendered with all 4 rows.
+      await waitFor(
+        () => {
+          const count = screen.getByTestId('busca-aggregate-count');
+          expect(count.textContent).toBe('4');
+        },
+        { timeout: 3000 },
+      );
+    });
+
+    When('the user picks UF "SP" and modality "Pregão Eletrônico"', async () => {
+      const uf = screen.getByTestId('busca-filter-uf') as HTMLSelectElement;
+      uf.value = 'SP';
+      await fireEvent.change(uf);
+      const modality = screen.getByTestId('busca-filter-modality') as HTMLSelectElement;
+      modality.value = 'Pregão Eletrônico';
+      await fireEvent.change(modality);
+    });
+
+    Then('the visible aggregates (count, total value, average value) reflect the filtered subset', async () => {
+      await waitFor(
+        () => {
+          // SP + Pregão Eletrônico narrows to the 1500 + 2000 rows.
+          expect(screen.getByTestId('busca-aggregate-count').textContent).toBe('2');
+          expect(screen.getByTestId('busca-aggregate-total').textContent).toMatch(/3\.500,00/);
+          expect(screen.getByTestId('busca-aggregate-average').textContent).toMatch(/1\.750,00/);
+        },
+        { timeout: 2000 },
+      );
+    });
   });
 
   Scenario('Empty search suggests accent-tolerant alternatives', ({ Given, When, Then }) => {
-    Given('the user submits the free-text query "construcao de escola"', noop);
+    Given('the user submits the free-text query "construcao de escola"', async () => {
+      cleanup();
+      vi.restoreAllMocks();
+      window.history.replaceState({}, '', '/busca?q=construcao%20de%20escola');
+      vi.spyOn(pncpPublicacao, 'fetchPublicacaoPagesForObjeto').mockResolvedValue([]);
+      render(BuscaView);
+      await tick();
+    });
     When('PNCP returns zero results', noop);
-    Then('the user sees a suggestion to retry with "construção de escola"', () =>
-      plannedStep('dedicated search page with accent-tolerant suggestions'),
-    );
+    Then('the user sees a suggestion to retry with "construção de escola"', async () => {
+      await waitFor(
+        () => {
+          const link = screen.getByTestId('busca-suggestion');
+          expect(link.textContent).toBe('construção de escola');
+        },
+        { timeout: 3000 },
+      );
+    });
   });
 
   Scenario('Supplier page by CNPJ shows history, peers and average ticket', ({ Given, Then, And }) => {

--- a/web/src/lib/accentLexicon.test.ts
+++ b/web/src/lib/accentLexicon.test.ts
@@ -35,4 +35,10 @@ describe('suggestAccented', () => {
   it('preserves whitespace between tokens', () => {
     expect(suggestAccented('construcao  de  escola')).toBe('construção  de  escola');
   });
+
+  it('handles punctuation separators (comma, period, dash)', () => {
+    expect(suggestAccented('construcao, de escola')).toBe('construção, de escola');
+    expect(suggestAccented('aquisicao - veiculos')).toBe('aquisição - veículos');
+    expect(suggestAccented('construcao de escola.')).toBe('construção de escola.');
+  });
 });

--- a/web/src/lib/accentLexicon.test.ts
+++ b/web/src/lib/accentLexicon.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { stripAccents, suggestAccented } from './accentLexicon';
+
+describe('stripAccents', () => {
+  it('removes diacritics from common Portuguese words', () => {
+    expect(stripAccents('construção')).toBe('construcao');
+    expect(stripAccents('São Paulo')).toBe('Sao Paulo');
+    expect(stripAccents('aquisição de veículos')).toBe('aquisicao de veiculos');
+  });
+
+  it('is a no-op on already-unaccented strings', () => {
+    expect(stripAccents('hospital municipal')).toBe('hospital municipal');
+  });
+});
+
+describe('suggestAccented', () => {
+  it('suggests the canonical accented form for an unaccented word', () => {
+    expect(suggestAccented('construcao de escola')).toBe('construção de escola');
+    expect(suggestAccented('aquisicao de veiculos')).toBe('aquisição de veículos');
+  });
+
+  it('returns null when the term already matches canonical accents', () => {
+    expect(suggestAccented('construção de escola')).toBeNull();
+  });
+
+  it('returns null when no word is in the lexicon', () => {
+    expect(suggestAccented('hospital municipal')).toBeNull();
+  });
+
+  it('returns null on empty input', () => {
+    expect(suggestAccented('')).toBeNull();
+    expect(suggestAccented('   ')).toBeNull();
+  });
+
+  it('preserves whitespace between tokens', () => {
+    expect(suggestAccented('construcao  de  escola')).toBe('construção  de  escola');
+  });
+});

--- a/web/src/lib/accentLexicon.ts
+++ b/web/src/lib/accentLexicon.ts
@@ -114,12 +114,15 @@ export function suggestAccented(term: string): string | null {
   const trimmed = term.trim();
   if (!trimmed) return null;
 
-  // Split on whitespace and punctuation, but preserve the original
-  // separators so the suggestion reads naturally back to the user.
-  const tokens = trimmed.split(/(\s+)/);
+  // Split on whitespace and the common procurement-query punctuation
+  // (commas, periods, semicolons, dashes, parentheses, ?!) but preserve
+  // the original separators so the suggestion reads naturally back to
+  // the user. The capture group keeps the separators in the output array.
+  const SEPARATOR = /([\s,.;:!?\-()/]+)/;
+  const tokens = trimmed.split(SEPARATOR);
   let changed = false;
   const rewritten = tokens.map((tok) => {
-    if (!tok || /^\s+$/.test(tok)) return tok;
+    if (!tok || SEPARATOR.test(tok)) return tok;
     const lower = tok.toLowerCase();
     const stripped = stripAccents(lower);
     const canonical = ENTRIES[stripped];

--- a/web/src/lib/accentLexicon.ts
+++ b/web/src/lib/accentLexicon.ts
@@ -1,0 +1,134 @@
+// Closed lexicon of common procurement nouns whose accented form is the
+// canonical Portuguese spelling. The map is keyed by the unaccented form so
+// a query like "construcao" can be normalized in O(1) into "construção".
+//
+// Why static and not derived from the corpus: the corpus is large and
+// contains many noisy spellings; a hand-picked closed list matches what a
+// supplier would reasonably mistype and fits Baliza's no-API/static
+// philosophy. Length cap is intentional — each new entry has to clear a
+// "would suppliers actually type the unaccented form" bar.
+
+const ENTRIES: Record<string, string> = {
+  // Acts of contracting
+  aquisicao: 'aquisição',
+  contratacao: 'contratação',
+  prestacao: 'prestação',
+  manutencao: 'manutenção',
+  construcao: 'construção',
+  reformacao: 'reforma',
+  ampliacao: 'ampliação',
+  modernizacao: 'modernização',
+  restauracao: 'restauração',
+  reabilitacao: 'reabilitação',
+  demolicao: 'demolição',
+  pavimentacao: 'pavimentação',
+  iluminacao: 'iluminação',
+  sinalizacao: 'sinalização',
+  urbanizacao: 'urbanização',
+  instalacao: 'instalação',
+  implantacao: 'implantação',
+  operacao: 'operação',
+  conservacao: 'conservação',
+  preparacao: 'preparação',
+  divulgacao: 'divulgação',
+  publicacao: 'publicação',
+  comunicacao: 'comunicação',
+  impressao: 'impressão',
+  traducao: 'tradução',
+  revisao: 'revisão',
+  inspecao: 'inspeção',
+  fiscalizacao: 'fiscalização',
+  supervisao: 'supervisão',
+  producao: 'produção',
+  distribuicao: 'distribuição',
+  separacao: 'separação',
+  avaliacao: 'avaliação',
+  capacitacao: 'capacitação',
+  formacao: 'formação',
+  vacinacao: 'vacinação',
+  medicacao: 'medicação',
+  alimentacao: 'alimentação',
+  educacao: 'educação',
+  gestao: 'gestão',
+  administracao: 'administração',
+  fundacao: 'fundação',
+  estacao: 'estação',
+  racao: 'ração',
+  lubrificacao: 'lubrificação',
+  // Goods (frequent unaccented mistypes)
+  veiculo: 'veículo',
+  veiculos: 'veículos',
+  onibus: 'ônibus',
+  mobiliario: 'mobiliário',
+  oleo: 'óleo',
+  combustivel: 'combustível',
+  gas: 'gás',
+  agua: 'água',
+  alcool: 'álcool',
+  mascara: 'máscara',
+  oculos: 'óculos',
+  camera: 'câmera',
+  video: 'vídeo',
+  copia: 'cópia',
+  // Health & care
+  saude: 'saúde',
+  medico: 'médico',
+  medica: 'médica',
+  cirurgico: 'cirúrgico',
+  cirurgica: 'cirúrgica',
+  farmaceutico: 'farmacêutico',
+  ambulancia: 'ambulância',
+  veterinario: 'veterinário',
+  higienico: 'higiênico',
+  higienica: 'higiênica',
+  sanitario: 'sanitário',
+  // Tech & equipment
+  eletronico: 'eletrônico',
+  eletronica: 'eletrônica',
+  telefonico: 'telefônico',
+  telefonica: 'telefônica',
+  didatico: 'didático',
+  didatica: 'didática',
+  pedagogico: 'pedagógico',
+  pedagogica: 'pedagógica',
+  // Logistics & utilities
+  energia: 'energia',
+  semaforo: 'semáforo',
+  transito: 'trânsito',
+  // Legal & administrative
+  publico: 'público',
+  publica: 'pública',
+};
+
+// Strip diacritics from a string. NFD splits accented characters into the
+// base letter + combining mark, the regex then drops every combining mark
+// in the U+0300–U+036F range.
+export function stripAccents(s: string): string {
+  return s.normalize('NFD').replace(/[̀-ͯ]/g, '');
+}
+
+// Suggest the canonical accented spelling for a free-text query. Returns
+// null when no word in the term has a canonical form different from what
+// the user typed (i.e. the suggestion would equal the input).
+export function suggestAccented(term: string): string | null {
+  const trimmed = term.trim();
+  if (!trimmed) return null;
+
+  // Split on whitespace and punctuation, but preserve the original
+  // separators so the suggestion reads naturally back to the user.
+  const tokens = trimmed.split(/(\s+)/);
+  let changed = false;
+  const rewritten = tokens.map((tok) => {
+    if (!tok || /^\s+$/.test(tok)) return tok;
+    const lower = tok.toLowerCase();
+    const stripped = stripAccents(lower);
+    const canonical = ENTRIES[stripped];
+    if (canonical && canonical !== lower) {
+      changed = true;
+      return canonical;
+    }
+    return tok;
+  });
+
+  return changed ? rewritten.join('') : null;
+}


### PR DESCRIPTION
## Summary
- Extends `BuscaView` with **UF + modality dropdowns** and a **count / total / average aggregate strip** that recomputes client-side as filters change. No extra API cost — filtering runs over the already-fetched `fetchPublicacaoPagesForObjeto` fan-out.
- Adds a **zero-result suggestion** backed by a closed lexicon (`web/src/lib/accentLexicon.ts`, ~80 procurement nouns keyed by unaccented form). A query like `construcao de escola` gets a clickable `construção de escola` pointer that re-submits and resets filters.
- Lexicon is loaded via **dynamic `import()`** so the common search path doesn't pay for it; only the rare zero-result branch pulls the chunk.
- Flips two `@planned @search` scenarios in `01_supplier_prospecting.feature` to `@green`.
- Bundle budget raised 310 KB → 320 KB (measured 307.7 KB) to absorb the new filters UI; documented in `scripts/check-bundle-size.mjs`.

## Test plan
- [x] `vitest run` — 525 pass / 43 skipped (was 519 / 49 — 6 new step assertions activated)
- [x] `npm run build` — bundle 307.7 KB, well under new 320 KB budget
- [x] `accentLexicon.test.ts` — 7 unit tests for `stripAccents` + `suggestAccented`
- [x] No runtime API additions; all filtering and suggestion logic is client-side

https://claude.ai/code/session_01Uhwg477URmu3n8fMEGUoc8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uhwg477URmu3n8fMEGUoc8)_