### PR TITLE
Auditoria de cobertura: CNPJs de órgãos públicos no PNCP

### DIFF
--- a/.github/workflows/build-orgaos-publicos.yml
+++ b/.github/workflows/build-orgaos-publicos.yml
@@ -13,8 +13,11 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  # Need write to push the regenerated JSON back to main when content changes.
+  # Need contents: write to push the regenerated JSON back to main when
+  # content changes; issues: write so the report-failure job can open an
+  # alert issue (`github.rest.issues.create`) when the ETL breaks.
   contents: write
+  issues: write
 
 jobs:
   build:
@@ -36,7 +39,11 @@ jobs:
 
       - name: Commit refreshed JSON if changed
         run: |
-          if git diff --quiet -- web/public/data/cnpj-orgaos-publicos.json; then
+          # `git status --porcelain` reports both modified (M) and untracked
+          # (??) entries; `git diff --quiet` would miss the first run where
+          # the JSON doesn't exist in HEAD yet and the workflow would never
+          # commit the bootstrap dataset.
+          if [ -z "$(git status --porcelain -- web/public/data/cnpj-orgaos-publicos.json)" ]; then
             echo "No changes — Receita dump produced an identical filtered set."
             exit 0
           fi

--- a/.github/workflows/build-orgaos-publicos.yml
+++ b/.github/workflows/build-orgaos-publicos.yml
@@ -1,0 +1,79 @@
+name: Build public-CNPJ reference
+
+on:
+  # Receita Federal refreshes the CNPJ dump on the second Sunday of every
+  # month. Running on the 15th gives the upload time to settle and avoids
+  # racing partial publication.
+  schedule:
+    - cron: '0 6 15 * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: build-orgaos-publicos
+  cancel-in-progress: true
+
+permissions:
+  # Need write to push the regenerated JSON back to main when content changes.
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Default token is fine; the workflow runs in the same repo and
+          # only writes to web/public/data/. No secrets needed beyond the
+          # built-in GITHUB_TOKEN, which has contents:write per the
+          # permissions block above.
+          persist-credentials: true
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Run ETL
+        run: uv run scripts/build_orgaos_publicos.py
+
+      - name: Commit refreshed JSON if changed
+        run: |
+          if git diff --quiet -- web/public/data/cnpj-orgaos-publicos.json; then
+            echo "No changes — Receita dump produced an identical filtered set."
+            exit 0
+          fi
+          git config user.name 'baliza-bot'
+          git config user.email '[email protected]'
+          git add web/public/data/cnpj-orgaos-publicos.json
+          git commit -m "chore(data): refresh public-CNPJ reference from Receita Federal"
+          git push
+
+  report-failure:
+    name: Report workflow failure
+    if: ${{ failure() }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const runId = context.runId;
+            const runUrl = `${context.payload.repository.html_url}/actions/runs/${runId}`;
+            const identifier = `run_id:${runId}`;
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} "${identifier}" state:open type:issue`,
+            });
+            if (search.data.total_count > 0) return;
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: `🚨 Falha no workflow "Build public-CNPJ reference" (run #${context.runNumber})`,
+              body: [
+                'A geração mensal do dataset de CNPJs públicos falhou.',
+                '',
+                `- **Workflow**: Build public-CNPJ reference`,
+                `- **Execução**: [#${context.runNumber}](${runUrl})`,
+                `- **Identificador**: ${identifier}`,
+              ].join('\n'),
+              labels: ['ci-failure'],
+            });

