### PR TITLE
docs(plan): PCA → CATMAT pipeline

### DIFF
--- a/docs/plans/pca-catmat-pipeline.md
+++ b/docs/plans/pca-catmat-pipeline.md
@@ -1,0 +1,271 @@
+# Plano: Pipeline PCA → CATMAT
+
+**Status:** proposta para revisão  
+**Escopo:** pipeline Python + Parquet novo + camada web  
+**Estimativa:** 3–4 semanas (pipeline) + 1 semana (web)
+
+---
+
+## Contexto e motivação
+
+O `catmat.json` já tem 13.280 entradas reais do gov.br (10.375 CATMAT + 2.905 CATSER).
+A `CatmatSearch` já funciona como ferramenta de lookup em `/catmat`.
+
+O problema: **nenhum contrato exibido no sistema tem o código CATMAT vinculado**.
+Os endpoints do PNCP que usamos hoje (`/v1/contratacoes/publicacao`, `/v1/contratos`)
+retornam apenas `objetoCompra` em texto livre — sem código de catálogo por item.
+
+O único endpoint PNCP que expõe `codigoItem` (= código CATMAT/CATSER) é o
+**Plano de Contratações Anuais (PCA)** — `/v1/pca/atualizacao`.
+
+---
+
+## Investigação: o que o PCA tem
+
+### Endpoint disponível
+
+```
+GET /v1/pca/atualizacao
+  dataInicio   (required) — ex: 2025-01-01
+  dataFim      (required) — ex: 2025-01-31
+  cnpj         (optional) — filtro por órgão
+  codigoUnidade(optional)
+  pagina       (required, min 1)
+  tamanhoPagina(optional, 10–500)
+```
+
+Resposta: `PaginaRetornoPlanoContratacaoComItensDoUsuarioDTO`
+
+```
+data[]:
+  orgaoEntidade.cnpj
+  orgaoEntidade.razaoSocial
+  unidadeOrgao.codigoUnidade
+  unidadeOrgao.nomeUnidade
+  unidadeOrgao.codigoIbge
+  anoCompra  (ano do PCA)
+  itens[]:
+    codigoItem              ← CATMAT/CATSER code
+    pdmCodigo               ← PDM (Padrão Descritivo de Material)
+    pdmDescricao
+    nomeClassificacaoCatalogo
+    descricaoItem           ← descrição em texto livre
+    quantidadeEstimada
+    valorUnitario
+    valorTotal
+    valorOrcamentoExercicio
+    unidadeFornecimento
+    grupoContratacaoCodigo
+    grupoContratacaoNome
+    classificacaoSuperiorCodigo
+    classificacaoSuperiorNome
+```
+
+### Incerteza a validar antes de implementar
+
+Não temos acesso à rede no ambiente de dev. Precisamos confirmar empiricamente:
+
+1. **`codigoItem` bate com `code` em `catmat.json`?**  
+   A hipótese é que sim (ambos são o código CATMAT/CATSER oficial), mas o formato
+   pode divergir (zero-padded? diferente número de dígitos?).
+
+2. **Cobertura real**: qual % dos itens PCA têm `codigoItem` preenchido?  
+   Muitos órgãos podem não informar o código.
+
+3. **Volume**: quantos itens PCA existem por mês? Necessário para estimar o tamanho
+   do Parquet e o custo de coleta.
+
+**Ação imediata antes de qualquer implementação:**
+```python
+# scripts/probe_pca.py — rodar uma vez, jogar output aqui como comentário
+GET /v1/pca/atualizacao?dataInicio=2025-01-01&dataFim=2025-01-31&pagina=1&tamanhoPagina=500
+→ imprimir: totalRegistros, % codigoItem preenchido, amostra de codigoItem vs catmat.json
+```
+
+---
+
+## Arquitetura proposta
+
+### A. Coletor Python (`src/baliza/pca_extractor.py`)
+
+Seguir o padrão de `extractor.py` (httpx + tenacity retry + structlog):
+
+```python
+async def fetch_pca_month(year: int, month: int) -> list[PcaItemRow]:
+    """Coleta todos os itens PCA publicados/atualizados no mês via /pca/atualizacao."""
+    data_inicio = f"{year}-{month:02d}-01"
+    data_fim    = last_day_of_month(year, month)
+    # página a página, tamanhoPagina=500
+    # para cada PlanoContratacaoComItensDoUsuarioDTO, explode itens
+    # retorna lista plana de PcaItemRow
+```
+
+Schema de saída plano (`PcaItemRow`):
+```
+ano_pca
+cnpj_orgao
+razao_social_orgao
+codigo_unidade
+nome_unidade
+codigo_ibge
+codigo_item       ← CATMAT/CATSER code
+pdm_codigo
+pdm_descricao
+nome_classificacao_catalogo
+descricao_item
+quantidade_estimada
+valor_unitario
+valor_total
+valor_orcamento_exercicio
+unidade_fornecimento
+grupo_contratacao_codigo
+grupo_contratacao_nome
+classificacao_superior_codigo
+classificacao_superior_nome
+data_coleta       ← data de coleta (partition key)
+```
+
+### B. Exportador Parquet (`src/baliza/pca_exporter.py`)
+
+Um Parquet por **ano PCA** (não por data de publicação):
+```
+data/pca/ano_pca=2024/pca_items.parquet
+data/pca/ano_pca=2025/pca_items.parquet
+```
+
+Tamanho estimado: ~50–200 MB por ano (a confirmar na probe).
+
+**Alternativa B2 — Parquet único por ano sem partição Hive:**
+```
+data/pca/pca_2025.parquet  (~50 MB gzipped)
+```
+
+Mais simples para o DuckDB-WASM carregar sem precisar descobrir partições.
+Preferir B2 enquanto o volume for pequeno (< 100 MB).
+
+### C. IA uploader
+
+Adicionar tabela `pca` ao manifest e upload via `ia_uploader.py`.
+Seguir padrão existente de `contratos`.
+
+### D. Web layer
+
+#### D.1 — Schema TypeScript (`web/src/lib/archive/schema.ts`)
+
+```typescript
+export interface ArchivedPcaItem {
+  ano_pca: number;
+  cnpj_orgao: string;
+  razao_social_orgao: string | null;
+  codigo_unidade: string | null;
+  nome_unidade: string | null;
+  codigo_ibge: string | null;
+  codigo_item: string;          // CATMAT/CATSER code
+  pdm_codigo: string | null;
+  pdm_descricao: string | null;
+  nome_classificacao_catalogo: string | null;
+  descricao_item: string | null;
+  quantidade_estimada: number | null;
+  valor_unitario: number | null;
+  valor_total: number | null;
+  unidade_fornecimento: string | null;
+  grupo_contratacao_nome: string | null;
+  classificacao_superior_nome: string | null;
+  data_coleta: string;
+}
+
+// Adicionar 'pca_itens' ao ARCHIVED_TABLES
+```
+
+#### D.2 — Query key (`web/src/lib/queryKeys.ts`)
+
+```typescript
+pcaItens: (codigoItem: string) => ['pca-itens', codigoItem] as const,
+```
+
+#### D.3 — Integração no frontend
+
+**Opção 1 — Inline no `CatmatSearch`:**  
+Ao selecionar um resultado CATMAT, mostrar quantos órgãos planejam comprar aquele
+item (agregado de `pca_itens WHERE codigo_item = $code`). Útil para fornecedor.
+
+**Opção 2 — Página `/pca?codigo=7510`:**  
+Nova página "Demanda planejada" que mostra todos os órgãos com esse item no PCA,
+com valor estimado e quantidade. Heatmap por UF opcional.
+
+**Opção 3 — Enriquecer `ContractDetailView`:**  
+Se o contrato tem `numeroControlePncpCompra`, buscar o PCA associado e mostrar
+quais itens foram planejados (com `codigoItem` resolvido para CATMAT).
+
+Recomendação: **Opção 2 primeiro** (escopo isolado, BDD testável), depois integrar
+nas demais views conforme valor comprovado.
+
+---
+
+## Particionamento e queries DuckDB-WASM
+
+O DuckDB-WASM carrega o arquivo inteiro antes de executar queries — não tem
+pushdown de predicados para arquivos remotos. Portanto:
+
+- **Parquet único por ano** (B2) é melhor que partição Hive: 1 fetch vs N
+- Comprimir com Zstd (DuckDB default): ~60–80% de compressão esperada
+- Arquivos por ano PCA: estimativa pessimista 200 MB raw → ~50 MB Zstd
+- Budget atual do bundle web: 320 KB JS — Parquet fica em IA, não no bundle
+
+Para evitar recarregar o arquivo a cada query, usar o mesmo padrão de
+`parquetFallback.ts`: fetch-once + cache em memória (via DuckDB WASM table).
+
+---
+
+## Estimativa de esforço
+
+| Tarefa | Esforço | Dependências |
+|---|---|---|
+| **Probe script** (`scripts/probe_pca.py`) | 2h | — |
+| **Validação codigoItem vs catmat.json** | 1h | probe |
+| **`PcaItemRow` + `pca_extractor.py`** | 1d | probe |
+| **`pca_exporter.py` + Parquet** | 1d | extractor |
+| **IA uploader + manifest** | 0.5d | exporter |
+| **Schema TS + `ArchivedPcaItem`** | 2h | — |
+| **`queryPcaItems` helper** | 2h | schema |
+| **`/pca` page + BDD scenario** | 2d | helper |
+| **Integração `CatmatSearch`** | 1d | pca page |
+| **CI: refresh PCA mensal** | 0.5d | extractor |
+
+**Total estimado: ~10 dias de trabalho** (não incluindo retrabalhados dependentes
+do resultado da probe).
+
+---
+
+## Riscos e trade-offs
+
+| Risco | Impacto | Mitigação |
+|---|---|---|
+| `codigoItem` não bate com `catmat.json` | Alto — invalidaria toda a cadeia | Rodar probe antes de implementar |
+| Cobertura baixa de `codigoItem` (< 20%) | Médio — feature pouco útil | Mostrar % de cobertura na UI |
+| Volume > 200 MB/ano de Parquet | Médio — DuckDB-WASM lento | Filtrar por ano PCA, lazy-load |
+| PCA endpoint instável / rate-limited | Baixo | Retry com backoff (já no padrão) |
+| Join PCA → contrato não disponível | Alto — dificulta integração futura | Documentar limitação; Opção 2 não depende do join |
+
+---
+
+## Decisões necessárias antes de começar
+
+1. **Rodar `probe_pca.py` primeiro?** (recomendado — valida a hipótese central)
+2. **Escopo inicial do web layer**: Opção 1, 2 ou 3?
+3. **Anos de PCA a coletar**: só 2025 ou histórico desde 2023?
+4. **Parquet único por ano (B2) ou partição Hive (B)?**
+5. **Prioridade relativa aos outros `@planned` de jornada** (`@alerts`, `@changelog`, `@api`)?
+
+---
+
+## Sequência de implementação sugerida
+
+```
+PR 1 (este) — plano (este documento)
+PR 2 — scripts/probe_pca.py + resultado da probe como comentário no PR
+PR 3 — pca_extractor.py + pca_exporter.py + testes unitários Python
+PR 4 — IA uploader + manifest + schema TS + queryPcaItems
+PR 5 — /pca page + BDD @green @catmat-demand
+PR 6 — integração CatmatSearch (Opção 1) se valor confirmado
+```

