### PR TITLE
fix: thread engine para export + melhorias web

### DIFF
--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -461,7 +461,10 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
                         if not dry_run:
                             progress.update(tid, description=f"Month {month_str} [Uploading]")
                             if ia_access_key and ia_secret_key:
-                                uploader.upload_month(
+                                # Use thread_engine so export reads from the same
+                                # in-memory DB that ingest_range just populated.
+                                thread_uploader = IAUploader(thread_engine)
+                                thread_uploader.upload_month(
                                     start_of_month, Path("data/processed"), ia_access_key, ia_secret_key,
                                     quarantine_stats=stats, quarantine_csv=q_csv if has_q else None
                                 )

--- a/web/src/components/BuscaView.svelte
+++ b/web/src/components/BuscaView.svelte
@@ -225,6 +225,8 @@
     <div class="skeleton-wrap" aria-busy="true" aria-label="Buscando contratações">
       <div class="skeleton skeleton-bid"></div>
       <div class="skeleton skeleton-bid"></div>
+      <div class="skeleton skeleton-bid"></div>
+      <div class="skeleton skeleton-bid"></div>
     </div>
   {:else if error}
     <AlertBanner title="Não foi possível buscar" message={error.message} level="error" />
@@ -325,7 +327,7 @@
                 <span class="agency">{c.orgaoEntidade?.razaoSocial ?? 'Órgão'}</span>
                 <span class="modality">{c.modalidadeNome ?? ''}</span>
               </div>
-              <p class="objeto">{truncate(c.objetoContratacao, 180)}</p>
+              <p class="objeto" title={c.objetoContratacao}>{truncate(c.objetoContratacao, 180)}</p>
               <div class="result-foot">
                 <span class="date">{formatDate(c.dataPublicacaoPncp ?? '')}</span>
                 <span class="valor">{formatBRL(c.valorTotalEstimado ?? null)}</span>

--- a/web/src/components/RawArchiveStatus.svelte
+++ b/web/src/components/RawArchiveStatus.svelte
@@ -73,12 +73,12 @@
 
   <div class="status-grid">
     <StatCard
-      title="Arquivos raw"
+      title="Arquivos brutos (ZIP)"
       value={formatInteger(status.rawZipCount)}
       hint={`cobertura ${formatPeriod(status.firstPeriod)} a ${formatPeriod(status.latestPeriod)}`}
     />
     <StatCard
-      title="Contratos raw"
+      title="Contratos extraídos"
       value={status.contractsCount === null ? '—' : formatInteger(status.contractsCount)}
       tone="success"
       hint={status.contractsCountCoverage > 0
@@ -86,14 +86,14 @@
         : 'contagem indisponível via view_archive.php'}
     />
     <StatCard
-      title="Volume bruto"
+      title="Volume total"
       value={formatBytes(status.rawBytes)}
       hint={`${formatInteger(status.filesCount)} arquivos no item`}
     />
     <StatCard
       title="Último mês"
       value={formatPeriod(status.latestPeriod)}
-      tone="warning"
+      tone="default"
       hint={status.latestContractsCount === null
         ? (status.latestRawFile?.name ?? 'sem arquivo raw detectado')
         : `${formatInteger(status.latestContractsCount)} contratos em ${status.latestRawFile?.name}`}

--- a/web/src/lib/pncpPublicacao.ts
+++ b/web/src/lib/pncpPublicacao.ts
@@ -144,6 +144,7 @@ export const MAX_DISPENSA_PAGES = 5;
 const DISPENSA_SINCE_DAYS = 365;
 
 function buildPageUrl(
+  filters: PublicacaoFilters,
   modalidade: number,
   pagina: number,
   dataInicial: string,
@@ -156,6 +157,8 @@ function buildPageUrl(
     pagina: String(pagina),
     tamanhoPagina: '50',
   });
+  if (filters.cnpj) params.set('cnpj', filters.cnpj);
+  if (filters.codigoMunicipioIbge) params.set('codigoMunicipioIbge', filters.codigoMunicipioIbge);
   return `${PUBLICACAO_URL}?${params.toString()}`;
 }
 
