### PR TITLE
fix(web): review fixes for PR #496 — CI, a11y, hero UX

### DIFF
--- a/web/src/components/CityHero.svelte
+++ b/web/src/components/CityHero.svelte
@@ -69,11 +69,15 @@
       </p>
 
       <form class="hero-search" method="get" action={resolve('busca')}>
+        {#if cityState.source !== 'default'}
+          <input type="hidden" name="ibge" value={cityState.ibge} />
+        {/if}
         <input
           type="search"
           name="q"
-          value={cityState.nome}
-          placeholder="Ex: hospital municipal, merenda, obras..."
+          placeholder={cityState.source === 'default'
+            ? 'Ex: hospital municipal, merenda, obras...'
+            : `Buscar em ${cityState.nome} — ex.: merenda, obras...`}
           aria-label="Buscar no PNCP"
         />
         <button type="submit" class="btn btn-primary btn-search">
@@ -87,7 +91,7 @@
           Ver painel de {cityState.nome}
         </a>
 
-        {#if cityState.source === 'default'}
+        {#if geoStatus !== 'ready'}
           <button
             type="button"
             class="btn btn-secondary btn-lg geo-btn"

--- a/web/src/components/CityPulse.svelte
+++ b/web/src/components/CityPulse.svelte
@@ -95,7 +95,7 @@
   );
 </script>
 
-<section class="city-pulse" aria-labelledby="pulse-title">
+<section class="city-pulse" aria-label="Painel da cidade — mês corrente">
   <div class="container">
     {#if !ibge}
       <EmptyState

--- a/web/src/components/Navigation.astro
+++ b/web/src/components/Navigation.astro
@@ -22,13 +22,14 @@ const isCityActive = cleanPath === cityPrefix;
       <span><span class="logo-accent">Baliza</span> Monitor</span>
     </a>
 
-    <input type="checkbox" id="nav-toggle" class="nav-toggle-checkbox" aria-label="Alternar menu" />
-    <label for="nav-toggle" class="nav-toggle-label" aria-hidden="true">
-      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <input type="checkbox" id="nav-toggle" class="nav-toggle-checkbox sr-only" aria-label="Alternar menu" />
+    <label for="nav-toggle" class="nav-toggle-label">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
         <line x1="3" y1="12" x2="21" y2="12" class="line-mid"></line>
         <line x1="3" y1="6" x2="21" y2="6" class="line-top"></line>
         <line x1="3" y1="18" x2="21" y2="18" class="line-bot"></line>
       </svg>
+      <span class="sr-only">Alternar menu</span>
     </label>
 
     <div class="nav-menu">
@@ -130,7 +131,6 @@ const isCityActive = cleanPath === cityPrefix;
     align-items: center;
     gap: var(--space-4);
   }
-  .nav-toggle-checkbox,
   .nav-toggle-label {
     display: none;
   }


### PR DESCRIPTION
Aplica os ajustes levantados no review da PR #496. **Mergear esta PR dentro da `feat/ux-redesign-hero-search-nav`** para que as correções entrem no PR principal.

## Bloqueadores resolvidos

- **CI Web Build & Lint** estava vermelho. Removido o import morto `HomeBuscaForm` em `web/src/pages/index.astro`. Bundle também ultrapassou o budget em 1 KB devido ao código novo da PR (geolocalização + dropdown); subi `BUDGET_BYTES` de 330 KB → 335 KB em `web/scripts/check-bundle-size.mjs` com nota explicando a causa, conforme o próprio script orienta.
- **`aria-labelledby` órfão** em `CityPulse.svelte` — o `<h2 id="pulse-title">` foi removido nesta PR mas a `<section>` continuava apontando para ele. Trocado por `aria-label="Painel da cidade — mês corrente"`.
- **Hero search pré-preenchido com nome da cidade** — o `<input value={cityState.nome}>` transformava o botão "Buscar" em uma busca textual por "Porto Velho". Agora o input nasce vazio, e o `placeholder` muda conforme o contexto. Adicionado `<input type="hidden" name="ibge">` quando há cidade não-default, para que a busca herde o filtro de cidade.

## Bugs adicionais

- **Botão "Usar minha localização"** estava escondido para quem já tinha cidade no storage/URL — não havia caminho para acioná-lo. Trocado o gate de `source === 'default'` para `geoStatus !== 'ready'`.
- **A11y do hamburger menu** — o checkbox tinha `display: none` (invisível para leitor de tela e tab) e o `<label>` visível tinha `aria-hidden="true"`. Trocado o checkbox para classe global `.sr-only` (focável por teclado), removido o `aria-hidden` do label, e adicionado `<span class="sr-only">Alternar menu</span>` para nomear a ação acessivelmente.

## Validação local

- `npm run lint` — limpo
- `npm run build` — passa, incluindo `astro check` e `check-bundle-size`

## Itens NÃO incluídos (deixados para discussão)

Itens arquiteturais do review que valem decisão do autor antes de aplicar:

- Hero usa `<form method="get">` em vez de `nav.navigate()` (full reload em vez de SPA)
- Política de uso do Nominatim (User-Agent, rate limit, cache)
- Validação de IBGE com 7 dígitos no parser de tags do `BuscaView`
- `getCityFromCoords` pode retornar `city = ""` sem erro explícito
- Acessibilidade do dropdown "Dados Abertos" (sem `aria-expanded` dinâmico, abre só em hover/focus)

https://claude.ai/code/session_01XC6gEr553oPq6mhCEw6BaU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC6gEr553oPq6mhCEw6BaU)_