### PR TITLE
feat: introduce PNCPResource with CONTRATOS (multi-table plan PR C)

### DIFF
--- a/src/baliza/consolidator.py
+++ b/src/baliza/consolidator.py
@@ -19,6 +19,7 @@ import internetarchive as ia
 from rich.console import Console
 
 from .ia_uploader import read_manifest_from_ia, register_monthly_uf_shards
+from .pncp_resources import CONTRATOS
 from .utils import DUCKDB_PARQUET_COPY_OPTIONS
 
 CONSOLIDATED_IA_ITEM = "baliza-pncp-consolidated"
@@ -69,7 +70,7 @@ def _current_year_is_fresh(manifest: list[dict], year: int) -> bool:
     canonical_mtimes: list[datetime.datetime] = []
     shard_mtimes: list[datetime.datetime] = []
     for row in manifest:
-        if row.get("table_name") != "contratos":
+        if row.get("table_name") != CONTRATOS.name:
             continue
         part = row.get("data_particao") or ""
         if not part.startswith(year_str):
@@ -125,7 +126,7 @@ class IAConsolidator:
             file_type = row.get("file_type", "")
             if (
                 (row.get("data_particao") or "").startswith(year_str)
-                and row.get("table_name") == "contratos"
+                and row.get("table_name") == CONTRATOS.name
                 and file_type in ("", "monthly_canonical")
             ):
                 url = row.get("parquet_url") or row.get("file_url")
@@ -271,7 +272,7 @@ class IAConsolidator:
                     ]
                     register_monthly_uf_shards(
                         year=year,
-                        table_name="contratos",
+                        table_name=CONTRATOS.name,
                         shards=shard_rows,
                         access_key=ia_access_key,
                         secret_key=ia_secret_key,

--- a/src/baliza/constants.py
+++ b/src/baliza/constants.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from datetime import date
 
-RESOURCE_CONTRATOS = "contratos"
+from .pncp_resources import CONTRATOS
+
+RESOURCE_CONTRATOS = CONTRATOS.name
 
 # PNCP's contratos endpoint has no data before 2021-09-06. Treat this as
 # immutable product-domain knowledge so backfills never waste runs probing

--- a/src/baliza/daily_exporter.py
+++ b/src/baliza/daily_exporter.py
@@ -19,6 +19,8 @@ import duckdb
 import pyarrow as pa
 from rich.console import Console
 
+from .pncp_resources import CONTRATOS
+
 from .utils import PARQUET_ROW_GROUP_SIZE, validate_identifier, write_optimized_parquet
 
 console = Console()
@@ -175,7 +177,7 @@ class DailyExporter:
         }
 
         with duckdb.connect(str(self.db_path), read_only=True) as con:
-            stats["tables"]["contratos"] = self._export_contratos(con, target_date, day_dir)
+            stats["tables"][CONTRATOS.name] = self._export_contratos(con, target_date, day_dir)
             stats["tables"]["orgaos"] = self._export_orgaos(con, target_date, day_dir)
             stats["tables"]["unidades"] = self._export_unidades(con, target_date, day_dir)
             stats["tables"]["fornecedores"] = self._export_fornecedores(con, target_date, day_dir)
@@ -266,7 +268,7 @@ class DailyExporter:
 
         output_path = output_dir / "contratos.parquet"
         file_size, row_count = write_optimized_parquet(
-            reader, output_path, CONTRATOS_SCHEMA, "contratos"
+            reader, output_path, CONTRATOS_SCHEMA, CONTRATOS.name
         )
         return {"row_count": row_count, "file_size_bytes": file_size}
 

--- a/src/baliza/extractor.py
+++ b/src/baliza/extractor.py
@@ -15,6 +15,8 @@ from pydantic import ValidationError
 from rich.console import Console
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
+from .pncp_resources import CONTRATOS
+
 from .engine import BalizaEngine
 from .models import RecuperarContratoDTO as Contrato
 from .utils import validate_url
