### PR TITLE
fix(extractor): increase retry attempts and backoff for PNCP API hangs

### DIFF
--- a/src/baliza/extractor.py
+++ b/src/baliza/extractor.py
@@ -134,7 +134,7 @@ def _validate_resource(resource: str):
         raise ValueError(f"Invalid resource path: {resource}")
 
 
-class RetryablePayloadError(ValueError):
+class RetryablePayloadError(Exception):
     """Raised when PNCP returns a syntactically invalid payload.
 
     We observe occasional empty/HTML upstream bodies with HTTP 200 while the
@@ -165,8 +165,8 @@ class PNCPExtractor:
 
     @retry(
         retry=retry_if_exception(_is_retryable_error),
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=2, max=10),
+        stop=stop_after_attempt(6),
+        wait=wait_exponential(multiplier=2, min=4, max=60),
     )
     def fetch_page(
         self, resource: str, start_date: datetime, end_date: datetime, page: int = 1
@@ -246,20 +246,26 @@ class PNCPExtractor:
     def _fetch_with_curl(
         self, resource: str, page: int, url: str, start_str: str, end_str: str
     ) -> dict[str, Any]:
-        result = subprocess.run(
-            [
-                "curl",
-                "-s",
-                "-H",
-                "accept: */*",
-                "-H",
-                f"User-Agent: {self.headers['User-Agent']}",
-                f"{url}?dataInicial={start_str}&dataFinal={end_str}&pagina={page}&tamanhoPagina={PAGE_SIZE}",
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+        try:
+            result = subprocess.run(
+                [
+                    "curl",
+                    "-s",
+                    "--max-time", "30",
+                    "--connect-timeout", "10",
+                    "-H",
+                    "accept: */*",
+                    "-H",
+                    f"User-Agent: {self.headers['User-Agent']}",
+                    f"{url}?dataInicial={start_str}&dataFinal={end_str}&pagina={page}&tamanhoPagina={PAGE_SIZE}",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=45,
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            raise RetryablePayloadError(f"curl failed for {resource} page {page}: {e}") from e
         return self._parse_json_payload(
             payload=result.stdout.strip(),
             resource=resource,


### PR DESCRIPTION
## Summary

- `stop_after_attempt(3)` → `(6)`: seis tentativas antes de desistir
- `wait_exponential(max=10)` → `(multiplier=2, min=4, max=60)`: backoff de 4s, 8s, 16s, 32s, 60s, 60s — cobre os travamentos de 4+ min observados na API do PNCP
- `RetryablePayloadError(ValueError)` → `(Exception)`: remove dependência frágil de ordenação em `_is_retryable_error` (a checagem de `ValueError` vinha depois de `RetryablePayloadError` só por isso não curto-circuitava)

## Why

Logs do GHA e da execução local mostraram a API do PNCP ficando muda por 4+ minutos numa página (HTTP 200 com body vazio ou HTML). Com 3 tentativas e max 10s de espera, o tenacity esgotava retries muito antes da API se recuperar, causando falha do mês inteiro com `RetryError[RetryablePayloadError]`. O worst case novo é ~6 min (6 × 30s timeout + 4+8+16+32+60+60s wait), cobrindo os gaps observados.

## Test plan

- [ ] CI verde
- [ ] Próxima execução local/GHA de 2025-11 não morre em `RetryError` em páginas que a API trava

🤖 Generated with [Claude Code](https://claude.com/claude-code)