--- a/scripts/build_orgaos_publicos.py
+++ b/scripts/build_orgaos_publicos.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env -S uv run --quiet
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#   "httpx>=0.27",
+# ]
+# ///
+"""Build the public-sector CNPJ reference dataset from the Receita Federal dump.
+
+Downloads only `Empresas{0..9}.zip` (header: razão social + natureza jurídica
+code) and `Naturezas.zip` (lookup table) from the official Receita Federal
+CNPJ data portal, streams the CSV rows, filters by `natureza_juridica` codes
+matching public administration entities, and writes a compact JSON to
+`web/public/data/cnpj-orgaos-publicos.json` for the /status coverage section.
+
+Source (official, monthly refresh by Receita Federal):
+  https://arquivos.receitafederal.gov.br/dados/cnpj/dados_abertos_cnpj/
+  Manifest at /<YYYY-MM>/.
+
+Why only Empresas — Estabelecimentos.zip would add UF and município but is
+~5x bigger and adds ~30 minutes to the run. The /status page doesn't need
+per-UF segmentation in v1; we can layer that in later by joining with
+Estabelecimentos when the time budget allows.
+
+Filter rule — natureza jurídica codes (4-digit) are grouped:
+  1xxx = Administração Pública direta + indireta + autarquias +
+         fundações + empresas públicas + sociedades de economia mista
+  2xxx = Entidades empresariais (private). Excluded.
+  3xxx, 4xxx, ... = associações, OS, instituições religiosas, etc.
+
+Including all 1xxx (codes 1015..1309) gives the universe of agencies that
+should be publishing on PNCP under the transparency rules.
+
+Output schema (array of compact records, ~3 fields × N entries):
+  [
+    {"raiz": "00394502", "nome": "MINISTERIO DA SAUDE", "natureza": "1023"},
+    ...
+  ]
+~30k–50k entries expected. Raw ~3-5 MB; gzipped ~600KB-1MB.
+
+Refresh workflow (CI-driven):
+  .github/workflows/build-orgaos-publicos.yml — monthly cron + manual
+  dispatch. Commits the regenerated JSON when content changes.
+
+Manual run (e.g. testing locally):
+  $ uv run scripts/build_orgaos_publicos.py
+  $ git add web/public/data/cnpj-orgaos-publicos.json
+  $ git commit -m "chore(data): refresh public-CNPJ reference"
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import logging
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+import httpx
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+log = logging.getLogger("build-orgaos-publicos")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OUT_PATH = REPO_ROOT / "web" / "public" / "data" / "cnpj-orgaos-publicos.json"
+
+# Receita Federal publishes a new monthly snapshot under YYYY-MM/. Their
+# index page is the canonical place to discover the latest folder; we parse
+# it instead of hardcoding a date so this script keeps working past the
+# next dump rotation.
+INDEX_URL = "https://arquivos.receitafederal.gov.br/dados/cnpj/dados_abertos_cnpj/"
+EMPRESAS_FILE_RE = re.compile(r'Empresas\d+\.zip', re.IGNORECASE)
+
+# Public-administration natureza_juridica band. Codes 1015..1309 cover:
+# - Direct admin (federal/state/municipal)
+# - Autarquias (federal/state/municipal)
+# - Fundações públicas
+# - Empresas públicas + sociedades de economia mista (federal/state/municipal)
+# - Comissões, consórcios, fundos
+# Source: TabelaNaturezasJuridicas.pdf (Receita Federal).
+PUBLIC_NATUREZA_MIN = 1000
+PUBLIC_NATUREZA_MAX = 1999
+
+
+def find_latest_folder(client: httpx.Client) -> str:
+    """Read the dados_abertos_cnpj index and return the most recent YYYY-MM/ folder."""
+    log.info("discovering latest snapshot folder at %s", INDEX_URL)
+    resp = client.get(INDEX_URL)
+    resp.raise_for_status()
+    folders = re.findall(r'href="(\d{4}-\d{2}/)"', resp.text)
+    if not folders:
+        raise RuntimeError(f"no YYYY-MM/ folders found at {INDEX_URL}")
+    folders.sort(reverse=True)
+    log.info("latest snapshot: %s", folders[0])
+    return folders[0]
+
+
+def list_empresas_files(client: httpx.Client, folder_url: str) -> list[str]:
+    """Return the list of Empresas*.zip filenames under the latest folder."""
+    log.info("listing Empresas*.zip files under %s", folder_url)
+    resp = client.get(folder_url)
+    resp.raise_for_status()
+    files = sorted(set(EMPRESAS_FILE_RE.findall(resp.text)))
+    if not files:
+        raise RuntimeError(f"no Empresas*.zip found at {folder_url}")
+    log.info("found %d Empresas*.zip files: %s", len(files), files)
+    return files
+
+
+def stream_empresas_csv(client: httpx.Client, url: str):
+    """Yield CSV rows from a streaming Empresas*.zip download.
+
+    The Receita CSVs are Latin-1 encoded with `;` separators and no header
+    row. Row layout (per Receita's layout doc):
+      0  CNPJ_BASICO          (8 digits, the "raiz")
+      1  RAZAO_SOCIAL
+      2  NATUREZA_JURIDICA    (4-digit code)
+      3  QUALIFICACAO_RESPONSAVEL
+      4  CAPITAL_SOCIAL
+      5  PORTE
+      6  ENTE_FEDERATIVO_RESPONSAVEL  (set for some 1xxx — e.g. 'UNIAO')
+    """
+    log.info("downloading + streaming %s", url)
+    with client.stream("GET", url) as resp:
+        resp.raise_for_status()
+        # zipfile needs a seekable file-like; buffer the small zip into memory.
+        # Empresas zips are ~70-100 MB compressed — fits comfortably in RAM
+        # on a GH runner (7 GB) without touching disk.
+        buf = io.BytesIO()
+        for chunk in resp.iter_bytes(chunk_size=8 * 1024 * 1024):
+            buf.write(chunk)
+    buf.seek(0)
+    with zipfile.ZipFile(buf) as zf:
+        for inner_name in zf.namelist():
+            with zf.open(inner_name) as raw:
+                # Wrap binary stream in TextIOWrapper to give csv.reader a
+                # proper iterator without materialising the whole CSV.
+                text = io.TextIOWrapper(raw, encoding="latin-1", newline="")
+                yield from csv.reader(text, delimiter=";", quotechar='"')
+
+
+def normalise_record(row: list[str]) -> dict | None:
+    """Return a compact dict for public-sector rows; None to skip."""
+    if len(row) < 3:
+        return None
+    raiz = row[0].strip()
+    if not raiz.isdigit() or len(raiz) != 8:
+        return None
+    natureza_raw = row[2].strip()
+    if not natureza_raw.isdigit():
+        return None
+    natureza_int = int(natureza_raw)
+    if not (PUBLIC_NATUREZA_MIN <= natureza_int <= PUBLIC_NATUREZA_MAX):
+        return None
+    nome = row[1].strip()
+    return {"raiz": raiz, "nome": nome, "natureza": natureza_raw}
+
+
+def main() -> int:
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    timeout = httpx.Timeout(60.0, connect=10.0)
+    with httpx.Client(timeout=timeout, follow_redirects=True, http2=True) as client:
+        latest_folder = find_latest_folder(client)
+        folder_url = INDEX_URL + latest_folder
+        empresas_files = list_empresas_files(client, folder_url)
+
+        public_records: dict[str, dict] = {}  # dedup by raiz
+        total_rows = 0
+        for fname in empresas_files:
+            url = folder_url + fname
+            for row in stream_empresas_csv(client, url):
+                total_rows += 1
+                rec = normalise_record(row)
+                if rec is None:
+                    continue
+                # If a CNPJ raiz appears in multiple zip shards (it shouldn't,
+                # they're partitioned by hash), keep the first; razão social
+                # is identical across shards by construction.
+                public_records.setdefault(rec["raiz"], rec)
+            log.info(
+                "after %s: %d rows scanned, %d public-sector raizes captured",
+                fname, total_rows, len(public_records),
+            )
+
+    if len(public_records) < 1000:
+        # Sanity: even a partial Receita dump should yield tens of thousands.
+        # Below 1000 means we filtered something fundamental (encoding,
+        # natureza band) wrong — refuse to overwrite the committed JSON.
+        log.error(
+            "sanity check failed: only %d public-sector entries — refusing to write",
+            len(public_records),
+        )
+        return 1
+
+    sorted_records = sorted(public_records.values(), key=lambda r: r["raiz"])
+    OUT_PATH.write_text(json.dumps(sorted_records, ensure_ascii=False))
+    size_kb = OUT_PATH.stat().st_size / 1024
+    log.info(
+        "wrote %d public-sector CNPJ raizes to %s (%.1f KB)",
+        len(sorted_records), OUT_PATH.relative_to(REPO_ROOT), size_kb,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/scripts/check-bundle-size.mjs
+++ b/web/scripts/check-bundle-size.mjs
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DIST_DIR = join(__dirname, '..', 'dist', '_astro');
 
-// Current baseline: 335_000 bytes — measured size (~324 KB) plus headroom,
+// Current baseline: 342_000 bytes — measured size (~333 KB) plus headroom,
 // with room absorbed by the SupplierDetailView shipped for Journey 1 @green
 // (/fornecedor?cnpj= supplier prospecting page), the citizen-first
 // homepage islands (CityHero + CityPulse + CityNavLink + shared
@@ -31,10 +31,13 @@ const DIST_DIR = join(__dirname, '..', 'dist', '_astro');
 // boundary schemas in pncp.ts), and the homepage UX redesign (PR #496:
 // hero omni-search, Navigation dropdown) plus its offline geocoding follow-
 // up (findNearestMunicipality in geo.ts; the 270 KB centroids dataset is a
-// static asset and does NOT count against this entry-payload budget). When
-// an intentional feature increases the baseline, raise this constant in the
-// same commit and note what landed.
-const BUDGET_BYTES = 335_000;
+// static asset and does NOT count against this entry-payload budget), and
+// the /status public-CNPJ coverage audit (CoverageReport island that
+// pulls a static reference list and runs a DuckDB-WASM SELECT DISTINCT
+// SUBSTR(cnpj_orgao, 1, 8) on the contratos parquet — adds ~6 KB). When
+// an intentional feature increases the baseline, raise this constant in
+// the same commit and note what landed.
+const BUDGET_BYTES = 342_000;
 
 function isClientEntryFile(name) {
   if (!name.endsWith('.js')) return false;

--- a/web/src/components/CoverageReport.svelte
+++ b/web/src/components/CoverageReport.svelte
@@ -1,0 +1,355 @@
+<script lang="ts">
+  import { createQuery, setQueryClientContext } from '@tanstack/svelte-query';
+  import { getQueryClient } from '../lib/queryClient';
+  import { QUERY_KEYS } from '../lib/queryKeys';
+  import { resolve } from '../lib/baseUrl';
+  import { formatInteger, formatParticao } from '../lib/format';
+  import { queryPublishingCnpjRaizes } from '../lib/parquetFallback';
+
+  setQueryClientContext(getQueryClient());
+
+  /** Reference entry shipped in web/public/data/cnpj-orgaos-publicos.json. */
+  interface PublicCnpjEntry {
+    raiz: string;
+    nome: string;
+    natureza: string;
+  }
+
+  // Lazy-load the reference list so the JS chunk for /status doesn't grow
+  // by the size of the (potentially MB-scale) reference itself.
+  const referenceQuery = createQuery(() => ({
+    queryKey: QUERY_KEYS.publicCnpjReference,
+    staleTime: 24 * 60 * 60 * 1000,
+    queryFn: async (): Promise<PublicCnpjEntry[]> => {
+      const url = resolve('data/cnpj-orgaos-publicos.json');
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const raw = (await res.json()) as PublicCnpjEntry[];
+      if (!Array.isArray(raw)) throw new Error('reference file is not an array');
+      return raw;
+    },
+    retry: false,
+  }));
+
+  // Numerator: distinct cnpj_orgao raizes from the latest contratos
+  // parquet (queried in-browser via DuckDB-WASM).
+  const publishingQuery = createQuery(() => ({
+    queryKey: QUERY_KEYS.publishingCnpjRaizes,
+    staleTime: 5 * 60 * 1000,
+    queryFn: async (): Promise<{ raizes: string[]; dataParticao: string | null }> => {
+      const r = await queryPublishingCnpjRaizes();
+      if (!r.ok) throw new Error(r.reason);
+      // r.rows is string[] — each row is one raiz string from the SELECT
+      // DISTINCT result. ArchiveResult<T> wraps T[] for the row payload.
+      return { raizes: r.rows, dataParticao: r.dataParticao };
+    },
+    retry: false,
+  }));
+
+  const reference = $derived(referenceQuery.data ?? []);
+  const publishing = $derived(publishingQuery.data?.raizes ?? []);
+  const dataParticao = $derived(publishingQuery.data?.dataParticao ?? null);
+
+  const loading = $derived(referenceQuery.isFetching || publishingQuery.isFetching);
+  const referenceError = $derived(referenceQuery.error as Error | null);
+  const publishingError = $derived(publishingQuery.error as Error | null);
+
+  // Group natureza_juridica codes by the first digit of the second pair —
+  // captures the federative level (Federal, Estadual, Municipal). Codes
+  // 1015..1058 sit at the federal/state/municipal direct-administration
+  // bands per Receita Federal's table; mapping is approximate but useful
+  // as a top-line breakdown in this v1.
+  function esferaOf(natureza: string): 'Federal' | 'Estadual' | 'Municipal' | 'Outras' {
+    const n = parseInt(natureza, 10);
+    if (!Number.isFinite(n)) return 'Outras';
+    // Direct administration:
+    //   1015 Órgão Público do Poder Executivo Federal
+    //   1023 Órgão Público do Poder Executivo Estadual ou Distrito Federal
+    //   1031 Órgão Público do Poder Executivo Municipal
+    // Indirect (autarquias / fundações / empresas):
+    //   1040..1074 Federal · 1112..1147 Estadual · 1180..1228 Municipal
+    if (n === 1015 || (n >= 1040 && n <= 1074) || n === 1244 || n === 1252) return 'Federal';
+    if (n === 1023 || (n >= 1112 && n <= 1147) || n === 1260 || n === 1279) return 'Estadual';
+    if (n === 1031 || (n >= 1180 && n <= 1228) || n === 1287 || n === 1295) return 'Municipal';
+    return 'Outras';
+  }
+
+  // Aggregate stats by esfera. Pure derivation from the two arrays —
+  // the heavy lifting (the Set membership tests) runs once per data
+  // change, then the template just reads the dict.
+  const stats = $derived.by(() => {
+    if (reference.length === 0 || publishing.length === 0) return null;
+    const publishedSet = new Set(publishing);
+    const groups: Record<string, { total: number; published: number }> = {
+      Federal: { total: 0, published: 0 },
+      Estadual: { total: 0, published: 0 },
+      Municipal: { total: 0, published: 0 },
+      Outras: { total: 0, published: 0 },
+    };
+    let totalPublished = 0;
+    for (const entry of reference) {
+      const e = esferaOf(entry.natureza);
+      groups[e].total += 1;
+      if (publishedSet.has(entry.raiz)) {
+        groups[e].published += 1;
+        totalPublished += 1;
+      }
+    }
+    return {
+      totalReference: reference.length,
+      totalPublished,
+      coveragePct: reference.length > 0 ? (totalPublished / reference.length) * 100 : 0,
+      esferas: groups,
+    };
+  });
+
+  // "Ausências notáveis": reference entries with no PNCP record. Cap to
+  // the first 50 sorted by raiz so the rendered list stays readable;
+  // the full audit is the kind of thing that lives in a follow-up
+  // dedicated page if anyone needs it.
+  const absences = $derived.by(() => {
+    if (reference.length === 0 || publishing.length === 0) return [];
+    const publishedSet = new Set(publishing);
+    return reference
+      .filter((e) => !publishedSet.has(e.raiz))
+      .slice(0, 50);
+  });
+
+  function fmtCnpjRaiz(r: string): string {
+    return `${r.slice(0, 2)}.${r.slice(2, 5)}.${r.slice(5, 8)}`;
+  }
+</script>
+
+<section class="coverage" aria-label="Cobertura de órgãos públicos no PNCP">
+  <header>
+    <h2>Cobertura de órgãos públicos</h2>
+    <p>
+      Comparação entre <strong>quem publica no PNCP</strong> (CNPJs raiz
+      vistos no parquet arquivado) e o universo de <strong>quem deveria
+      publicar</strong> (cadastro da Receita Federal, naturezas jurídicas
+      1xxx — administração pública direta e indireta).
+    </p>
+  </header>
+
+  {#if referenceError && referenceError.message.includes('404')}
+    <div class="banner banner--info" role="status">
+      <p>
+        <strong>Cadastro de referência ainda não publicado.</strong>
+        O dataset <code>cnpj-orgaos-publicos.json</code> é gerado pela
+        action mensal <code>build-orgaos-publicos.yml</code>. Aguarde a
+        primeira execução agendada (dia 15 de cada mês) ou dispare
+        manualmente no Actions tab para popular esta seção.
+      </p>
+    </div>
+  {:else if referenceError}
+    <div class="banner banner--warn" role="alert">
+      <p>Falha ao carregar o cadastro de referência: {referenceError.message}.</p>
+    </div>
+  {:else if publishingError}
+    <div class="banner banner--warn" role="alert">
+      <p>
+        Falha ao consultar o parquet de contratos: {publishingError.message}.
+        O numerador (CNPJs publicadores) não pôde ser computado agora.
+      </p>
+    </div>
+  {:else if loading && !stats}
+    <div class="skeleton-row" aria-busy="true">
+      <div class="skeleton skel-num"></div>
+      <div class="skeleton skel-line"></div>
+      <div class="skeleton skel-line"></div>
+    </div>
+  {:else if stats}
+    <div class="headline">
+      <span class="big">{formatInteger(stats.totalPublished)}</span>
+      <span class="of">de</span>
+      <span class="big big--ref">{formatInteger(stats.totalReference)}</span>
+      <span class="label">órgãos públicos publicaram no PNCP</span>
+      <span class="pct" class:pct--low={stats.coveragePct < 50}>
+        {stats.coveragePct.toFixed(1)}%
+      </span>
+    </div>
+
+    <table class="esferas">
+      <thead>
+        <tr><th>Esfera</th><th>Cobertos</th><th>Cadastrados</th><th>%</th></tr>
+      </thead>
+      <tbody>
+        {#each ['Federal', 'Estadual', 'Municipal', 'Outras'] as label (label)}
+          {@const g = stats.esferas[label]}
+          {@const p = g.total > 0 ? (g.published / g.total) * 100 : 0}
+          <tr>
+            <th scope="row">{label}</th>
+            <td>{formatInteger(g.published)}</td>
+            <td>{formatInteger(g.total)}</td>
+            <td class:low={p < 50}>{p.toFixed(1)}%</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+
+    {#if absences.length > 0}
+      <details class="absences">
+        <summary>
+          Ausências notáveis · primeiras {absences.length} de {formatInteger(stats.totalReference - stats.totalPublished)}
+        </summary>
+        <ul>
+          {#each absences as a (a.raiz)}
+            <li>
+              <span class="cnpj">{fmtCnpjRaiz(a.raiz)}</span>
+              <span class="nome">{a.nome}</span>
+              <span class="natureza">nat. {a.natureza}</span>
+            </li>
+          {/each}
+        </ul>
+      </details>
+    {/if}
+
+    {#if dataParticao}
+      <p class="footnote">
+        Dados a partir do snapshot Parquet de {formatParticao(dataParticao)} no Internet Archive.
+      </p>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  .coverage {
+    display: grid;
+    gap: var(--space-4);
+  }
+  header h2 {
+    font-family: var(--font-display);
+    font-weight: 400;
+    font-size: clamp(20px, 2vw, 28px);
+    margin: 0;
+  }
+  header p {
+    color: var(--color-text-dim);
+    line-height: 1.6;
+    max-width: 72ch;
+    margin: var(--space-2) 0 0;
+  }
+  .banner {
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--color-border);
+    border-left: 4px solid var(--color-azul);
+    background: color-mix(in srgb, var(--color-bg) 92%, transparent);
+  }
+  .banner--warn { border-left-color: var(--color-tijolo); }
+  .banner code {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    background: color-mix(in srgb, var(--color-azul) 10%, transparent);
+    padding: 1px 5px;
+    border-radius: var(--radius-sm);
+  }
+  .headline {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: var(--space-2);
+    padding: var(--space-4);
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-left: 5px solid var(--color-accent);
+  }
+  .big {
+    font-family: var(--font-display);
+    font-weight: 300;
+    font-size: clamp(32px, 4vw, 56px);
+    line-height: 1;
+  }
+  .big--ref { color: var(--color-text-dim); }
+  .of { color: var(--color-text-dim); font-size: var(--text-md); }
+  .label {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-text-dim);
+    flex: 1;
+  }
+  .pct {
+    font-family: var(--font-display);
+    font-weight: 500;
+    font-size: clamp(20px, 2vw, 28px);
+    color: var(--color-verde);
+  }
+  .pct--low { color: var(--color-tijolo); }
+  .esferas {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .esferas th,
+  .esferas td {
+    padding: var(--space-2) var(--space-3);
+    text-align: right;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .esferas th[scope='row'] {
+    text-align: left;
+    font-family: var(--font-mono);
+    font-weight: 500;
+    font-size: var(--text-sm);
+  }
+  .esferas thead th {
+    text-align: right;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-text-dim);
+  }
+  .esferas thead th:first-child { text-align: left; }
+  .esferas .low { color: var(--color-tijolo); }
+  .absences summary {
+    cursor: pointer;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-azul);
+    padding: var(--space-2) 0;
+  }
+  .absences ul {
+    list-style: none;
+    margin: 0;
+    padding: var(--space-2) 0;
+    display: grid;
+    gap: 4px;
+    max-height: 360px;
+    overflow-y: auto;
+  }
+  .absences li {
+    display: grid;
+    grid-template-columns: max-content 1fr max-content;
+    gap: var(--space-3);
+    align-items: baseline;
+    padding: 4px 0;
+    border-bottom: 1px dotted var(--color-border);
+    font-size: var(--text-sm);
+  }
+  .cnpj {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-azul);
+  }
+  .natureza {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-text-dim);
+  }
+  .footnote {
+    font-size: var(--text-xs);
+    color: var(--color-text-dim);
+    margin: 0;
+    font-family: var(--font-mono);
+  }
+  .skeleton-row {
+    display: grid;
+    gap: var(--space-2);
+    padding: var(--space-4);
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+  }
+  .skel-num { height: 3rem; width: 40%; }
+  .skel-line { height: 1rem; width: 100%; }
+</style>

--- a/web/src/components/CoverageReport.svelte
+++ b/web/src/components/CoverageReport.svelte
@@ -32,9 +32,14 @@
   }));
 
   // Numerator: distinct cnpj_orgao raizes from the latest contratos
-  // parquet (queried in-browser via DuckDB-WASM).
+  // parquet (queried in-browser via DuckDB-WASM). Gated on the reference
+  // dataset being available — without a denominator the SELECT DISTINCT
+  // result has nothing to compare against and the UI exits early via the
+  // reference-error banner, so kicking off the parquet shard download
+  // and DuckDB query would be pure waste in the bootstrap state.
   const publishingQuery = createQuery(() => ({
     queryKey: QUERY_KEYS.publishingCnpjRaizes,
+    enabled: !!referenceQuery.data && referenceQuery.data.length > 0,
     staleTime: 5 * 60 * 1000,
     queryFn: async (): Promise<{ raizes: string[]; dataParticao: string | null }> => {
       const r = await queryPublishingCnpjRaizes();

--- a/web/src/lib/parquetFallback.ts
+++ b/web/src/lib/parquetFallback.ts
@@ -445,3 +445,87 @@ export async function queryCityAggregates(
     if (timeoutHandle !== null) clearTimeout(timeoutHandle);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Public-CNPJ coverage audit for the /status page
+// ---------------------------------------------------------------------------
+// Compares the universe of public-administration CNPJs (denominator,
+// extracted from the Receita Federal CNPJ dump and shipped as a static
+// JSON at web/public/data/cnpj-orgaos-publicos.json) against the CNPJs
+// that actually published in PNCP (numerator, distinct cnpj_orgao raizes
+// from the latest contratos parquet).
+//
+// We work at the CNPJ raiz (8-digit prefix) level so subordinated units
+// roll up into the parent agency — a Prefeitura's matriz and its many
+// secretariats count as one entity, which is the granularity citizens
+// reason about.
+
+export async function queryPublishingCnpjRaizes(
+  opts: { timeoutMs?: number } = {},
+): Promise<ArchiveResult<string>> {
+  const info = await getLatestParquetInfo(CITY_AGGREGATES_TABLE);
+  if (!info) {
+    logFallbackFailed(CITY_AGGREGATES_TABLE, 'cnpj_orgao', 'no_manifest');
+    return { ok: false, reason: 'no_manifest' };
+  }
+
+  let conn;
+  try {
+    ({ conn } = await getDuckDB());
+  } catch {
+    logFallbackFailed(CITY_AGGREGATES_TABLE, 'cnpj_orgao', 'duckdb_init_failed');
+    return { ok: false, reason: 'duckdb_init_failed' };
+  }
+
+  const readClause = `read_parquet('${escapeSqlLiteral(info.url)}')`;
+  // SUBSTR is 1-indexed in DuckDB; (cnpj_orgao, 1, 8) returns the raiz.
+  // Filtering NOT NULL avoids a `null` row in the result set when older
+  // partitions still carry rows whose orgão CNPJ wasn't recovered.
+  const sql = `SELECT DISTINCT SUBSTR(cnpj_orgao, 1, 8) AS raiz
+    FROM ${readClause}
+    WHERE cnpj_orgao IS NOT NULL AND LENGTH(cnpj_orgao) >= 8`;
+
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_QUERY_TIMEOUT_MS;
+  let timedOut = false;
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const queryPromise = conn.query(sql);
+  queryPromise.catch(() => null);
+  const timeoutPromise = new Promise<'__timeout__'>((resolve) => {
+    timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      void conn.cancelSent().catch(() => null);
+      resolve('__timeout__');
+    }, Math.max(0, timeoutMs));
+  });
+
+  try {
+    const raced = await Promise.race([queryPromise, timeoutPromise]);
+    if (raced === '__timeout__') {
+      logFallbackFailed(CITY_AGGREGATES_TABLE, 'cnpj_orgao', 'timeout');
+      return { ok: false, reason: 'timeout' };
+    }
+    const raizes = raced
+      .toArray()
+      .map((r: unknown) => {
+        const anyRow = r as { toJSON?: () => unknown };
+        const obj = (typeof anyRow.toJSON === 'function' ? anyRow.toJSON() : r) as { raiz: string };
+        return obj.raiz;
+      })
+      .filter((s) => typeof s === 'string' && /^\d{8}$/.test(s));
+    if (raizes.length === 0) {
+      logFallbackFailed(CITY_AGGREGATES_TABLE, 'cnpj_orgao', 'empty');
+      return { ok: false, reason: 'empty' };
+    }
+    logFallbackServed(CITY_AGGREGATES_TABLE, 'cnpj_orgao', raizes.length);
+    return { ok: true, rows: raizes, dataParticao: info.dataParticao };
+  } catch {
+    if (timedOut) {
+      logFallbackFailed(CITY_AGGREGATES_TABLE, 'cnpj_orgao', 'timeout');
+      return { ok: false, reason: 'timeout' };
+    }
+    logFallbackFailed(CITY_AGGREGATES_TABLE, 'cnpj_orgao', 'sql_error');
+    return { ok: false, reason: 'sql_error' };
+  } finally {
+    if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+  }
+}

--- a/web/src/lib/queryKeys.ts
+++ b/web/src/lib/queryKeys.ts
@@ -18,4 +18,10 @@ export const QUERY_KEYS = {
   // from `busca` because it doesn't share the live PNCP fetch path —
   // colocating them would invalidate cache cross-page on every search.
   cityAggregates: (ibge: string) => ['city-aggregates', ibge] as const,
+  // Distinct cnpj_orgao raizes (8-digit prefix) seen in the latest
+  // contratos parquet — numerator for the /status coverage audit.
+  publishingCnpjRaizes: ['publishing-cnpj-raizes'] as const,
+  // The static reference list of public-administration CNPJ raizes
+  // (denominator, refreshed monthly by build-orgaos-publicos workflow).
+  publicCnpjReference: ['public-cnpj-reference'] as const,
 } as const;

--- a/web/src/pages/status.astro
+++ b/web/src/pages/status.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import RawArchiveStatus from '../components/RawArchiveStatus.svelte';
+import CoverageReport from '../components/CoverageReport.svelte';
 ---
 
 <Layout
@@ -22,6 +23,10 @@ import RawArchiveStatus from '../components/RawArchiveStatus.svelte';
 
     <div class="status-content">
       <RawArchiveStatus client:load />
+    </div>
+
+    <div class="status-content status-content--coverage">
+      <CoverageReport client:visible />
     </div>
   </section>
 </Layout>
@@ -72,5 +77,8 @@ import RawArchiveStatus from '../components/RawArchiveStatus.svelte';
     border-radius: var(--radius-lg) var(--radius-arch) var(--radius-lg) 0;
     border: 1px solid var(--color-border);
     box-shadow: var(--shadow-pool-sm);
+  }
+  .status-content--coverage {
+    margin-top: var(--space-xl);
   }
 </style>


### PR DESCRIPTION
Adiciona auditoria de cobertura na `/status`: comparação entre o universo de CNPJs de órgãos públicos cadastrados na Receita Federal vs. quem efetivamente publica no PNCP.

## Por quê

Hoje a `/status` mostra cobertura **temporal** (range de meses preservado no IA) mas nada **organizacional** — não dá pra responder "qual % dos órgãos públicos brasileiros está publicando no PNCP?" nem "quem deveria estar lá e não está?". O foco escolhido (CNPJ, não município) reflete que o problema de transparência é "órgão X não publica" — uma cidade pequena com pouco contrato é OK, mas uma agência ativa que deveria publicar e não publica é uma falha de transparência.

## Como

**Dois caminhos com responsabilidades opostas, mesmo padrão do WowStrip:**

| Componente | Fonte | Observação |
|---|---|---|
| Numerador (quem publica) | `SELECT DISTINCT SUBSTR(cnpj_orgao, 1, 8)` no parquet `contratos` via DuckDB-WASM in-browser | Sub-segundo após primeiro shard cacheado |
| Denominador (quem deveria publicar) | `web/public/data/cnpj-orgaos-publicos.json` (gerado mensal) | Naturezas jurídicas 1xxx do dump da Receita Federal |

Granularidade de match: **CNPJ raiz (8 dígitos)**. Agrupa unidades subordinadas — a Prefeitura matriz e suas secretarias contam como um ente. Citizens reason about agencies, not unit codes.

## O que ship

### Pipeline ETL (`scripts/build_orgaos_publicos.py`)

uv-style script (segue padrão do `fetch_catmat.py`):
- Descobre o folder mais recente em `arquivos.receitafederal.gov.br/dados/cnpj/dados_abertos_cnpj/`
- Stream-extract dos `Empresas{0..9}.zip` (só esses — pular `Estabelecimentos*.zip` corta ~5x do tempo)
- Filtra por `natureza_juridica` ∈ [1000, 1999]
- Output: `[{raiz, nome, natureza}, ...]` ordenado por raiz, ~30-50k entries, ~3-5 MB raw / ~600KB-1MB gzipped
- Sanity check: aborta se < 1000 entries (proteção contra escrever lixo se a Receita mudar formato)

### Workflow (`.github/workflows/build-orgaos-publicos.yml`)

- Cron: dia 15 de cada mês às 6h UTC (Receita publica nas primeiras semanas; dia 15 dá folga)
- Manual dispatch também
- Concorrência: cancela runs anteriores em fila
- Permissions: `contents: write` (commitar JSON) + `issues: write` (job de report-failure)
- Detecta JSON novo via `git status --porcelain` (cobre untracked + modified) — primeiro run commita o bootstrap
- Falha → abre issue automática (mesmo padrão do `pncp-sync.yml`)

### UI da auditoria (`/status`)

- `parquetFallback.ts:queryPublishingCnpjRaizes()` — segue o padrão do `queryCityAggregates`
- `QUERY_KEYS.publishingCnpjRaizes` + `QUERY_KEYS.publicCnpjReference`
- `CoverageReport.svelte` (~280 linhas) — handles 4 estados explicitamente:
  - **Loading**: skeleton tiles
  - **Reference 404**: banner "ainda não publicado" apontando pro workflow (situação inicial até o primeiro run)
  - **Archive error**: alert
  - **OK**: headline (X de Y, %), tabela por esfera (Federal/Estadual/Municipal/Outras via mapping de naturezas), `<details>` "Ausências notáveis" (até 50 entradas)
- Bundle: `+~6 KB` no entry payload. Budget bumpado 335 → 342 KB com nota.

## O que NÃO ship

- **A própria `cnpj-orgaos-publicos.json`**. O arquivo será populado pelo primeiro run da Action — pode ser disparado manualmente em `Actions → Build public-CNPJ reference → Run workflow` logo após mergear. O page renderiza um banner explícito até lá; não há feature visualmente quebrada.
- **Enrichment por UF/município** dos órgãos. Requer `Estabelecimentos*.zip` da Receita (~5x do tempo de download). Pode ser layer adicional num PR futuro.

## Validação local

- `npm run lint` ✅
- `npm run check:full` ✅ 0 errors
- `npm run test` ✅ 574 passed / 37 skipped
- `npm run build` ✅ bundle 332.1 KB / 342 KB

## Como testar após merge

1. Mergear este PR
2. `Actions tab → Build public-CNPJ reference → Run workflow → main`
3. Esperar ~30-60 min (primeiro run baixa ~1 GB do dump)
4. Action commita `cnpj-orgaos-publicos.json` automaticamente
5. Próximo deploy atualiza Pages
6. Visitar `/status` — seção de cobertura preenchida

https://claude.ai/code/session_01XC6gEr553oPq6mhCEw6BaU