### PR TITLE
fix: serialize manifest writes with a threading.Lock

### DIFF
--- a/src/baliza/ia_uploader.py
+++ b/src/baliza/ia_uploader.py
@@ -5,6 +5,7 @@ import hashlib
 import io
 import shutil
 import tempfile
+import threading
 import zipfile
 from datetime import date, datetime
 from pathlib import Path
@@ -18,6 +19,11 @@ from .engine import BalizaEngine
 from .utils import DUCKDB_PARQUET_COPY_OPTIONS, PARQUET_ROW_GROUP_SIZE
 
 console = Console()
+
+# Serializes all manifest read-modify-write cycles within a process.
+# ThreadPoolExecutor workers share this lock, preventing concurrent writers
+# from overwriting each other's updates to manifest.csv on IA.
+_manifest_lock = threading.Lock()
 
 
 def restore_from_raw_zip(raw_zip_url: str, raw_month_dir: Path) -> bool:
@@ -196,58 +202,59 @@ def register_monthly_uf_shards(
     writing partial rows on top of a read failure would wipe the canonical
     history from the live manifest.
     """
-    year_str = str(year)
-    manifest = read_manifest_from_ia()
-    # Use the latest canonical month already published for this year as the
-    # shard's data_particao. That way the web resolver's
-    # `canonical.dataParticao > shard.dataParticao` freshness check can
-    # detect month-level lag (e.g. canonical 2025-04 vs shards rebuilt when
-    # only 2025-01 was published). Falls back to the year string when no
-    # canonical rows exist yet.
-    canonical_months = [
-        r.get("data_particao", "")
-        for r in manifest
-        if r.get("table_name") == table_name
-        and (r.get("data_particao") or "").startswith(year_str)
-        and r.get("file_type", "") in ("", "monthly_canonical")
-    ]
-    data_particao = max(canonical_months) if canonical_months else year_str
-    # Drop prior monthly_uf rows for this year+table across any partition
-    # value — we're rebuilding every shard, so stale entries from earlier
-    # rebuilds (which may carry a different data_particao) would otherwise
-    # accumulate and mislead readers.
-    manifest = [
-        r
-        for r in manifest
-        if not (
-            r.get("table_name") == table_name
-            and r.get("file_type") == "monthly_uf"
+    with _manifest_lock:
+        year_str = str(year)
+        manifest = read_manifest_from_ia()
+        # Use the latest canonical month already published for this year as the
+        # shard's data_particao. That way the web resolver's
+        # `canonical.dataParticao > shard.dataParticao` freshness check can
+        # detect month-level lag (e.g. canonical 2025-04 vs shards rebuilt when
+        # only 2025-01 was published). Falls back to the year string when no
+        # canonical rows exist yet.
+        canonical_months = [
+            r.get("data_particao", "")
+            for r in manifest
+            if r.get("table_name") == table_name
             and (r.get("data_particao") or "").startswith(year_str)
-        )
-    ]
-    now = datetime.now().isoformat()
-    for s in shards:
-        manifest.append(
-            {
-                "data_particao": data_particao,
-                "table_name": table_name,
-                "row_count": s.get("row_count", 0),
-                "quarantine_count": 0,
-                "ia_item_id": s.get("ia_item_id", ""),
-                "raw_zip_url": "",
-                "parquet_url": s["parquet_url"],
-                "quarantine_url": "",
-                "uploaded_at": now,
-                "file_type": "monthly_uf",
-                "uf_sigla": s["uf_sigla"],
-                "sort_key": _CONTRATOS_SORT_KEY,
-                "row_group_size": PARQUET_ROW_GROUP_SIZE,
-                "bloom_filter_columns": _CONTRATOS_BLOOM_FILTER_COLUMNS,
-                "sha256": s.get("sha256", ""),
-                "file_size_bytes": s.get("file_size_bytes", 0),
-            }
-        )
-    write_manifest_to_ia(manifest, access_key, secret_key)
+            and r.get("file_type", "") in ("", "monthly_canonical")
+        ]
+        data_particao = max(canonical_months) if canonical_months else year_str
+        # Drop prior monthly_uf rows for this year+table across any partition
+        # value — we're rebuilding every shard, so stale entries from earlier
+        # rebuilds (which may carry a different data_particao) would otherwise
+        # accumulate and mislead readers.
+        manifest = [
+            r
+            for r in manifest
+            if not (
+                r.get("table_name") == table_name
+                and r.get("file_type") == "monthly_uf"
+                and (r.get("data_particao") or "").startswith(year_str)
+            )
+        ]
+        now = datetime.now().isoformat()
+        for s in shards:
+            manifest.append(
+                {
+                    "data_particao": data_particao,
+                    "table_name": table_name,
+                    "row_count": s.get("row_count", 0),
+                    "quarantine_count": 0,
+                    "ia_item_id": s.get("ia_item_id", ""),
+                    "raw_zip_url": "",
+                    "parquet_url": s["parquet_url"],
+                    "quarantine_url": "",
+                    "uploaded_at": now,
+                    "file_type": "monthly_uf",
+                    "uf_sigla": s["uf_sigla"],
+                    "sort_key": _CONTRATOS_SORT_KEY,
+                    "row_group_size": PARQUET_ROW_GROUP_SIZE,
+                    "bloom_filter_columns": _CONTRATOS_BLOOM_FILTER_COLUMNS,
+                    "sha256": s.get("sha256", ""),
+                    "file_size_bytes": s.get("file_size_bytes", 0),
+                }
+            )
+        write_manifest_to_ia(manifest, access_key, secret_key)
 
 
 def _sha256(path: Path) -> str:
@@ -344,50 +351,51 @@ class IAUploader:
         Existing fields not present in ``fields`` are preserved (merge, not replace).
         Uses the strict reader — transient read failures abort rather than wipe the live manifest.
         """
-        manifest = read_manifest_from_ia()
-        parquet_item_id = f"baliza-pncp-{month_str}"
+        with _manifest_lock:
+            manifest = read_manifest_from_ia()
+            parquet_item_id = f"baliza-pncp-{month_str}"
 
-        existing_idx: int | None = None
-        for i, row in enumerate(manifest):
-            if (
-                row.get("data_particao") == month_str
-                and row.get("table_name") == "contratos"
-                and row.get("file_type", "") in ("", "monthly_canonical")
-            ):
-                existing_idx = i
-                break
+            existing_idx: int | None = None
+            for i, row in enumerate(manifest):
+                if (
+                    row.get("data_particao") == month_str
+                    and row.get("table_name") == "contratos"
+                    and row.get("file_type", "") in ("", "monthly_canonical")
+                ):
+                    existing_idx = i
+                    break
 
-        now = datetime.now().isoformat()
-        if existing_idx is not None:
-            manifest[existing_idx] = {**manifest[existing_idx], **fields}
-        else:
-            new_row: dict[str, Any] = {
-                "data_particao": month_str,
-                "table_name": "contratos",
-                "row_count": 0,
-                "quarantine_count": 0,
-                "ia_item_id": parquet_item_id,
-                "raw_zip_url": f"https://archive.org/download/{RAW_ITEM_ID}/raw-{month_str}.zip",
-                "parquet_url": "",
-                "quarantine_url": "",
-                "uploaded_at": now,
-                "file_type": "monthly_canonical",
-                "uf_sigla": "",
-                "sort_key": _CONTRATOS_SORT_KEY,
-                "row_group_size": PARQUET_ROW_GROUP_SIZE,
-                "bloom_filter_columns": _CONTRATOS_BLOOM_FILTER_COLUMNS,
-                "sha256": "",
-                "file_size_bytes": 0,
-                "mirror_uploaded_at": "",
-                "raw_zip_sha256": "",
-                "raw_zip_size_bytes": 0,
-                "parquet_uploaded_at": "",
-                "parquet_schema_version": "",
-            }
-            new_row.update(fields)
-            manifest.append(new_row)
+            now = datetime.now().isoformat()
+            if existing_idx is not None:
+                manifest[existing_idx] = {**manifest[existing_idx], **fields}
+            else:
+                new_row: dict[str, Any] = {
+                    "data_particao": month_str,
+                    "table_name": "contratos",
+                    "row_count": 0,
+                    "quarantine_count": 0,
+                    "ia_item_id": parquet_item_id,
+                    "raw_zip_url": f"https://archive.org/download/{RAW_ITEM_ID}/raw-{month_str}.zip",
+                    "parquet_url": "",
+                    "quarantine_url": "",
+                    "uploaded_at": now,
+                    "file_type": "monthly_canonical",
+                    "uf_sigla": "",
+                    "sort_key": _CONTRATOS_SORT_KEY,
+                    "row_group_size": PARQUET_ROW_GROUP_SIZE,
+                    "bloom_filter_columns": _CONTRATOS_BLOOM_FILTER_COLUMNS,
+                    "sha256": "",
+                    "file_size_bytes": 0,
+                    "mirror_uploaded_at": "",
+                    "raw_zip_sha256": "",
+                    "raw_zip_size_bytes": 0,
+                    "parquet_uploaded_at": "",
+                    "parquet_schema_version": "",
+                }
+                new_row.update(fields)
+                manifest.append(new_row)
 
-        write_manifest_to_ia(manifest, access_key, secret_key)
+            write_manifest_to_ia(manifest, access_key, secret_key)
 
     def upload_raw_zip(
         self,
@@ -659,9 +667,8 @@ class IAUploader:
         must abort the publish rather than overwrite the live manifest with
         only the new row.
         """
-        manifest = read_manifest_from_ia()
-
-        # Build new row
+        # Build the new row before acquiring the lock — sha256/size computation
+        # is pure local I/O and doesn't need to be serialized.
         month_str = start_date.strftime("%Y-%m")
         parquet_filename = f"contratos-{month_str}.parquet"
         parquet_url = f"https://archive.org/download/{item_id}/{parquet_filename}"
@@ -700,20 +707,21 @@ class IAUploader:
             "file_size_bytes": parquet_size,
         }
 
-        # Deduplicate only against the canonical row for this partition.
-        # Manifest v2 allows multiple rows per partition (monthly_uf shards,
-        # supplemental dailies); blanket removal would silently drop their
-        # hash/size metadata. Empty/missing file_type is treated as canonical
-        # for v1 backward compat (matches web's isCanonicalRow).
-        manifest = [
-            r
-            for r in manifest
-            if not (
-                r["data_particao"] == month_str
-                and r["table_name"] == "contratos"
-                and r.get("file_type", "") in ("", "monthly_canonical")
-            )
-        ]
-        manifest.append(new_row)
-
-        write_manifest_to_ia(manifest, access_key, secret_key)
+        with _manifest_lock:
+            manifest = read_manifest_from_ia()
+            # Deduplicate only against the canonical row for this partition.
+            # Manifest v2 allows multiple rows per partition (monthly_uf shards,
+            # supplemental dailies); blanket removal would silently drop their
+            # hash/size metadata. Empty/missing file_type is treated as canonical
+            # for v1 backward compat (matches web's isCanonicalRow).
+            manifest = [
+                r
+                for r in manifest
+                if not (
+                    r["data_particao"] == month_str
+                    and r["table_name"] == "contratos"
+                    and r.get("file_type", "") in ("", "monthly_canonical")
+                )
+            ]
+            manifest.append(new_row)
+            write_manifest_to_ia(manifest, access_key, secret_key)


### PR DESCRIPTION
## Problema

O comando `build` usa `ThreadPoolExecutor` com até 8 workers. Cada worker chama `_upsert_manifest_row` (ou `_update_remote_manifest` / `register_monthly_uf_shards`), que faz um ciclo **read-modify-write** no `manifest.csv` do Internet Archive.

Sem sincronização, dois threads em paralelo:
1. Ambos leem a mesma versão do manifesto
2. Ambos adicionam sua entrada
3. O segundo write sobrescreve o primeiro, perdendo a atualização

**Sintoma observado:** backfill de 55 meses com 2 workers resultou em apenas 29 entradas gravadas — ~50% de perda silenciosa.

## Fix

Adiciona um `threading.Lock` em nível de módulo (`_manifest_lock`) que envolve o ciclo read-modify-write nos três métodos que escrevem no manifesto:

- `_upsert_manifest_row` (path `upload_raw_zip` + `upload_parquet`)
- `_update_remote_manifest` (path `upload_month`)
- `register_monthly_uf_shards`

O lock é em nível de módulo (não de instância) para ser compartilhado entre todos os `IAUploader` no mesmo processo. O cálculo de sha256/tamanho em `_update_remote_manifest` foi movido para antes da aquisição do lock, já que é I/O local puro que não precisa de serialização.

## Testes

7/7 passando (`test_sync.py` + `test_consolidate.py`).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>