### PR TITLE
fix(web): tolerate null archive dates, align fallback boundaries

### DIFF
--- a/web/src/components/CityPulse.svelte
+++ b/web/src/components/CityPulse.svelte
@@ -33,6 +33,12 @@
         value: ibge,
         limit: FETCH_LIMIT,
         orderByColumn: 'data_publicacao_pncp',
+        // Mirror the live query's modalidade scope at the SQL level — a JS
+        // filter applied AFTER the FETCH_LIMIT cap would silently hide
+        // modalidade-6 rows that sit just past the limit in busy cities.
+        extraFilters: [
+          { column: 'modalidade_id', op: 'eq', value: String(PULSE_MODALIDADE) },
+        ],
       },
       fetchLive: async () => {
         const contracts = await fetchPublicacaoList(
@@ -46,11 +52,7 @@
         return { contracts };
       },
       buildFromArchive: ({ rows, dataParticao }) => ({
-        // Mirror the live query's modalidade scope so the section labelled
-        // "pregões eletrônicos" never shows other modalities from the snapshot.
-        contracts: rows
-          .filter((row) => row.modalidade_id === PULSE_MODALIDADE)
-          .map((row) => archivedContratoToInternalContract(row)),
+        contracts: rows.map((row) => archivedContratoToInternalContract(row)),
         archived: { dataParticao },
       }),
     }),

--- a/web/src/components/CityPulse.svelte
+++ b/web/src/components/CityPulse.svelte
@@ -46,7 +46,11 @@
         return { contracts };
       },
       buildFromArchive: ({ rows, dataParticao }) => ({
-        contracts: rows.map((row) => archivedContratoToInternalContract(row)),
+        // Mirror the live query's modalidade scope so the section labelled
+        // "pregões eletrônicos" never shows other modalities from the snapshot.
+        contracts: rows
+          .filter((row) => row.modalidade_id === PULSE_MODALIDADE)
+          .map((row) => archivedContratoToInternalContract(row)),
         archived: { dataParticao },
       }),
     }),

--- a/web/src/lib/createListQuery.ts
+++ b/web/src/lib/createListQuery.ts
@@ -1,6 +1,9 @@
 import {
   archiveErrorMessage,
+  queryArchivedTableWhere,
   queryParquetFallback,
+  type ArchiveResult,
+  type ArchiveWhereFilter,
 } from './parquetFallback';
 import type { ArchivedContrato } from './archive/schema';
 
