### PR TITLE
fix(web): preserve unknown contract values as em-dash in ContractCard

### DIFF
--- a/web/src/components/ContractCard.svelte
+++ b/web/src/components/ContractCard.svelte
@@ -23,7 +23,7 @@
     {#if buyer}
       <span class="buyer">{buyer}</span>
     {/if}
-    <span class="valor">{formatBRL(valor ?? 0)}</span>
+    <span class="valor">{formatBRL(valor)}</span>
   </div>
 </a>
 


### PR DESCRIPTION
## Por que isso

PR #478 (`Refactor: extract reusable EntityDetailLayout and ContractCard`) introduziu em `web/src/components/ContractCard.svelte`:

```svelte
<span class="valor">{formatBRL(valor ?? 0)}</span>
```

`formatBRL` já trata `null`/`undefined` retornando `—`:

```ts
export function formatBRL(v: number | null | undefined): string {
  if (v == null) return EM_DASH;
  return v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
}
```

O `?? 0` derruba o `null` antes de chegar lá, fazendo contratos com `valorTotalEstimado` ausente renderizarem **"R$ 0,00"** — visualmente indistinguível de um contrato que legitimamente declarou valor zero. Antes do refactor cada detail view passava `item.valorTotalEstimado` direto e mostrava em-dash corretamente.

Achado pelo codex bot na PR #478 ([P1 review comment](https://github.com/franklinbaldo/baliza/pull/478#discussion_r3142056049)).

Atinge: `AgencyDetailView`, `SupplierDetailView`, `CityDetailView` — qualquer linha do "recent contracts" sem valor agora aparecia como zero.

## Diff

```svelte
- <span class="valor">{formatBRL(valor ?? 0)}</span>
+ <span class="valor">{formatBRL(valor)}</span>
```

## Validação

- `npm run check:full` — 0 errors / 0 warnings / 13 hints
- `npm run test` — 546 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01SprUTetdVLnfMdv6P2HMAq)_