--- a/docs/plans/pca-catmat-pipeline.md
+++ b/docs/plans/pca-catmat-pipeline.md
@@ -281,6 +281,12 @@ A implementação requer:
   `data_particao.localeCompare`. Para PCA (que não tem mês natural), usar
   `data_particao = f"{ano_pca}-12-31"` em cada linha de manifesto. Sem isso, o
   frontend nunca resolve arquivos PCA (`r.table_name === tableName` é exact match).
+- **`file_type` obrigatório — crítico:** `isCanonicalRow()` em `ia-manifest.ts:89`
+  aceita apenas `!r.file_type` (ausente/vazio) ou `r.file_type === 'monthly_canonical'`.
+  Qualquer outro valor (ex: `"pca_canonical"`) é silenciosamente ignorado pelo resolver
+  e `/pca` retorna sempre `no_manifest`. PCA deve usar `file_type` **vazio/ausente**,
+  ou o PR D da arquitetura (`multi-table-pipeline.md`) deve estender `isCanonicalRow`
+  antes desta implementação. Não introduzir novo `file_type` sem atualizar o resolver.
 - `sort_key` e `bloom_filter_columns` específicos para PCA (sugestão: `codigo_item`)
 - tratar múltiplos tipos de tabela em `_update_remote_manifest`
 