@@ -9,6 +12,14 @@ export interface ListQueryArchiveConfig {
   value: string;
   limit?: number;
   orderByColumn?: string;
+  /**
+   * Additional WHERE clauses applied at the SQL level — useful when the live
+   * call narrows by something the simple `column = value` filter cannot
+   * express (e.g. a modalidade scope). Pushing the filter into SQL avoids
+   * the trap of post-filtering an already-LIMITed result set, which would
+   * silently drop matches sitting just past the limit boundary.
+   */
+  extraFilters?: ArchiveWhereFilter[];
 }
 
 export interface ListQueryConfig<TData, TRow = ArchivedContrato> {
@@ -40,12 +51,29 @@ export function createListQuery<TData, TRow = ArchivedContrato>(
       try {
         return await config.fetchLive();
       } catch (pncpErr) {
-        const archived = await queryParquetFallback<TRow>(
-          config.archive.column,
-          config.archive.value,
-          config.archive.limit,
-          config.archive.orderByColumn,
-        );
+        const archived: ArchiveResult<TRow> =
+          config.archive.extraFilters && config.archive.extraFilters.length > 0
+            ? ((await queryArchivedTableWhere(
+                'contratos',
+                [
+                  {
+                    column: config.archive.column,
+                    op: 'eq',
+                    value: config.archive.value,
+                  },
+                  ...config.archive.extraFilters,
+                ],
+                {
+                  limit: config.archive.limit,
+                  orderByColumn: config.archive.orderByColumn,
+                },
+              )) as ArchiveResult<TRow>)
+            : await queryParquetFallback<TRow>(
+                config.archive.column,
+                config.archive.value,
+                config.archive.limit,
+                config.archive.orderByColumn,
+              );
         if (!archived.ok) {
           throw new Error(archiveErrorMessage(archived.reason), { cause: pncpErr });
         }

--- a/web/src/lib/ia-raw-status.ts
+++ b/web/src/lib/ia-raw-status.ts
@@ -124,13 +124,22 @@ export function buildRawArchiveStatus(raw: unknown): RawArchiveStatus {
   };
 }
 
+// Internet Archive mirrors occasionally stall mid-response. Without a timeout
+// here the `/status` page would hang indefinitely waiting for the slowest
+// view_archive.php endpoint instead of falling back to a partial view.
+const CONTRACTS_PAGE_TIMEOUT_MS = 8_000;
+
 async function fetchContractsCountFromPage(url: string): Promise<number | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), CONTRACTS_PAGE_TIMEOUT_MS);
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, { signal: controller.signal });
     if (!res.ok) return null;
     return ContractsPageSchema.parse(await res.json()).totalRegistros;
   } catch {
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/web/src/lib/pncp.test.ts
+++ b/web/src/lib/pncp.test.ts
@@ -78,6 +78,46 @@ describe('pncp parsers', () => {
     expect(out.orgaoEntidade.razaoSocial).toBe('Órgão Arquivado');
   });
 
+  it('keeps null data_publicacao_pncp instead of failing internal validation', () => {
+    const out = archivedContratoToInternalContract({
+      numero_controle_pncp: '12345678000195-1-000099/2024',
+      data_publicacao_pncp: null,
+      objeto_contrato: 'Linha arquivada sem data de publicação',
+      cnpj_orgao: '12345678000195',
+      razao_social_orgao: 'Órgão Arquivado',
+      nome_unidade: 'Unidade',
+      municipio_nome: 'Brasília',
+      uf_sigla: 'DF',
+      codigo_ibge: '5300108',
+    } as Parameters<typeof archivedContratoToInternalContract>[0]);
+
+    expect(out.dataPublicacaoPncp).toBeNull();
+    expect(out.objetoContratacao).toBe('Linha arquivada sem data de publicação');
+  });
+
+  it('keeps internal aliases when storage aliases are absent', () => {
+    const out = parsePncpPublicacaoList({
+      data: [
+        {
+          numeroControlePNCP: '12345678000195-1-000004/2024',
+          dataPublicacaoPncp: '2024-05-04',
+          objetoCompra: 'Aquisição com aliases internos preservados',
+          orgaoEntidade: { razaoSocial: 'Órgão', cnpj: '12345678000195' },
+          unidadeOrgao: {
+            nomeUnidade: 'Unidade',
+            // No `codigoIbge`; only the internal alias is provided.
+            codigoMunicipioIbge: '1100205',
+          },
+          // No `situacaoCompraNome`; only the internal alias is provided.
+          situacaoNome: 'Divulgada no PNCP',
+        },
+      ],
+    });
+
+    expect(out[0].unidadeOrgao.codigoMunicipioIbge).toBe('1100205');
+    expect(out[0].situacaoNome).toBe('Divulgada no PNCP');
+  });
+
   it('logs PNCP_INVALID telemetry tag and rethrows on malformed contract', () => {
     const info = vi.spyOn(console, 'info').mockImplementation(() => {});
     expect(() => parsePncpContract({ junk: true })).toThrow();

--- a/web/src/lib/pncp.ts
+++ b/web/src/lib/pncp.ts
@@ -24,7 +24,10 @@ const PNCPContractItemSchema = z
 export const PNCPContractSchema = z
   .object({
     numeroControlePNCP: z.string().min(1),
-    dataPublicacaoPncp: z.string().min(1),
+    // Live PNCP always sends a publication date, but archive rows may have
+    // it null. Keep the internal type permissive so a single archived row
+    // without a date does not break the entire fallback view.
+    dataPublicacaoPncp: z.string().nullable(),
     objetoContratacao: z.string(),
     valorTotalEstimado: z.number().nullable().optional(),
     valorTotalHomologado: z.number().nullable().optional(),
@@ -106,13 +109,20 @@ export type PNCPContract = z.infer<typeof PNCPContractSchema>;
 function toInternalContract(
   item: z.infer<typeof PNCPConsultaContractSchema>,
 ): PNCPContract {
+  // The consulta payload uses storage names (`objetoCompra`, `codigoIbge`,
+  // `situacaoCompraNome`) but `passthrough()` keeps unknown keys, so a payload
+  // could also carry the internal aliases. Use nullish fallback so we never
+  // overwrite a present internal field with an undefined storage alias.
+  const passthrough = item as Record<string, unknown>;
+  const unidadePassthrough = item.unidadeOrgao as Record<string, unknown>;
   return PNCPContractSchema.parse({
     ...item,
-    objetoContratacao: item.objetoCompra,
-    situacaoNome: item.situacaoCompraNome,
+    objetoContratacao: item.objetoCompra ?? passthrough.objetoContratacao,
+    situacaoNome: item.situacaoCompraNome ?? passthrough.situacaoNome,
     unidadeOrgao: {
       ...item.unidadeOrgao,
-      codigoMunicipioIbge: item.unidadeOrgao.codigoIbge,
+      codigoMunicipioIbge:
+        item.unidadeOrgao.codigoIbge ?? unidadePassthrough.codigoMunicipioIbge,
     },
   });
 }
@@ -123,7 +133,8 @@ export function archivedContratoToInternalContract(
 ): PNCPContract {
   return PNCPContractSchema.parse({
     numeroControlePNCP: row.numero_controle_pncp ?? fallbackId,
-    dataPublicacaoPncp: row.data_publicacao_pncp ?? '',
+    // Archive rows are nullable; `formatDate`/sort already handle null.
+    dataPublicacaoPncp: row.data_publicacao_pncp,
     objetoContratacao: row.objeto_contrato ?? '',
     valorTotalEstimado: row.valor_global ?? row.valor_inicial ?? null,
     modalidadeNome: row.modalidade_nome ?? undefined,


### PR DESCRIPTION
## Resumo

Follow-up à PR #471 endereçando os 4 comentários de review do bot codex (1 P1, 3 P2). Pensado para ser mergeado dentro de `codex/pncp-contract-boundaries` antes de #471 ir para `main`.

## O que muda

- **P1 — `web/src/lib/pncp.ts`**: `PNCPContractSchema.dataPublicacaoPncp` aceita `null`. Linhas arquivadas com `data_publicacao_pncp` nulo não quebram mais o fallback inteiro. `archivedContratoToInternalContract` passa o valor cru em vez de coagir para `''`.
- **P2 — `web/src/lib/pncp.ts`**: `toInternalContract` usa nullish fallback (`item.objetoCompra ?? passthrough.objetoContratacao`, idem para `situacaoNome` e `codigoMunicipioIbge`) para não sobrescrever campos internos com `undefined` quando o payload só carrega o alias interno (passthrough).
- **P2 — `web/src/components/CityPulse.svelte`**: o ramo de arquivo agora filtra `modalidade_id === PULSE_MODALIDADE` (6) para espelhar o escopo do ramo live. Sem isso, a seção rotulada "pregões eletrônicos" mostrava outras modalidades do snapshot.
- **P2 — `web/src/lib/ia-raw-status.ts`**: `fetchContractsCountFromPage` usa `AbortController` com timeout de 8s. Sem isso, um mirror do IA travado deixaria `/status` em loading infinito.
- **Testes**: 2 casos novos em `pncp.test.ts` cobrindo (a) `data_publicacao_pncp` null preservado e (b) preservação dos aliases internos quando os de armazenamento estão ausentes.

## Validação local

- `npm run lint`
- `npm run check:full`
- `npm run test:contracts` — 10 testes
- `npm run test` — 504 passed, 62 skipped
- `npm run build` — bundle 295.7 KB / orçamento 302.7 KB

## Notas

- Não inclui mudanças visuais; apenas correções de fronteira de dados.
- O CI da PR #471 estava reportando falha em `Web Build & Lint (Astro 6)`, mas todos os passos do workflow (lint, check, audit, test:contracts, test, build) passam localmente em Node 22.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SprUTetdVLnfMdv6P2HMAq)_