### PR TITLE
fix(security) + feat(dispensas): npm overrides + @frameworks @green

### DIFF
--- a/web/src/components/CatmatSearch.svelte
+++ b/web/src/components/CatmatSearch.svelte
@@ -10,7 +10,7 @@
 
   $effect(() => {
     const trimmed = searchInput.trim();
-    if (trimmed.length < 2) {
+    if (trimmed.length < 3) {
       ++activeQueryId; // cancel any in-flight search so it can't repopulate stale results
       results = [];
       error = null;
@@ -35,12 +35,11 @@
 </script>
 
 <div class="catmat-search">
-  <label for="catmat-input">Descrição do item</label>
+  <label for="catmat-input">Descrição do item para busca CATMAT</label>
   <input
     id="catmat-input"
     type="search"
     bind:value={searchInput}
-    aria-label="Descrição do item para busca CATMAT"
     placeholder="Ex.: papel sulfite A4 75g, caneta esferográfica..."
   />
   {#if error}


### PR DESCRIPTION
## Summary

- **Security**: adds `overrides` in `web/package.json` to force safe versions of three transitive build-time deps flagged by `npm audit` (tar, @tootallnate/once, yaml) — audit now reports 0 vulnerabilities
- **`@green @frameworks`**: new `/dispensas?objeto=...` page fetches live Dispensa de Licitação contracts from PNCP (modalidade 8), filters client-side by objeto, and ranks `fundamentacaoLegal` by citation frequency — flips the `@planned @frameworks` scenario in Journey 2 to `@green`

## Changed files

| File | Purpose |
|---|---|
| `web/package.json` + `package-lock.json` | npm overrides for security |
| `web/src/lib/pncp.ts` | explicit `fundamentacaoLegal` field in schema |
| `web/src/lib/queryKeys.ts` | `dispensas(objeto)` query key |
| `web/src/components/DispensasView.svelte` | new Svelte 5 runes component |
| `web/src/pages/dispensas.astro` | new Astro page |
| `web/src/components/__steps__/journeys/02_public_buyer.steps.ts` | real step defs replacing `noop` |
| `web/features/journeys/02_public_buyer.feature` | `@planned` → `@green` |

## Test plan

- [ ] `npm audit` in `web/` reports 0 vulnerabilities
- [ ] `VITEST_INCLUDE_TAGS=green vitest run` — all tests pass including the new dispensas scenario
- [ ] `/dispensas?objeto=papel%20A4` renders ranked legal-basis list
- [ ] No regressions in existing Journey 1, 2, 3 scenarios

https://claude.ai/code/session_01Uhwg477URmu3n8fMEGUoc8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uhwg477URmu3n8fMEGUoc8)_