@@ -300,7 +306,7 @@ export interface ArchivedPcaItem {
   // sem codigo_ibge direto — join externo com unidades(codigo_unidade, cnpj_orgao)
   data_publicacao_pncp: string | null;
   data_atualizacao_global_pca: string | null;
-  codigo_item: string;        // CATMAT/CATSER, sempre string
+  codigo_item: string | null;  // CATMAT/CATSER, sempre string se presente; nullable (models.py:32)
   pdm_codigo: string | null;
   pdm_descricao: string | null;
   nome_classificacao_catalogo: string | null;

--- a/docs/plans/pca-catmat-pipeline.md
+++ b/docs/plans/pca-catmat-pipeline.md
@@ -45,8 +45,11 @@ itens[]                 → ver abaixo
 ```
 
 **Nota importante:** não há `codigoIbge`, `ufSigla` nem `municipioNome` no DTO.
-Dados geográficos exigem join externo com a tabela `unidades` (que tem `codigo_ibge`
-via `codigo_unidade`). Qualquer UI de heatmap por UF depende desse join.
+Dados geográficos exigem join externo com a tabela `unidades` — mas a chave da tabela
+`unidades` é composta: `(codigo_unidade, cnpj_orgao)` (ver `UNIDADES_SCHEMA` e
+`GROUP BY codigo_unidade, cnpj_orgao` em `daily_exporter.py:315-325`). Um join só por
+`codigo_unidade` pode associar o `codigo_ibge` errado quando órgãos distintos
+compartilham o mesmo código de unidade. O join correto é sempre pelos dois campos.
 
 ### `PlanoContratacaoItemDTO` (item)
 
@@ -283,7 +286,9 @@ export interface ArchivedPcaItem {
   razao_social_orgao: string | null;
   codigo_unidade: string | null;
   nome_unidade: string | null;
-  // sem codigo_ibge direto — join externo com unidades se necessário
+  // sem codigo_ibge direto — join externo com unidades(codigo_unidade, cnpj_orgao)
+  data_publicacao_pncp: string | null;
+  data_atualizacao_global_pca: string | null;
   codigo_item: string;        // CATMAT/CATSER, sempre string
   pdm_codigo: string | null;
   pdm_descricao: string | null;
@@ -292,6 +297,7 @@ export interface ArchivedPcaItem {
   quantidade_estimada: number | null;
   valor_unitario: number | null;
   valor_total: number | null;
+  valor_orcamento_exercicio: number | null;
   unidade_fornecimento: string | null;
   unidade_requisitante: string | null;
   grupo_contratacao_codigo: string | null;  // manter código E nome (não só nome)

--- a/docs/plans/pca-catmat-pipeline.md
+++ b/docs/plans/pca-catmat-pipeline.md
@@ -125,6 +125,18 @@ destruir zeros à esquerda. Idem no `catmat.ts` frontend (`code: string`).
 
 O resultado da probe define se o plano avança ou precisa ser reescrito.
 
+**Árvore de decisão pós-probe:**
+
+```
+match rate ≥ 70%  → prosseguir com o plano como descrito
+match rate 30–69% → prosseguir, mas UI mostra apenas itens com match confirmado;
+                    campo "código não resolvido" visível para auditoria
+match rate < 30%  → pivot: não usar codigoItem como link para catmat.json;
+                    usar pdmDescricao/nomeClassificacaoCatalogo como texto de busca
+                    (feature de demanda planejada ainda viável, sem resolução CATMAT)
+cobertura < 20%   → reavaliação completa antes de qualquer implementação
+```
+
 ---
 
 ## Arquitetura proposta (sujeita a resultado da probe)
@@ -135,15 +147,27 @@ Reutilizar padrões de retry/cache/validação do `extractor.py`, mas **não reu
 `fetch_page` diretamente** — o endpoint PCA usa `dataInicio`/`dataFim` (não
 `dataInicial`/`dataFinal`) e o flattening é diferente (explode itens do pai para linhas).
 
+Assim como `extractor.py` tem `_flatten_contrato()`, o `pca_extractor.py` precisa
+de `_flatten_pca(pca: dict, item: dict) -> dict` que:
+- converte todos os campos camelCase do DTO para snake_case
+- explode o item aninhado no contexto do PCA pai
+- garante `codigo_item` como `str` (nunca `int`)
+- adiciona `data_coleta` (timestamp de coleta)
+
 ```python
 async def fetch_pca_window(data_inicio: str, data_fim: str) -> list[PcaItemRow]:
     """Coleta e explode itens PCA de uma janela temporal via /pca/atualizacao."""
     # tamanhoPagina=500 (max do endpoint)
     # Para cada PlanoContratacaoComItensDoUsuarioDTO, explode itens em linhas planas
-    # codigoItem → sempre str, nunca int
+    # usando _flatten_pca(pca, item) → codigoItem sempre str, nunca int
+
+def _flatten_pca(pca: dict, item: dict) -> dict:
+    """Achata DTO camelCase para linha snake_case, codigoItem → str."""
+    ...
 ```
 
-Schema plano de saída (`PcaItemRow`) — campo a campo do OpenAPI, snake_case:
+Schema plano de saída (`PcaItemRow`) — campo a campo do OpenAPI, snake_case
+(conversão camelCase → snake_case feita por `_flatten_pca`):
 ```
 id_pca_pncp
 ano_pca
@@ -201,9 +225,24 @@ no nosso stack — não assuma.
 Se não houver pushdown útil, B2 (tabela agregada pequena) sustenta o CatmatSearch
 inline sem baixar arquivo grande; B1 fica para o caso de uso de detalhes por órgão.
 
+### B.1 Exportador anual vs MonthlyExporter
+
+O `MonthlyExporter` existente usa `data_particao` (DATE) como chave de partição e
+`month_dir` como pasta de upload. O PCA exporta por `ano_pca` (int), não por mês —
+portanto **não reutilizar `MonthlyExporter` diretamente**. Criar `PcaExporter` próprio
+que:
+- escreve `pca_{ano}.parquet` com chave de deduplicação `(id_pca_pncp, numero_item)`
+- não tem sentinela `.fetched` por dia (a coleta é incremental por janela de datas)
+- o campo `data_coleta` serve como auditoria, não como partition key
+
 ### C. IA uploader
 
-Adicionar tabela `pca` ao manifest e upload via `ia_uploader.py` (padrão existente).
+Adicionar tabela `pca` ao manifest e upload via `ia_uploader.py`, mas **não é
+plug-and-play**: `MANIFEST_FIELDNAMES` em `ia_uploader.py` é hardcoded para `contratos`.
+A implementação requer:
+- novo tipo de entrada no manifest (`table: "pca"`, `ano_pca: int`, não `data_particao`)
+- `sort_key` e `bloom_filter_columns` específicos para PCA (sugestão: `codigo_item`)
+- tratar múltiplos tipos de tabela em `_update_remote_manifest`
 
 ### D. Web layer
 
@@ -228,11 +267,27 @@ export interface ArchivedPcaItem {
   valor_unitario: number | null;
   valor_total: number | null;
   unidade_fornecimento: string | null;
+  unidade_requisitante: string | null;
+  grupo_contratacao_codigo: string | null;  // manter código E nome (não só nome)
   grupo_contratacao_nome: string | null;
+  classificacao_superior_codigo: string | null;  // idem
   classificacao_superior_nome: string | null;
+  classificacao_catalogo_id: number | null;
+  categoria_item_pca_nome: string | null;
+  data_inclusao: string | null;
+  data_atualizacao: string | null;
+  data_desejada: string | null;
   data_coleta: string;
 }
 ```
+
+**Nota sobre ARCHIVED_TABLES:** é uma lista fechada (closed allowlist) em
+`web/src/lib/archive/schema.ts`. Adicionar `pca_itens` requer alteração em **dois**
+arquivos: `schema.ts` (interface + entrada no array) e `parquetFallback.ts` (tabela
+permitida no `switch` de validação). Não é só adicionar a interface.
+
+**Nota sobre query keys:** `pcaItens` vai no objeto `QUERY_KEYS` em
+`web/src/lib/queryKeys.ts`, não solto.
 
 #### D.2 Página `/pca?codigo=7510` (Opção 2 — escopo inicial)
 

--- a/docs/plans/pca-catmat-pipeline.md
+++ b/docs/plans/pca-catmat-pipeline.md
@@ -164,6 +164,7 @@ valor_unitario
 valor_total
 valor_orcamento_exercicio
 unidade_fornecimento
+unidade_requisitante
 grupo_contratacao_codigo
 grupo_contratacao_nome
 classificacao_superior_codigo

--- a/docs/plans/pca-catmat-pipeline.md
+++ b/docs/plans/pca-catmat-pipeline.md
@@ -1,6 +1,6 @@
 # Plano: Pipeline PCA → CATMAT
 
-**Status:** v2 — incorpora revisão do PR #506  
+**Status:** v4 — data_particao obrigatório, pca_itens normalizado, alavancas de stack  
 **Escopo:** pipeline Python + Parquet novo + camada web  
 **Estimativa:** 2–3 semanas (happy path após probe favorável: ~10 dias)
 
@@ -225,6 +225,14 @@ no nosso stack — não assuma.
 Se não houver pushdown útil, B2 (tabela agregada pequena) sustenta o CatmatSearch
 inline sem baixar arquivo grande; B1 fica para o caso de uso de detalhes por órgão.
 
+**Alavanca de stack já disponível para B2 — `build-data.mjs`:**
+`web/scripts/build-data.mjs` roda DuckDB Node.js em build time, lê arquivos `.qmd`
+de `web/src/queries/` e escreve JSON estático em `public/data/`. Para a tabela
+agregada B2, basta adicionar um `.qmd` com a query de agregação lendo o Parquet do IA
+via `httpfs` — sem DuckDB-WASM no browser. O script já é chamado em `npm run build`
+e `npm run dev`. Nota: o script atual tem um stub de manifesto hardcoded; será
+necessário substituir pela leitura real do manifesto IA para ativar a produção.
+
 ### B.1 Exportador anual vs MonthlyExporter
 
 O `MonthlyExporter` existente usa `data_particao` (DATE) como chave de partição e
@@ -234,13 +242,24 @@ que:
 - escreve `pca_{ano}.parquet` com chave de deduplicação `(id_pca_pncp, numero_item)`
 - não tem sentinela `.fetched` por dia (a coleta é incremental por janela de datas)
 - o campo `data_coleta` serve como auditoria, não como partition key
+- define `PCA_SCHEMA_VERSION = "1.0.0"` (mesmo padrão de `SCHEMA_VERSION = "2.0.0"`
+  em `daily_exporter.py`); bumpar quando colunas mudarem — `builder.py` detecta
+  versões antigas via `parquet_schema_version` e reprocessa automaticamente
+- sort order: `(codigo_item, cnpj_orgao)` + bloom filter em `codigo_item` para
+  pushdown eficiente ao filtrar por código CATMAT no browser ou no build-time
+- usa `BalizaEngine.upsert_rows()` (`engine.py:67`) para dedup — PK
+  `(id_pca_pncp, numero_item)` — não reimplementar a lógica de filter-old+union-new
 
 ### C. IA uploader
 
-Adicionar tabela `pca` ao manifest e upload via `ia_uploader.py`, mas **não é
+Adicionar tabela `pca_itens` ao manifest e upload via `ia_uploader.py`, mas **não é
 plug-and-play**: `MANIFEST_FIELDNAMES` em `ia_uploader.py` é hardcoded para `contratos`.
 A implementação requer:
-- novo tipo de entrada no manifest (`table: "pca"`, `ano_pca: int`, não `data_particao`)
+- novo tipo de entrada no manifest com `table_name: "pca_itens"` — **crítico**:
+  `ia-manifest.ts` valida `data_particao: z.string().min(1)` e ordena as linhas por
+  `data_particao.localeCompare`. Para PCA (que não tem mês natural), usar
+  `data_particao = f"{ano_pca}-12-31"` em cada linha de manifesto. Sem isso, o
+  frontend nunca resolve arquivos PCA (`r.table_name === tableName` é exact match).
 - `sort_key` e `bloom_filter_columns` específicos para PCA (sugestão: `codigo_item`)
 - tratar múltiplos tipos de tabela em `_update_remote_manifest`
 

--- a/docs/plans/pca-catmat-pipeline.md
+++ b/docs/plans/pca-catmat-pipeline.md
@@ -1,114 +1,160 @@
 # Plano: Pipeline PCA → CATMAT
 
-**Status:** proposta para revisão  
+**Status:** v2 — incorpora revisão do PR #506  
 **Escopo:** pipeline Python + Parquet novo + camada web  
-**Estimativa:** 3–4 semanas (pipeline) + 1 semana (web)
+**Estimativa:** 2–3 semanas (happy path após probe favorável: ~10 dias)
 
 ---
 
 ## Contexto e motivação
 
-O `catmat.json` já tem 13.280 entradas reais do gov.br (10.375 CATMAT + 2.905 CATSER).
-A `CatmatSearch` já funciona como ferramenta de lookup em `/catmat`.
+O Baliza tem como objetivo fazer o backup de todos os endpoints públicos do PNCP.
+O PCA (Plano de Contratações Anuais) é um endpoint público documentado no OpenAPI
+do PNCP — portanto está dentro do escopo de coleta independentemente do valor de produto.
 
-O problema: **nenhum contrato exibido no sistema tem o código CATMAT vinculado**.
-Os endpoints do PNCP que usamos hoje (`/v1/contratacoes/publicacao`, `/v1/contratos`)
-retornam apenas `objetoCompra` em texto livre — sem código de catálogo por item.
+O valor de produto adicional: o PCA expõe `codigoItem` (código CATMAT/CATSER) por item
+planejado, transformando o `catmat.json` estático de "lookup de código" em "demanda
+planejada consultável por código".
 
-O único endpoint PNCP que expõe `codigoItem` (= código CATMAT/CATSER) é o
-**Plano de Contratações Anuais (PCA)** — `/v1/pca/atualizacao`.
+Os endpoints que usamos hoje (`/v1/contratacoes/publicacao`, `/v1/contratos`) retornam
+apenas `objetoCompra` em texto livre — sem código de catálogo por item.
+
+> **Aviso de produto obrigatório na UI:** PCA é demanda planejada, não contrato firmado.
+> O Baliza deve deixar explícito: "Esses dados indicam intenção/planejamento informado
+> ao PNCP, não contratação realizada."
 
 ---
 
-## Investigação: o que o PCA tem
+## Schema real do endpoint PCA
 
-### Endpoint disponível
+Baseado no OpenAPI do repo (`docs/openapi/api-pncp-consulta.json`) e em
+`src/baliza/models.py` — não em suposição:
 
-```
-GET /v1/pca/atualizacao
-  dataInicio   (required) — ex: 2025-01-01
-  dataFim      (required) — ex: 2025-01-31
-  cnpj         (optional) — filtro por órgão
-  codigoUnidade(optional)
-  pagina       (required, min 1)
-  tamanhoPagina(optional, 10–500)
-```
-
-Resposta: `PaginaRetornoPlanoContratacaoComItensDoUsuarioDTO`
+### `PlanoContratacaoComItensDoUsuarioDTO` (pai, por PCA)
 
 ```
-data[]:
-  orgaoEntidade.cnpj
-  orgaoEntidade.razaoSocial
-  unidadeOrgao.codigoUnidade
-  unidadeOrgao.nomeUnidade
-  unidadeOrgao.codigoIbge
-  anoCompra  (ano do PCA)
-  itens[]:
-    codigoItem              ← CATMAT/CATSER code
-    pdmCodigo               ← PDM (Padrão Descritivo de Material)
-    pdmDescricao
-    nomeClassificacaoCatalogo
-    descricaoItem           ← descrição em texto livre
-    quantidadeEstimada
-    valorUnitario
-    valorTotal
-    valorOrcamentoExercicio
-    unidadeFornecimento
-    grupoContratacaoCodigo
-    grupoContratacaoNome
-    classificacaoSuperiorCodigo
-    classificacaoSuperiorNome
+idPcaPncp               string  ← chave do PCA
+anoPca                  integer
+orgaoEntidadeCnpj       string
+orgaoEntidadeRazaoSocial string
+codigoUnidade           string
+nomeUnidade             string
+dataPublicacaoPNCP      string
+dataAtualizacaoGlobalPCA string
+itens[]                 → ver abaixo
 ```
 
-### Incerteza a validar antes de implementar
+**Nota importante:** não há `codigoIbge`, `ufSigla` nem `municipioNome` no DTO.
+Dados geográficos exigem join externo com a tabela `unidades` (que tem `codigo_ibge`
+via `codigo_unidade`). Qualquer UI de heatmap por UF depende desse join.
 
-Não temos acesso à rede no ambiente de dev. Precisamos confirmar empiricamente:
+### `PlanoContratacaoItemDTO` (item)
 
-1. **`codigoItem` bate com `code` em `catmat.json`?**  
-   A hipótese é que sim (ambos são o código CATMAT/CATSER oficial), mas o formato
-   pode divergir (zero-padded? diferente número de dígitos?).
-
-2. **Cobertura real**: qual % dos itens PCA têm `codigoItem` preenchido?  
-   Muitos órgãos podem não informar o código.
-
-3. **Volume**: quantos itens PCA existem por mês? Necessário para estimar o tamanho
-   do Parquet e o custo de coleta.
-
-**Ação imediata antes de qualquer implementação:**
-```python
-# scripts/probe_pca.py — rodar uma vez, jogar output aqui como comentário
-GET /v1/pca/atualizacao?dataInicio=2025-01-01&dataFim=2025-01-31&pagina=1&tamanhoPagina=500
-→ imprimir: totalRegistros, % codigoItem preenchido, amostra de codigoItem vs catmat.json
+```
+numeroItem              integer  ← parte da chave primária (ver dedup)
+codigoItem              string   ← CATMAT/CATSER — SEMPRE tratar como string
+pdmCodigo               string
+pdmDescricao            string
+nomeClassificacaoCatalogo string
+descricaoItem           string
+quantidadeEstimada      number
+valorUnitario           number
+valorTotal              number
+valorOrcamentoExercicio number
+unidadeFornecimento     string
+grupoContratacaoCodigo  string
+grupoContratacaoNome    string
+classificacaoSuperiorCodigo string
+classificacaoSuperiorNome   string
+classificacaoCatalogoId integer
+categoriaItemPcaNome    string
+dataInclusao            datetime
+dataAtualizacao         datetime
+dataDesejada            date
 ```
 
 ---
 
-## Arquitetura proposta
+## Deduplicação — decisão necessária antes do Parquet
+
+`/v1/pca/atualizacao` é um fluxo por data de atualização global. O mesmo PCA/item pode
+reaparecer em coletas diferentes se for alterado. O plano precisa de uma regra explícita.
+
+**Chave primária proposta:** `(idPcaPncp, numeroItem)`
+
+**Estratégia de tabela:**
+
+| Opção | Descrição | Prós | Contras |
+|---|---|---|---|
+| **current-state por ano PCA** | última versão de cada `(idPcaPncp, numeroItem)` por `anoPca` | simples de querir, menor volume | perde histórico de alterações |
+| **event-log append-only** | toda ocorrência preservada | histórico completo | dedup na query; volume maior |
+
+**Recomendação:** `current-state por ano PCA` para a primeira feature. Adicionar
+campos de auditoria: `data_publicacao_pncp`, `data_atualizacao_global_pca`,
+`data_inclusao`, `data_atualizacao`, `data_coleta`.
+
+---
+
+## PR 2 — Probe (obrigatório antes de qualquer implementação)
+
+Uma página de um mês não valida a hipótese. A probe deve ser um script Python robusto
+(`scripts/probe_pca.py`) que rode e produza um relatório Markdown/JSON commitado no PR,
+cobrindo:
+
+```
+Janelas a cobrir:
+  2025-01, 2025-06, 2025-12 (ou mês mais recente disponível)
+  + uma janela com cnpj específico de órgão grande (ex: prefeitura SP)
+
+Por janela, extrair:
+  totalRegistros, totalPaginas
+  total de itens explodidos
+  % de itens com codigoItem preenchido
+  % de match exato codigoItem → catmat.json (string, sem conversão)
+  % de match normalizado (strip zeros à esquerda, etc.)
+  exemplos de codigoItem sem match em catmat.json
+  presença/nulidade dos campos críticos (idPcaPncp, numeroItem, anoPca)
+  duplicatas por (idPcaPncp, numeroItem) dentro da janela
+  tamanho médio por página
+  estimativa extrapolada de Parquet por ano (row count × avg row size)
+  verificar se codigoItem tem zeros à esquerda (ex: "07510" vs "7510")
+```
+
+**Regra:** `codigoItem` é sempre string — nunca converter para int, para não
+destruir zeros à esquerda. Idem no `catmat.ts` frontend (`code: string`).
+
+O resultado da probe define se o plano avança ou precisa ser reescrito.
+
+---
+
+## Arquitetura proposta (sujeita a resultado da probe)
 
 ### A. Coletor Python (`src/baliza/pca_extractor.py`)
 
-Seguir o padrão de `extractor.py` (httpx + tenacity retry + structlog):
+Reutilizar padrões de retry/cache/validação do `extractor.py`, mas **não reutilizar
+`fetch_page` diretamente** — o endpoint PCA usa `dataInicio`/`dataFim` (não
+`dataInicial`/`dataFinal`) e o flattening é diferente (explode itens do pai para linhas).
 
 ```python
-async def fetch_pca_month(year: int, month: int) -> list[PcaItemRow]:
-    """Coleta todos os itens PCA publicados/atualizados no mês via /pca/atualizacao."""
-    data_inicio = f"{year}-{month:02d}-01"
-    data_fim    = last_day_of_month(year, month)
-    # página a página, tamanhoPagina=500
-    # para cada PlanoContratacaoComItensDoUsuarioDTO, explode itens
-    # retorna lista plana de PcaItemRow
+async def fetch_pca_window(data_inicio: str, data_fim: str) -> list[PcaItemRow]:
+    """Coleta e explode itens PCA de uma janela temporal via /pca/atualizacao."""
+    # tamanhoPagina=500 (max do endpoint)
+    # Para cada PlanoContratacaoComItensDoUsuarioDTO, explode itens em linhas planas
+    # codigoItem → sempre str, nunca int
 ```
 
-Schema de saída plano (`PcaItemRow`):
+Schema plano de saída (`PcaItemRow`) — campo a campo do OpenAPI, snake_case:
 ```
+id_pca_pncp
 ano_pca
 cnpj_orgao
 razao_social_orgao
-codigo_unidade
+codigo_unidade           ← join com unidades para obter codigo_ibge
 nome_unidade
-codigo_ibge
-codigo_item       ← CATMAT/CATSER code
+data_publicacao_pncp
+data_atualizacao_global_pca
+numero_item
+codigo_item              ← string, nunca int
 pdm_codigo
 pdm_descricao
 nome_classificacao_catalogo
@@ -122,45 +168,57 @@ grupo_contratacao_codigo
 grupo_contratacao_nome
 classificacao_superior_codigo
 classificacao_superior_nome
-data_coleta       ← data de coleta (partition key)
+classificacao_catalogo_id
+categoria_item_pca_nome
+data_inclusao
+data_atualizacao
+data_desejada
+data_coleta              ← timestamp da coleta (adicionado pelo extractor)
 ```
 
-### B. Exportador Parquet (`src/baliza/pca_exporter.py`)
+### B. Estratégia de Parquet (decisão pendente de benchmark)
 
-Um Parquet por **ano PCA** (não por data de publicação):
+**B1 — Parquet único por ano PCA** (proposta inicial):
 ```
-data/pca/ano_pca=2024/pca_items.parquet
-data/pca/ano_pca=2025/pca_items.parquet
-```
-
-Tamanho estimado: ~50–200 MB por ano (a confirmar na probe).
-
-**Alternativa B2 — Parquet único por ano sem partição Hive:**
-```
-data/pca/pca_2025.parquet  (~50 MB gzipped)
+data/pca/pca_2024.parquet
+data/pca/pca_2025.parquet
 ```
 
-Mais simples para o DuckDB-WASM carregar sem precisar descobrir partições.
-Preferir B2 enquanto o volume for pequeno (< 100 MB).
+**B2 — Tabela agregada pequena por código** (sugerida na revisão):
+```
+data/pca/pca_demanda_por_codigo_2025.parquet
+  ano_pca, codigo_item, tipo_catalogo, descricao_catalogo,
+  orgaos_count, unidades_count, quantidade_total, valor_total
+```
+
+**Decisão pendente:** benchmarkar no browser (`read_parquet(url_ia)` via DuckDB-WASM)
+se há range requests / pushdown para filtro `WHERE codigo_item = ?`.
+A documentação do DuckDB menciona pushdown Parquet com HTTP range requests, mas o
+comportamento específico com duckdb-wasm + IA como servidor HTTP precisa ser medido
+no nosso stack — não assuma.
+
+Se não houver pushdown útil, B2 (tabela agregada pequena) sustenta o CatmatSearch
+inline sem baixar arquivo grande; B1 fica para o caso de uso de detalhes por órgão.
 
 ### C. IA uploader
 
-Adicionar tabela `pca` ao manifest e upload via `ia_uploader.py`.
-Seguir padrão existente de `contratos`.
+Adicionar tabela `pca` ao manifest e upload via `ia_uploader.py` (padrão existente).
 
 ### D. Web layer
 
-#### D.1 — Schema TypeScript (`web/src/lib/archive/schema.ts`)
+#### D.1 Schema TypeScript (`web/src/lib/archive/schema.ts`)
 
 ```typescript
 export interface ArchivedPcaItem {
+  id_pca_pncp: string;
+  numero_item: number;
   ano_pca: number;
   cnpj_orgao: string;
   razao_social_orgao: string | null;
   codigo_unidade: string | null;
   nome_unidade: string | null;
-  codigo_ibge: string | null;
-  codigo_item: string;          // CATMAT/CATSER code
+  // sem codigo_ibge direto — join externo com unidades se necessário
+  codigo_item: string;        // CATMAT/CATSER, sempre string
   pdm_codigo: string | null;
   pdm_descricao: string | null;
   nome_classificacao_catalogo: string | null;
@@ -173,99 +231,69 @@ export interface ArchivedPcaItem {
   classificacao_superior_nome: string | null;
   data_coleta: string;
 }
-
-// Adicionar 'pca_itens' ao ARCHIVED_TABLES
 ```
 
-#### D.2 — Query key (`web/src/lib/queryKeys.ts`)
+#### D.2 Página `/pca?codigo=7510` (Opção 2 — escopo inicial)
 
-```typescript
-pcaItens: (codigoItem: string) => ['pca-itens', codigoItem] as const,
-```
+- Lista órgãos/unidades com aquele `codigo_item` no PCA do ano corrente
+- Agrega: total de unidades, quantidade planejada, valor total estimado
+- **Aviso obrigatório:** "Demanda planejada no PCA. Indica intenção, não contrato."
+- BDD scenario `@green @pca-demand` em Journey 1 (fornecedor)
 
-#### D.3 — Integração no frontend
-
-**Opção 1 — Inline no `CatmatSearch`:**  
-Ao selecionar um resultado CATMAT, mostrar quantos órgãos planejam comprar aquele
-item (agregado de `pca_itens WHERE codigo_item = $code`). Útil para fornecedor.
-
-**Opção 2 — Página `/pca?codigo=7510`:**  
-Nova página "Demanda planejada" que mostra todos os órgãos com esse item no PCA,
-com valor estimado e quantidade. Heatmap por UF opcional.
-
-**Opção 3 — Enriquecer `ContractDetailView`:**  
-Se o contrato tem `numeroControlePncpCompra`, buscar o PCA associado e mostrar
-quais itens foram planejados (com `codigoItem` resolvido para CATMAT).
-
-Recomendação: **Opção 2 primeiro** (escopo isolado, BDD testável), depois integrar
-nas demais views conforme valor comprovado.
+Integração com CatmatSearch (Opção 1) e ContractDetailView (Opção 3) ficam para depois
+que o valor da Opção 2 for confirmado.
 
 ---
 
-## Particionamento e queries DuckDB-WASM
+## Anos a coletar
 
-O DuckDB-WASM carrega o arquivo inteiro antes de executar queries — não tem
-pushdown de predicados para arquivos remotos. Portanto:
-
-- **Parquet único por ano** (B2) é melhor que partição Hive: 1 fetch vs N
-- Comprimir com Zstd (DuckDB default): ~60–80% de compressão esperada
-- Arquivos por ano PCA: estimativa pessimista 200 MB raw → ~50 MB Zstd
-- Budget atual do bundle web: 320 KB JS — Parquet fica em IA, não no bundle
-
-Para evitar recarregar o arquivo a cada query, usar o mesmo padrão de
-`parquetFallback.ts`: fetch-once + cache em memória (via DuckDB WASM table).
+Começar por **2025 e 2026** (anos com PCA atualizados e com data de atualizacao global
+disponível a partir de 25/02/2025). Não assumir que o endpoint de atualizacao sirve bem
+para backfill de 2023/2024 sem testar — validar na probe com janelas 2024-Q4/2025-Q1
+para avaliar disponibilidade histórica.
 
 ---
 
 ## Estimativa de esforço
 
-| Tarefa | Esforço | Dependências |
+| Tarefa | Happy path | Estimativa realista |
 |---|---|---|
-| **Probe script** (`scripts/probe_pca.py`) | 2h | — |
-| **Validação codigoItem vs catmat.json** | 1h | probe |
-| **`PcaItemRow` + `pca_extractor.py`** | 1d | probe |
-| **`pca_exporter.py` + Parquet** | 1d | extractor |
-| **IA uploader + manifest** | 0.5d | exporter |
-| **Schema TS + `ArchivedPcaItem`** | 2h | — |
-| **`queryPcaItems` helper** | 2h | schema |
-| **`/pca` page + BDD scenario** | 2d | helper |
-| **Integração `CatmatSearch`** | 1d | pca page |
-| **CI: refresh PCA mensal** | 0.5d | extractor |
+| Probe script + relatório (PR 2) | 0.5d | 1d |
+| `pca_extractor.py` + testes | 1d | 2d |
+| `pca_exporter.py` + Parquet | 1d | 2d |
+| IA uploader + manifest | 0.5d | 1d |
+| Benchmark DuckDB-WASM | — | 0.5d |
+| Schema TS + query helper | 0.5d | 1d |
+| Página `/pca` + BDD | 2d | 3d |
+| CI: refresh PCA mensal | 0.5d | 1d |
+| **Total** | **~6d** | **~11.5d (2–3 semanas)** |
 
-**Total estimado: ~10 dias de trabalho** (não incluindo retrabalhados dependentes
-do resultado da probe).
+Se cobertura/matching da probe forem ruins: replanejar antes da web layer.
 
 ---
 
-## Riscos e trade-offs
+## Riscos
 
 | Risco | Impacto | Mitigação |
 |---|---|---|
-| `codigoItem` não bate com `catmat.json` | Alto — invalidaria toda a cadeia | Rodar probe antes de implementar |
-| Cobertura baixa de `codigoItem` (< 20%) | Médio — feature pouco útil | Mostrar % de cobertura na UI |
-| Volume > 200 MB/ano de Parquet | Médio — DuckDB-WASM lento | Filtrar por ano PCA, lazy-load |
-| PCA endpoint instável / rate-limited | Baixo | Retry com backoff (já no padrão) |
-| Join PCA → contrato não disponível | Alto — dificulta integração futura | Documentar limitação; Opção 2 não depende do join |
+| `codigoItem` não bate com `catmat.json` | Alto | Probe antes de tudo |
+| Cobertura < 20% de `codigoItem` | Médio | Mostrar % cobertura na UI |
+| Zeros à esquerda destruídos por parse int | Alto | Sempre string |
+| DuckDB-WASM baixa arquivo inteiro | Médio | Benchmark; usar tabela agregada se necessário |
+| `/pca/atualizacao` não cobre backfill 2023/2024 | Médio | Testar na probe |
+| UI confunde PCA com contrato real | Alto (produto) | Aviso obrigatório na página |
+| Volume > 200 MB/ano | Médio | Filtrar por ano, lazy-load, tabela agregada |
 
 ---
 
-## Decisões necessárias antes de começar
-
-1. **Rodar `probe_pca.py` primeiro?** (recomendado — valida a hipótese central)
-2. **Escopo inicial do web layer**: Opção 1, 2 ou 3?
-3. **Anos de PCA a coletar**: só 2025 ou histórico desde 2023?
-4. **Parquet único por ano (B2) ou partição Hive (B)?**
-5. **Prioridade relativa aos outros `@planned` de jornada** (`@alerts`, `@changelog`, `@api`)?
-
----
-
-## Sequência de implementação sugerida
+## Sequência de PRs
 
 ```
-PR 1 (este) — plano (este documento)
-PR 2 — scripts/probe_pca.py + resultado da probe como comentário no PR
-PR 3 — pca_extractor.py + pca_exporter.py + testes unitários Python
-PR 4 — IA uploader + manifest + schema TS + queryPcaItems
-PR 5 — /pca page + BDD @green @catmat-demand
-PR 6 — integração CatmatSearch (Opção 1) se valor confirmado
+PR 1 (este) — plano revisado (este documento)
+PR 2 — scripts/probe_pca.py + relatório de cobertura/matching
+PR 3 — pca_extractor.py + pca_exporter.py + testes Python
+         decisão de particionamento baseada em benchmark DuckDB-WASM
+PR 4 — IA uploader + manifest + schema TS + query helper
+PR 5 — /pca?codigo=... page + BDD @green @pca-demand
+PR 6 — integração CatmatSearch (Opção 1) se valor confirmado pela Opção 2
 ```

--- a/docs/plans/pca-catmat-pipeline.md
+++ b/docs/plans/pca-catmat-pipeline.md
@@ -1,8 +1,13 @@
 # Plano: Pipeline PCA → CATMAT
 
-**Status:** v4 — data_particao obrigatório, pca_itens normalizado, alavancas de stack  
+**Status:** v7 — data_particao obrigatório, pca_itens normalizado, alavancas de stack  
 **Escopo:** pipeline Python + Parquet novo + camada web  
 **Estimativa:** 2–3 semanas (happy path após probe favorável: ~10 dias)
+
+> ⚠️ **Pré-requisito:** este plano depende de `docs/plans/multi-table-pipeline.md` (PR #509).
+> Os PRs A–D daquele plano devem ser mergeados antes dos PRs 3–4 deste.
+> Sem o refactoring do `TableContract`, a implementação do PCA reproduz os cinco
+> pontos de acoplamento hard-coded identificados na auto-análise de stack.
 
 ---
 

--- a/docs/plans/pca-catmat-pipeline.md
+++ b/docs/plans/pca-catmat-pipeline.md
@@ -259,6 +259,12 @@ que:
   sintética `pca_row_id = f"{id_pca_pncp}__{numero_item}"` no `_flatten_pca()` e
   passá-la como `pk`. Alternativa: estender `upsert_rows` para aceitar
   `pk: str | list[str]` — mas isso é mudança de contrato do helper existente.
+- **Nulos na PK sintética:** `idPcaPncp` e `numeroItem` são nullable em `models.py`
+  (linhas 242 e 28). Rows com qualquer parte nula colapsam para a mesma chave
+  (ex: `"None__None"`) e `upsert_rows` pode sobrescrever/descartar dados. Requisito:
+  `_flatten_pca()` deve **rejeitar** (quarentena, não silenciar) qualquer row onde
+  `id_pca_pncp` seja `None`/vazio **ou** `numero_item` seja `None`/zero antes de
+  construir `pca_row_id`.
 
 ### C. IA uploader
 

--- a/docs/plans/pca-catmat-pipeline.md
+++ b/docs/plans/pca-catmat-pipeline.md
@@ -243,12 +243,19 @@ que:
 - não tem sentinela `.fetched` por dia (a coleta é incremental por janela de datas)
 - o campo `data_coleta` serve como auditoria, não como partition key
 - define `PCA_SCHEMA_VERSION = "1.0.0"` (mesmo padrão de `SCHEMA_VERSION = "2.0.0"`
-  em `daily_exporter.py`); bumpar quando colunas mudarem — `builder.py` detecta
-  versões antigas via `parquet_schema_version` e reprocessa automaticamente
+  em `daily_exporter.py`); bumpar quando colunas mudarem. **Atenção:** `builder.py`
+  aplica `strptime(part, "%Y-%m")` — strings `"YYYY-12-31"` levantam `ValueError` e
+  são silenciosamente ignoradas (linha 58–60). O auto-reprocessamento do builder
+  **não cobre PCA**; `PcaExporter` precisa implementar sua própria checagem de
+  `parquet_schema_version` ao decidir reexportar.
 - sort order: `(codigo_item, cnpj_orgao)` + bloom filter em `codigo_item` para
   pushdown eficiente ao filtrar por código CATMAT no browser ou no build-time
-- usa `BalizaEngine.upsert_rows()` (`engine.py:67`) para dedup — PK
-  `(id_pca_pncp, numero_item)` — não reimplementar a lógica de filter-old+union-new
+- dedup com PK `(id_pca_pncp, numero_item)` — **atenção:** `BalizaEngine.upsert_rows()`
+  (`engine.py:67`) aceita apenas `pk: str` (coluna única, linha 109:
+  `t_existing[pk].isin(t_new[pk])`). Para usar a lógica existente, criar coluna
+  sintética `pca_row_id = f"{id_pca_pncp}__{numero_item}"` no `_flatten_pca()` e
+  passá-la como `pk`. Alternativa: estender `upsert_rows` para aceitar
+  `pk: str | list[str]` — mas isso é mudança de contrato do helper existente.
 
 ### C. IA uploader
 


### PR DESCRIPTION
## O que é este PR

Apenas o documento de plano — sem código ainda. O objetivo é revisar a estratégia antes de implementar.

## Problema

O `catmat.json` com 13.280 entradas já existe e o `CatmatSearch` funciona. Mas nenhum contrato exibido no sistema tem código CATMAT vinculado. Os endpoints PNCP que usamos hoje (`/v1/contratacoes/publicacao`, `/v1/contratos`) retornam apenas `objetoCompra` em texto livre.

**O único lugar onde `codigoItem` (= código CATMAT) existe é o PCA** — Plano de Contratações Anuais, endpoint `/v1/pca/atualizacao`.

## O que o plano cobre (v4)

- Schema real do endpoint (campos camelCase corretos do OpenAPI, sem suposições)
- Deduplicação: PK `(idPcaPncp, numeroItem)`, estratégia current-state
- `_flatten_pca()` explicitado — espelho de `_flatten_contrato()`
- `PcaExporter` separado do `MonthlyExporter` (anual, não mensal)
- Parquet: sort order `(codigo_item, cnpj_orgao)` + bloom filter; `PCA_SCHEMA_VERSION`
- `BalizaEngine.upsert_rows()` para dedup — não reinventar
- **`build-data.mjs` como alavanca para B2** (agregação em build-time, sem DuckDB-WASM)
- `data_particao = f"{ano_pca}-12-31"` obrigatório no manifest (`ia-manifest.ts` exige `z.string().min(1)`)
- `table_name: "pca_itens"` normalizado em todos os lugares (exact match no frontend)
- Integração com frontend restrita a Opção 2 (`/pca?codigo=`) no escopo inicial
- Estimativa: ~10 dias em 6 PRs; probe obrigatória antes de qualquer código

## Decisões necessárias antes de prosseguir

1. Rodar `probe_pca.py` (PR 2) para validar `codigoItem` vs `catmat.json`?
2. Escopo do web layer: Opção 2 (`/pca?codigo=`) confirma como ponto de entrada?
3. Anos históricos: 2025–2026 primeiro; testar 2023/2024 na probe?
4. Prioridade relativa aos outros `@planned`?

## Arquivo

`docs/plans/pca-catmat-pipeline.md`

https://claude.ai/code/session_01Uhwg477URmu3n8fMEGUoc8