@@ -364,9 +366,9 @@ class PNCPExtractor:
         without the snake_case PK. Any lookup error is treated as 'no'."""
         try:
             tables = self.engine.con.list_tables(database="main")
-            if "contratos" not in tables:
+            if CONTRATOS.name not in tables:
                 return False
-            columns = set(self.engine.con.table("contratos", database="main").schema().names)
+            columns = set(self.engine.con.table(CONTRATOS.name, database="main").schema().names)
         except Exception:
             return False
         return "numeroControlePNCP" in columns and "numero_controle_pncp" not in columns
@@ -413,13 +415,13 @@ class PNCPExtractor:
                 except ValidationError as e:
                     stats["quarantine"] += 1
                     logger.warning("validation_failed", error=str(e), entry_id=entry.get("id"))
-                    self.engine.quarantine_record("contratos", start_date, str(e), entry)
+                    self.engine.quarantine_record(CONTRATOS.name, start_date, str(e), entry)
 
             # Ingest valid rows into Ibis (shared engine) via UPSERT
             if valid_rows:
                 # Direct memory ingestion (Idempotent)
                 self.engine.upsert_rows(
-                    valid_rows, "contratos", schema="main", pk="numero_controle_pncp"
+                    valid_rows, CONTRATOS.name, schema="main", pk="numero_controle_pncp"
                 )
 
         return stats

--- a/src/baliza/ia_uploader.py
+++ b/src/baliza/ia_uploader.py
@@ -16,6 +16,7 @@ import internetarchive as ia
 from rich.console import Console
 
 from .engine import BalizaEngine
+from .pncp_resources import CONTRATOS
 from .utils import DUCKDB_PARQUET_COPY_OPTIONS, PARQUET_ROW_GROUP_SIZE
 
 console = Console()
@@ -283,7 +284,7 @@ class MonthlyExporter:
         files: dict[str, Path] = {}
 
         month_str = start_date.strftime("%Y-%m")
-        table_name = "contratos"
+        table_name = CONTRATOS.name
         filename = f"{table_name}-{month_str}.parquet"
         out_path = output_dir / filename
 
@@ -359,7 +360,7 @@ class IAUploader:
             for i, row in enumerate(manifest):
                 if (
                     row.get("data_particao") == month_str
-                    and row.get("table_name") == "contratos"
+                    and row.get("table_name") == CONTRATOS.name
                     and row.get("file_type", "") in ("", "monthly_canonical")
                 ):
                     existing_idx = i
@@ -371,7 +372,7 @@ class IAUploader:
             else:
                 new_row: dict[str, Any] = {
                     "data_particao": month_str,
-                    "table_name": "contratos",
+                    "table_name": CONTRATOS.name,
                     "row_count": 0,
                     "quarantine_count": 0,
                     "ia_item_id": parquet_item_id,
@@ -683,7 +684,7 @@ class IAUploader:
 
         new_row = {
             "data_particao": month_str,
-            "table_name": "contratos",
+            "table_name": CONTRATOS.name,
             "row_count": q_stats.get("valid", 0) if q_stats else 0,
             "quarantine_count": q_stats.get("quarantine", 0) if q_stats else 0,
             "ia_item_id": item_id,
@@ -719,7 +720,7 @@ class IAUploader:
                 for r in manifest
                 if not (
                     r["data_particao"] == month_str
-                    and r["table_name"] == "contratos"
+                    and r["table_name"] == CONTRATOS.name
                     and r.get("file_type", "") in ("", "monthly_canonical")
                 )
             ]

--- a/src/baliza/pncp_resources.py
+++ b/src/baliza/pncp_resources.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class FetchSpec:
+    endpoint: str
+    date_param: str  # e.g., "data_publicacao"
+    paginate_by: str  # e.g., "month"
+
+@dataclass(frozen=True)
+class PNCPResource:
+    name: str  # e.g., "contratos"
+    fetch: FetchSpec
+
+CONTRATOS = PNCPResource(
+    name="contratos",
+    fetch=FetchSpec(
+        endpoint="contratos",
+        date_param="data_publicacao",
+        paginate_by="month",
+    ),
+)


### PR DESCRIPTION
This PR implements PR C of the multi-table pipeline plan.

It introduces the `PNCPResource` and `FetchSpec` abstractions to replace hardcoded strings identifying the resource. A single concrete instance, `CONTRATOS`, has been added to test and enforce this new indirection without changing any pipeline behavior or parity (zero regression constraint maintained).

**Changes:**
- Added `src/baliza/pncp_resources.py` with `FetchSpec` and `PNCPResource` dataclasses.
- Defined the `CONTRATOS` resource explicitly.
- Modified `constants.py`, `ia_uploader.py`, `consolidator.py`, `daily_exporter.py`, and `extractor.py` to use `CONTRATOS.name` instead of the literal string `"contratos"`.
- Verified that all unit, integration, and characterization tests pass as expected.

---
*PR created automatically by Jules for task [7202014114509368952](https://jules.google.com/task/7202014114509368952) started by @franklinbaldo*