### PR TITLE
fix(web): unbreak Web Build & Lint after #501 + #502

### DIFF
--- a/web/features/journeys/07_auditor_watchdog.feature
+++ b/web/features/journeys/07_auditor_watchdog.feature
@@ -7,16 +7,19 @@ Feature: Journey 7 — Auditor and watchdog
   extraction workflow rebuilds and uploads to Internet Archive.
   See VISION.md → "Auditor / watchdog".
 
-  @green @alerts
+  @planned @alerts
   Scenario: Save the current query as a watch in localStorage
-    # Planned: watch persistence is not implemented. Static-compatible —
-    # localStorage only; no backend state.
+    # Planned: the search results page does not yet expose a "Salvar
+    # vigilância" button. The underlying watchStore.svelte.ts (addWatch /
+    # isWatched / hydrateWatches) is wired and tested via the agency- and
+    # contract-page entry points below; this scenario stays @planned until
+    # the search-results page surfaces the same affordance.
     Given a search result list is visible for "dispensa acima de 1 milhão"
     When the user clicks "Salvar vigilância"
     Then a watch entry is persisted in localStorage
     And the watch appears in the user's "Minhas vigilâncias" list
 
-  @green @rss
+  @planned @rss
   Scenario: Curated RSS feed on Internet Archive publishes new matches
     # Planned: the daily PNCP sync (pncp-sync.yml → ia_uploader) does not
     # yet emit feed-{slug}.xml alongside the monthly parquet. Feeds are for
@@ -28,11 +31,12 @@ Feature: Journey 7 — Auditor and watchdog
     Then the response is a valid RSS 2.0 document
     And each item links to a /contratacao permalink
 
-  @green @diff
+  @planned @diff
   Scenario: Diff view shows what changed since the last visit
-    # Planned: visit-diff is not implemented. Static-compatible — the
-    # client compares the current manifest's data_particao against a
-    # stored snapshot timestamp in localStorage.
+    # Planned: WatchList.svelte renders a "novidades desde sua última
+    # visita" section when a watch row carries a `lastVisited` value, but
+    # there is no dedicated diff-view route yet that surfaces it as a
+    # sectioned page. Stays @planned until that view ships.
     Given the user has previously visited a saved watch
     When the user opens the watch again
     Then the user sees a "novidades desde sua última visita" section listing only new matches

--- a/web/src/components/__steps__/accessibility.steps.ts
+++ b/web/src/components/__steps__/accessibility.steps.ts
@@ -1,6 +1,6 @@
 import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber';
 import { screen, waitFor } from '@testing-library/svelte/pure';
-import { render } from './shared';
+import { render, mockFetchError } from './shared';
 import userEvent from '@testing-library/user-event';
 import { expect, vi } from 'vitest';
 import { tick } from 'svelte';
@@ -59,7 +59,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
         ],
         dataParticao: '2024-01-01',
       });
-      global.fetch = vi.fn().mockResolvedValue(new Response('Error', { status: 503 }));
+      mockFetchError();
 
       // Need a stable container
       const container = document.body.appendChild(document.createElement('div'));

--- a/web/src/components/__steps__/accessibility.steps.ts
+++ b/web/src/components/__steps__/accessibility.steps.ts
@@ -35,24 +35,31 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     Given('a dashboard page with interactive elements', async () => {
       user = userEvent.setup();
 
-      global.fetch = vi.fn().mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            data: [
-              {
-                numeroControlePNCP: '123-1/2024',
-                dataPublicacaoPncp: '2024-01-01T00:00:00',
-                objetoContratacao: 'Test Bid',
-                valorTotalEstimado: 1000,
-                orgaoEntidade: { cnpj: '00000000000191', razaoSocial: 'Órgão Fictício' },
-                municipio: { nome: 'São Paulo', uf: 'SP' },
-                unidadeOrgao: { nomeUnidade: 'Secretaria' }
-              }
-            ]
-          }),
-          { status: 200 }
-        )
-      );
+      // Route through the archive fallback. The live PNCP path would
+      // share its mocked Response across three modality fetches plus the
+      // centroids loader, all racing to consume the same body — only the
+      // first .json() succeeds, the others throw "body stream already
+      // read", and findMunicipalityByIbge cascades into an error state.
+      fallbackMock.mockResolvedValue({
+        ok: true,
+        rows: [
+          {
+            numero_controle_pncp: '123-1/2024',
+            objeto_contrato: 'Test Bid',
+            data_publicacao_pncp: '2024-01-01T00:00:00',
+            valor_global: 1000,
+            cnpj_orgao: '00000000000191',
+            razao_social_orgao: 'Órgão Fictício',
+            uf_sigla: 'SP',
+            municipio_nome: 'São Paulo',
+            codigo_ibge: '3550308',
+            ni_fornecedor: '12345678000100',
+            nome_razao_social_fornecedor: 'Fornecedor X',
+          },
+        ],
+        dataParticao: '2024-01-01',
+      });
+      global.fetch = vi.fn().mockResolvedValue(new Response('Error', { status: 503 }));
 
       // Need a stable container
       const container = document.body.appendChild(document.createElement('div'));

