### PR TITLE
fix: prevent phantom parquet_url entries in manifest

### DIFF
--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -133,13 +133,16 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
             try:
                 # manifest dates in monthly strategy are strings "YYYY-MM"
                 raw_manifest = uploader._read_manifest_from_ia()
-                # A month is "done" only when its Parquet is on IA (parquet_url non-empty).
-                # Months that went through `mirror` only have raw_zip_url set — they still
-                # need `build` (or `sync`) to produce the Parquet.
+                # A month is "done" only when its Parquet is on IA AND we have a sha256
+                # to prove the upload was confirmed. parquet_url alone is not sufficient:
+                # old manifest-recovery runs wrote the expected URL before the file existed,
+                # leaving entries that 404 and cause the consolidator to skip the whole year.
                 uploaded = {
                     row["data_particao"]
                     for row in raw_manifest
-                    if row.get("data_particao") and row.get("parquet_url")
+                    if row.get("data_particao")
+                    and row.get("parquet_url")
+                    and row.get("sha256")
                 }
                 # Lookup for raw_zip_url by month — used to skip PNCP fetch
                 # when we already have the ZIP on IA for a past month.

--- a/src/baliza/ia_uploader.py
+++ b/src/baliza/ia_uploader.py
@@ -681,7 +681,11 @@ class IAUploader:
             "quarantine_count": q_stats.get("quarantine", 0) if q_stats else 0,
             "ia_item_id": item_id,
             "raw_zip_url": f"https://archive.org/download/{item_id}/raw-{month_str}.zip",
-            "parquet_url": parquet_url,
+            # Only write parquet_url when we confirmed the file was in the upload set.
+            # An empty sha256 means the Parquet was never generated; writing the URL
+            # anyway produces a manifest entry that points to a non-existent file and
+            # causes the consolidator to 404 and the sync to skip the month forever.
+            "parquet_url": parquet_url if parquet_sha256 else "",
             "quarantine_url": f"https://archive.org/download/{item_id}/quarentena-{month_str}.csv"
             if q_stats and q_stats.get("quarantine", 0) > 0
             else "",

--- a/tests/features/sync.feature
+++ b/tests/features/sync.feature
@@ -21,6 +21,15 @@ Feature: Sync a month to Internet Archive
     And the IA upload mock should not have been called
 
   @tier1
+  Scenario: Sync re-queues months whose manifest entry has no sha256
+    Given the IA manifest lists a month with parquet_url but no sha256
+    And PNCP returns a single page of contracts
+    And IA credentials are configured
+    When I run baliza sync without --force-month
+    Then the sync command should exit successfully
+    And the IA upload mock should have been called for item "baliza-pncp-2023-01"
+
+  @tier1
   Scenario: Sync in dry-run mode extracts but does not upload
     Given PNCP returns a single page of contracts
     When I run baliza sync --force-month 2023-01 --dry-run

--- a/tests/step_defs/test_sync.py
+++ b/tests/step_defs/test_sync.py
@@ -92,6 +92,14 @@ def test_sync_skips_uploaded():
 
 @scenario(
     "../features/sync.feature",
+    "Sync re-queues months whose manifest entry has no sha256",
+)
+def test_sync_requeues_phantom_parquet_url():
+    pass
+
+
+@scenario(
+    "../features/sync.feature",
     "Sync in dry-run mode extracts but does not upload",
 )
 def test_sync_dry_run():
@@ -152,9 +160,25 @@ def manifest_lists_every_month(mock_ia_manifest):
                     "data_particao": month,
                     "table_name": RESOURCE_CONTRATOS,
                     "parquet_url": f"https://example.invalid/contratos-{month}.parquet",
+                    "sha256": "a" * 64,
                 }
             )
     mock_ia_manifest(rows)
+
+
+@given("the IA manifest lists a month with parquet_url but no sha256")
+def manifest_lists_phantom_parquet(mock_ia_manifest):
+    # Simulates the historical state where manifest-recovery wrote parquet_url
+    # before the Parquet was actually uploaded (sha256 empty → file never verified).
+    # The sync must treat this month as pending and re-queue it.
+    mock_ia_manifest([
+        {
+            "data_particao": "2023-01",
+            "table_name": "contratos",
+            "parquet_url": "https://archive.org/download/baliza-pncp-2023-01/contratos-2023-01.parquet",
+            "sha256": "",
+        }
+    ])
 
 
 # ── When ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problema

O consolidador anual falhava com HTTP 404 em todos os anos (2022–2025) e logava:
> ⚠ Skipping 2022: one or more source files returned HTTP 404

Causa raiz: duas partes interligadas.

**Bug 1 — `_update_remote_manifest` escrevia `parquet_url` antes de confirmar o upload**

Quando runs de recovery/mirror rodaram, eles ziparam o JSON raw mas não geraram Parquet. O `_update_remote_manifest` ainda assim escrevia o `parquet_url` esperado no manifesto (com `sha256` vazio), criando entradas fantasma apontando para arquivos inexistentes no IA.

**Bug 2 — `cli_simple.py` confiava em `parquet_url` não-vazio como prova de conclusão**

O sync lia essas entradas fantasma, via `parquet_url` preenchida, e marcava o mês como "pronto" — pulando-o. O consolidador então tentava baixar via DuckDB httpfs, recebia 404, e descartava o ano inteiro.

## Fix

1. **`ia_uploader.py::_update_remote_manifest`**: só escreve `parquet_url` quando `sha256` é não-vazio (ou seja, o arquivo existia localmente e foi verificado antes do upload).

2. **`cli_simple.py`**: exige `sha256` não-vazio além de `parquet_url` para considerar um mês "pronto". Isso re-enfileira automaticamente todos os meses fantasma (2023–2025) no próximo sync.

## Efeito imediato

Na próxima execução do `PNCP Sync`, os ~30 meses com `parquet_url` mas `sha256` vazio serão tratados como pendentes e processados (build do Parquet a partir dos ZIPs raw já no IA). Depois disso, o consolidador anual funcionará normalmente.

## Teste adicionado

Novo cenário BDD: *"Sync re-queues months whose manifest entry has no sha256"* — cobre o caso phantom end-to-end.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>