@@ -174,10 +177,12 @@ export async function fetchPublicacaoPagesForObjeto(
     sinceDays?: number;
     modalidades?: readonly number[];
     now?: Date;
+    filters?: PublicacaoFilters;
   } = {},
 ): Promise<PNCPContract[]> {
   const term = objeto.trim().toLowerCase();
-  if (!term) return [];
+  // Allow empty term if we have filters, otherwise return empty
+  if (!term && !opts.filters?.cnpj && !opts.filters?.codigoMunicipioIbge) return [];
   const {
     maxPages = MAX_BUSCA_PAGES,
     sinceDays = BUSCA_SINCE_DAYS,
@@ -196,7 +201,7 @@ export async function fetchPublicacaoPagesForObjeto(
     for (let pagina = 1; pagina <= maxPages; pagina++) {
       fetches.push(
         (async () => {
-          const res = await fetch(buildPageUrl(modalidade, pagina, dataInicial, dataFinal));
+          const res = await fetch(buildPageUrl(opts.filters || {}, modalidade, pagina, dataInicial, dataFinal));
           if (!res.ok) {
             throw new Error(
               `PNCP publicacao returned ${res.status} for modalidade ${modalidade} page ${pagina}`,
@@ -221,8 +226,10 @@ export async function fetchPublicacaoPagesForObjeto(
   const collected = new Map<string, PNCPContract>();
   for (const r of ok) {
     for (const c of r.value) {
-      const objetoLower = (c.objetoContratacao ?? '').toLowerCase();
-      if (!objetoLower.includes(term)) continue;
+      if (term) {
+        const objetoLower = (c.objetoContratacao ?? '').toLowerCase();
+        if (!objetoLower.includes(term)) continue;
+      }
       if (c.numeroControlePNCP && !collected.has(c.numeroControlePNCP)) {
         collected.set(c.numeroControlePNCP, c);
       }
@@ -237,10 +244,10 @@ export async function fetchPublicacaoPagesForObjeto(
 
 export async function fetchDispensaPagesForObjeto(
   objeto: string,
-  opts: { maxPages?: number; sinceDays?: number; now?: Date } = {},
+  opts: { maxPages?: number; sinceDays?: number; now?: Date; filters?: PublicacaoFilters } = {},
 ): Promise<PNCPContract[]> {
   const term = objeto.trim().toLowerCase();
-  if (!term) return [];
+  if (!term && !opts.filters?.cnpj && !opts.filters?.codigoMunicipioIbge) return [];
   const { maxPages = MAX_DISPENSA_PAGES, sinceDays = DISPENSA_SINCE_DAYS, now = new Date() } = opts;
 
   const end = new Date(now);
@@ -251,7 +258,7 @@ export async function fetchDispensaPagesForObjeto(
 
   const collected = new Map<string, PNCPContract>();
   for (let pagina = 1; pagina <= maxPages; pagina++) {
-    const res = await fetch(buildPageUrl(8, pagina, dataInicial, dataFinal));
+    const res = await fetch(buildPageUrl(opts.filters || {}, 8, pagina, dataInicial, dataFinal));
     if (!res.ok) {
       // Surface a real error instead of silently returning a partial result —
       // an empty list would render "Nenhuma base legal encontrada" and mask
@@ -261,8 +268,10 @@ export async function fetchDispensaPagesForObjeto(
     const page = parsePncpPublicacaoList(await res.json());
     if (!page.length) break;
     for (const c of page) {
-      const objetoLower = (c.objetoContratacao ?? '').toLowerCase();
-      if (!objetoLower.includes(term)) continue;
+      if (term) {
+        const objetoLower = (c.objetoContratacao ?? '').toLowerCase();
+        if (!objetoLower.includes(term)) continue;
+      }
       if (c.numeroControlePNCP && !collected.has(c.numeroControlePNCP)) {
         collected.set(c.numeroControlePNCP, c);
       }

--- a/web/src/pages/status.astro
+++ b/web/src/pages/status.astro
@@ -9,7 +9,10 @@ import RawArchiveStatus from '../components/RawArchiveStatus.svelte';
 >
   <section class="status-section container">
     <div class="status-header">
-      <h1 class="section-title">Status do Pipeline</h1>
+      <div class="header-with-badge">
+        <h1 class="section-title">Status do Pipeline</h1>
+        <span class="badge operational">🟢 Operacional</span>
+      </div>
       <p class="section-desc">
         Acompanhe o estado do item bruto no Internet Archive. Esta tela lê
         diretamente os metadados públicos de <code>baliza-pncp-raw</code>,
@@ -32,8 +35,24 @@ import RawArchiveStatus from '../components/RawArchiveStatus.svelte';
   }
   .section-title {
     font-size: var(--font-size-3xl);
-    margin-bottom: var(--space-xs);
     color: var(--color-primary);
+    margin: 0;
+  }
+  .header-with-badge {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    margin-bottom: var(--space-xs);
+  }
+  .badge.operational {
+    background: color-mix(in srgb, var(--color-success) 15%, transparent);
+    color: var(--color-success);
+    border: 1px solid color-mix(in srgb, var(--color-success) 30%, transparent);
+    padding: 4px 12px;
+    border-radius: var(--radius-pill);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    font-family: var(--font-mono);
   }
   .section-desc {
     color: var(--color-secondary);


### PR DESCRIPTION
## Summary

### Fix: parquet export usa engine errado no sync (`cli_simple.py`)
- Cada worker chama `connect_thread_safe()` → DuckDB in-memory separado por thread
- O `uploader` compartilhado usava o engine principal (vazio), então `export_month` sempre via `contratos does not exist`
- Isso causava `error_count += 1` e exit code 1 mesmo o upload tendo funcionado via raw ZIP
- Fix: cria `IAUploader(thread_engine)` por worker para que export leia do mesmo DB que o `ingest_range` acabou de popular

### Melhorias web
- **`pncpPublicacao.ts`**: passa filtros `cnpj` / `codigoMunicipioIbge` na URL da API PNCP; permite busca sem termo de texto quando há filtros
- **`BuscaView.svelte`**: 2 skeletons extras no estado de loading; `title` no objeto para mostrar texto completo no hover
- **`RawArchiveStatus.svelte`**: labels em PT-BR ("Arquivos brutos (ZIP)", "Contratos extraídos", "Volume total"); remove tom `warning` do card "Último mês"
- **`status.astro`**: badge "🟢 Operacional" ao lado do título da página

## Test plan

- [ ] `baliza sync --force-month 2025-11` sem warning `contratos does not exist` e exit code 0
- [ ] Parquet aparece no item IA após sync
- [ ] GHA cron não abre mais issues de falha falso-positivo
- [ ] Página de busca aceita filtro de CNPJ sem termo de texto
- [ ] Status page mostra badge e labels em PT-BR

🤖 Generated with [Claude Code](https://claude.com/claude-code)