--- a/web/src/components/__steps__/journeys/07_auditor_watchdog.steps.ts
+++ b/web/src/components/__steps__/journeys/07_auditor_watchdog.steps.ts
@@ -1,6 +1,6 @@
 import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber';
-import { noop, plannedStep } from './_shared';
-import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import { noop, plannedStep, render } from './_shared';
+import { screen, fireEvent, waitFor, cleanup } from '@testing-library/svelte/pure';
 import { expect, vi } from 'vitest';
 import { tick } from 'svelte';
 import AgencyDetailViewRaw from '../../AgencyDetailView.svelte';
@@ -24,6 +24,7 @@ const feature = await loadFeature('features/journeys/07_auditor_watchdog.feature
 
 describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
   BeforeEachScenario(() => {
+    cleanup();
     vi.clearAllMocks();
     localStorage.clear();
     fallbackMock.mockResolvedValue({ ok: false, reason: 'empty' });
@@ -64,19 +65,27 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
 
   Scenario('Subscribe to a CNPJ from its agency page', ({ Given, When, Then }) => {
     Given('the user opens "/orgao?cnpj=00000000000191"', async () => {
-      global.fetch = vi.fn().mockResolvedValue(
-        new Response(
-          JSON.stringify([
-            {
-              numeroControlePNCP: '123-1/2024',
-              dataPublicacaoPncp: '2024-01-01',
-              valorTotalEstimado: 1000,
-              orgaoEntidade: { cnpj: '00000000000191', razaoSocial: 'Órgão Fictício' },
-            },
-          ]),
-          { status: 200 }
-        )
-      );
+      // Force the archive fallback path so the agency view is dataReady within
+      // findByRole's 1s default. The bare-array live mock the original test
+      // used races createListQuery's retry/backoff (queryClient.retry=1 with
+      // 1s delay) and times out before the button renders.
+      fallbackMock.mockResolvedValue({
+        ok: true,
+        rows: [
+          {
+            numero_controle_pncp: '00000000000191-1-000001/2024',
+            objeto_contrato: 'Aquisição de teste',
+            data_publicacao_pncp: '2024-01-01T00:00:00',
+            valor_global: 1000,
+            cnpj_orgao: '00000000000191',
+            razao_social_orgao: 'Órgão Fictício',
+            ni_fornecedor: '12345678000100',
+            nome_razao_social_fornecedor: 'Fornecedor X',
+          },
+        ],
+        dataParticao: '2024-01-01',
+      });
+      global.fetch = vi.fn().mockResolvedValue(new Response('Error', { status: 503 }));
       render(AgencyDetailView, { props: { cnpj: '00000000000191' } });
       await tick();
     });
@@ -114,10 +123,10 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
               cnpj_orgao: '12345678000195',
               razao_social_orgao: 'Buyer',
               ni_fornecedor: '98765432000111',
-              nome_razao_social_fornecedor: 'Supplier S.A.'
-            }
+              nome_razao_social_fornecedor: 'Supplier S.A.',
+            },
           ],
-          dataParticao: '2024-01-01'
+          dataParticao: '2024-01-01',
         });
 
         global.fetch = vi.fn().mockResolvedValue(new Response('Error', { status: 503 }));
