### PR TITLE
feat(sync): upload raw ZIP to baliza-pncp-raw before ingest

### DIFF
--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -430,6 +430,23 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
                         raw_month_dir.mkdir(parents=True, exist_ok=True)
                         sentinel.touch()
 
+                        # 3b. Upload raw ZIP to baliza-pncp-raw before ingest.
+                        # keep_raw_dir=True so pages stay on disk for ingest_range.
+                        if not dry_run and ia_access_key and ia_secret_key:
+                            progress.update(tid, description=f"Month {month_str} [Raw ZIP]")
+                            try:
+                                uploader.upload_raw_zip(
+                                    start_of_month,
+                                    raw_month_dir,
+                                    ia_access_key,
+                                    ia_secret_key,
+                                    keep_raw_dir=True,
+                                )
+                            except Exception as e:
+                                progress.console.log(
+                                    f"[yellow]⚠ Raw ZIP upload failed for {month_str}: {e}[/yellow]"
+                                )
+
                         # 4. Ingest
                         progress.update(tid, description=f"Month {month_str} [Ingesting]")
                         stats = extractor.ingest_range(month_start_dt)


### PR DESCRIPTION
## Summary

- After all JSON pages for a month are fetched, `baliza sync` now zips them and uploads to `baliza-pncp-raw` (the single IA item for raw archives) before proceeding with DuckDB ingest
- Uses `keep_raw_dir=True` so local pages are preserved for `ingest_range`
- Raw ZIP failure is non-fatal: a warning is logged and ingest + Parquet upload continue normally
- Updates the manifest `raw_zip_url` / `mirror_uploaded_at` fields for each month processed

## Why

The workflow runs `baliza sync` — not `baliza mirror`. Without this change, `baliza-pncp-raw` was only populated by the one-time migration script (PR #464). Now every month that goes through `sync` automatically gets a raw backup on IA, including the 6 missing months (2025-02, 04, 05, 07, 09, 11) currently being fetched by the scheduler.

## Test plan

- [ ] Confirm ruff passes (no new lint errors)
- [ ] Run a dry-run locally: raw ZIP block is guarded by `not dry_run`, so no upload fires
- [ ] Watch next GHA `pncp-sync` run logs for `[Raw ZIP]` progress step and `✓ ... ZIP updated` lines
- [ ] Verify `baliza-pncp-raw` IA item gains new files after a successful run

🤖 Generated with [Claude Code](https://claude.com/claude-code)