@@ -132,15 +141,12 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       });
 
       Then('the user is offered a watch form pre-filled with the supplier CNPJ', async () => {
-        // According to our simplification, it's just a button that adds to localStorage directly
         await waitFor(() => {
           expect(screen.getByText('✓ Acompanhando')).toBeInTheDocument();
         });
         const stored = localStorage.getItem('baliza-watches');
         expect(stored).toBeTruthy();
         const watches = JSON.parse(stored!);
-        // Could be 1 or 2 depending on if the previous test's localstorage cleared properly
-        // Let's just check the last one added
         const watch = watches[watches.length - 1];
         expect(watch.type).toBe('supplier');
         expect(watch.filter).toBe('98765432000111');

--- a/web/src/components/__steps__/journeys/07_auditor_watchdog.steps.ts
+++ b/web/src/components/__steps__/journeys/07_auditor_watchdog.steps.ts
@@ -1,5 +1,5 @@
 import { loadFeature, describeFeature } from '@amiceli/vitest-cucumber';
-import { noop, plannedStep, render } from './_shared';
+import { noop, plannedStep, render, mockFetchError } from './_shared';
 import { screen, fireEvent, waitFor, cleanup } from '@testing-library/svelte/pure';
 import { expect, vi } from 'vitest';
 import { tick } from 'svelte';
@@ -85,7 +85,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
         ],
         dataParticao: '2024-01-01',
       });
-      global.fetch = vi.fn().mockResolvedValue(new Response('Error', { status: 503 }));
+      mockFetchError();
       render(AgencyDetailView, { props: { cnpj: '00000000000191' } });
       await tick();
     });
@@ -129,7 +129,7 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
           dataParticao: '2024-01-01',
         });
 
-        global.fetch = vi.fn().mockResolvedValue(new Response('Error', { status: 503 }));
+        mockFetchError();
 
         render(ContractDetailView, { props: { id: '12345678000195-1-000001/2024' } });
         await tick();

--- a/web/src/components/__steps__/journeys/_shared.ts
+++ b/web/src/components/__steps__/journeys/_shared.ts
@@ -1,4 +1,4 @@
-export { render } from '../shared';
+export { render, mockFetchError } from '../shared';
 
 export function plannedStep(description: string): never {
   throw new Error(`planned: ${description} not yet implemented`);

--- a/web/src/components/__steps__/shared.ts
+++ b/web/src/components/__steps__/shared.ts
@@ -42,3 +42,7 @@ export function render(
 ) {
   return tlRender(component as Parameters<typeof tlRender>[0], props);
 }
+
+export function mockFetchError(): void {
+  global.fetch = vi.fn().mockResolvedValue(new Response('Error', { status: 503 }));
+}


### PR DESCRIPTION
## Summary

The Web Build & Lint (Astro 6) check has been failing on `main` since #502 landed. Three independent root causes:

1. **`07_auditor_watchdog.steps.ts`** imported `render/screen` from `@testing-library/svelte` (auto-cleanup) instead of `/pure`. vitest-cucumber runs each Given/When/Then step as its own vitest test, so auto-cleanup wiped the DOM rendered in Given before When could query it. Switched to `/pure` plus an explicit `cleanup()` in `BeforeEachScenario`, matching every other steps file.

2. **Three Journey 7 scenarios were tagged `@green`** but their Then steps still call `plannedStep()`, which throws by contract. Re-tagged "Save the current query as a watch", "Curated RSS feed on IA", and "Diff view shows what changed" as `@planned` so the default vitest exclude (`planned`, `wip`) filters them out. The Subscribe-to-CNPJ and Crossover scenarios stay `@green` because their UI has actually shipped.

3. **Live-PNCP fetch mock collision.** The Subscribe scenario and the focus-states scenario in `accessibility.steps.ts` tried to drive the live PNCP path with a single `Response` that gets multiplexed across three modality fetches plus the centroids loader. After the first `.json()` call the body is locked, the subsequent reads throw "body stream already read", and the views fall into the error state — all within `findByRole`'s 1s default. Routed both tests through the archive fallback (`queryParquetFallback` mock returning `ok: true`), which avoids the body-consumption race and matches the pattern already used in detail-view-fallback / contract-detail tests. `accessibility.steps.ts` also had `objetoContratacao` (the internal field name) where the PNCP schema requires `objetoCompra`.

## Verification

After the fix, locally:
- `npm run test:bdd` — **584 passed, 31 skipped, 30 files**
- `npm run test:contracts` — **10 passed**
- `npm run lint` — **0 errors, 0 warnings**
- `npm run check:full` — Astro check + svelte-check clean (4918 files, 0 errors)

## Test plan

- [ ] Web Build & Lint (Astro 6) goes green
- [ ] No newly skipped tests besides the three Journey 7 scenarios re-tagged `@planned` (their UI hasn't shipped yet — see in-feature comments)
- [ ] Visual smoke check that the Subscribe-to-CNPJ button still flips to "✓ Acompanhando" on `/orgao` and the supplier-watch button still works on `/contratacao`

https://claude.ai/code/session_01ReUzyZyQUMrEXaeUGbCCYb

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReUzyZyQUMrEXaeUGbCCYb)_