### PR TITLE
feat: post-#530 sprint — pytest CI, cassette refresh schedule, município cassette, CATMAT 2-char BDD

### DIFF
--- a/.github/workflows/pncp-cassette-check.yml
+++ b/.github/workflows/pncp-cassette-check.yml
@@ -5,7 +5,10 @@ name: PNCP Cassette Check
 #   2. All cassette-based integration tests pass using only the pre-recorded
 #      YAML files — no live network calls to pncp.gov.br.
 #
-# To refresh cassettes after an API schema change:
+# Weekly schedule (Mondays 06:00 UTC): re-records cassettes and opens a PR
+# if any responses changed — keeps fixtures from going silently stale.
+#
+# To refresh cassettes manually after an API schema change:
 #   uv run python scripts/record_pncp_cassettes.py
 # then commit the updated files in tests/cassettes/pncp/.
 
@@ -24,7 +27,15 @@ on:
       - 'tests/cassettes/**'
       - 'tests/integration/test_pncp_cassettes.py'
       - 'src/**'
+  schedule:
+    # Every Monday at 06:00 UTC — refresh cassettes from the live API.
+    - cron: '0 6 * * 1'
   workflow_dispatch:
+    inputs:
+      refresh_cassettes:
+        description: 'Re-record cassettes from the live PNCP API'
+        type: boolean
+        default: false
 
 jobs:
   cassette-check:
@@ -44,6 +55,34 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-groups --all-extras
 
+      - name: Refresh cassettes (scheduled / manual)
+        # Runs on the weekly cron or when refresh_cassettes=true is set.
+        # Overwrites cassette files with fresh PNCP API responses.
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.refresh_cassettes == 'true')
+        run: uv run python scripts/record_pncp_cassettes.py
+
+      - name: Open PR if cassettes changed after refresh
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.refresh_cassettes == 'true')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet tests/cassettes/; then
+            echo "Cassettes unchanged — no PR needed."
+          else
+            git config user.name  "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            BRANCH="chore/refresh-pncp-cassettes-$(date +%Y-%m-%d)"
+            git checkout -b "$BRANCH"
+            git add tests/cassettes/
+            git commit -m "chore(cassettes): refresh PNCP cassettes $(date +%Y-%m-%d)"
+            git push origin "$BRANCH"
+            gh pr create \
+              --title "chore(cassettes): refresh PNCP cassettes $(date +%Y-%m-%d)" \
+              --body "Automated weekly refresh of PNCP API cassettes. Review the diff to confirm the schema is unchanged before merging." \
+              --base main \
+              --head "$BRANCH"
+          fi
+
       - name: Verify cassette files are present
         run: |
           REQUIRED=(
@@ -51,6 +90,7 @@ jobs:
             tests/cassettes/pncp/publicacao_pregao_page1.yaml
             tests/cassettes/pncp/publicacao_dispensa_page1.yaml
             tests/cassettes/pncp/publicacao_inexigibilidade_page1.yaml
+            tests/cassettes/pncp/publicacao_municipio_pregao_page1.yaml
           )
           missing=()
           for f in "${REQUIRED[@]}"; do

--- a/.github/workflows/pncp-cassette-check.yml
+++ b/.github/workflows/pncp-cassette-check.yml
@@ -58,11 +58,11 @@ jobs:
       - name: Refresh cassettes (scheduled / manual)
         # Runs on the weekly cron or when refresh_cassettes=true is set.
         # Overwrites cassette files with fresh PNCP API responses.
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.refresh_cassettes == 'true')
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && fromJSON(inputs.refresh_cassettes))
         run: uv run python scripts/record_pncp_cassettes.py
 
       - name: Open PR if cassettes changed after refresh
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.refresh_cassettes == 'true')
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && fromJSON(inputs.refresh_cassettes))
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/pncp-cassette-check.yml
+++ b/.github/workflows/pncp-cassette-check.yml
@@ -58,11 +58,11 @@ jobs:
       - name: Refresh cassettes (scheduled / manual)
         # Runs on the weekly cron or when refresh_cassettes=true is set.
         # Overwrites cassette files with fresh PNCP API responses.
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && fromJSON(inputs.refresh_cassettes))
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.refresh_cassettes)
         run: uv run python scripts/record_pncp_cassettes.py
 
       - name: Open PR if cassettes changed after refresh
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && fromJSON(inputs.refresh_cassettes))
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.refresh_cassettes)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,14 @@ jobs:
       - name: Run Linting (Ruff)
         run: uv run ruff check src/ tests/
 
-#      - name: Run V2 Integration Tests
-#        run: uv run python -m unittest tests/test_baliza_v2.py
+      - name: Run Python Tests
+        # Skip integration/test_pncp_cassettes.py — that runs in the dedicated
+        # pncp-cassette-check workflow with its own iptables network block.
+        run: |
+          uv run pytest tests/ \
+            --ignore=tests/integration/test_pncp_cassettes.py \
+            --tb=short \
+            -q
 
       - name: Create test summary
         if: always()
@@ -45,4 +51,3 @@ jobs:
           echo "## Python V2 Test Results 🧪" >> $GITHUB_STEP_SUMMARY
           echo "Status: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
           echo "Python: ${{ matrix.python-version }}" >> $GITHUB_STEP_SUMMARY
-          echo "Engine: Ibis 12.0.0 (Native Path)" >> $GITHUB_STEP_SUMMARY

--- a/scripts/record_pncp_cassettes.py
+++ b/scripts/record_pncp_cassettes.py
@@ -126,6 +126,20 @@ def main() -> None:
                 "tamanhoPagina": 10,
             },
         ),
+        # 5. Municipality filter (São Paulo, IBGE 3550308) — used by LocalBids
+        #    and CompararView when the web UI narrows by city.
+        (
+            "publicacao_municipio_pregao_page1",
+            f"{BASE}/contratacoes/publicacao",
+            {
+                "dataInicial": DATE_INITIAL,
+                "dataFinal": DATE_FINAL,
+                "codigoModalidadeContratacao": 6,
+                "codigoMunicipioIbge": "3550308",
+                "pagina": 1,
+                "tamanhoPagina": 10,
+            },
+        ),
     ]
 
     failed: list[str] = []

--- a/tests/cassettes/pncp/publicacao_municipio_pregao_page1.yaml
+++ b/tests/cassettes/pncp/publicacao_municipio_pregao_page1.yaml
@@ -1,0 +1,70 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Baliza/1.0 (cassette-recorder)
+    method: GET
+    uri: https://pncp.gov.br/api/consulta/v1/contratacoes/publicacao?dataInicial=20250101&dataFinal=20250103&codigoModalidadeContratacao=6&codigoMunicipioIbge=3550308&pagina=1&tamanhoPagina=10
+  response:
+    body:
+      string: '{"data": [{"dataAtualizacao": "2025-01-02T09:04:20", "orgaoEntidade": {"cnpj": "62070362000106", "razaoSocial":
+        "(UO) ESP-CIA.DO METROPOLIT DE SAO PAULO-METRO", "poderId": "E", "esferaId": "E"}, "anoCompra": 2024, "sequencialCompra":
+        586, "numeroCompra": "90597", "processo": "10021391", "objetoCompra": "Fornecimento de válvulas hidráulicas.", "orgaoSubRogado":
+        null, "unidadeOrgao": {"ufNome": "São Paulo", "codigoUnidade": "373301", "ufSigla": "SP", "municipioNome": "São Paulo",
+        "nomeUnidade": "ESP-CIA. METROPOLITANA DE SAO PAULO-METRO", "codigoIbge": "3550308"}, "unidadeSubRogada": null, "valorTotalHomologado":
+        null, "srp": false, "dataInclusao": "2025-01-02T09:04:20", "amparoLegal": {"codigo": 1, "nome": "Lei 14.133/2021,
+        Art. 28, I", "descricao": "pregão: modalidade de licitação obrigatória para aquisição de bens e serviços comuns"},
+        "dataAberturaProposta": "2025-01-03T08:00:00", "dataEncerramentoProposta": "2025-01-21T09:00:00", "informacaoComplementar":
+        "A aquisição deverá ser feita por grupo, portanto, com orçamento para todos os itens do grupo. Para as respostas de
+        esclarecimentos e impugnações deste edital acesse o link: https://cnetmobile.estaleiro.serpro.gov.br/comprasnet-web/public/landing?destino=quadro-informativo&compra=37330105905972024",
+        "linkSistemaOrigem": "https://cnetmobile.estaleiro.serpro.gov.br/comprasnet-web/public/landing?destino=acompanhamento-compra&compra=37330105905972024",
+        "justificativaPresencial": null, "dataPublicacaoPncp": "2025-01-02T09:04:20", "dataAtualizacaoGlobal": "2025-01-31T10:17:41",
+        "numeroControlePNCP": "62070362000106-1-000586/2024", "modalidadeId": 6, "linkProcessoEletronico": null, "modoDisputaId":
+        1, "valorTotalEstimado": 0.0, "modalidadeNome": "Pregão - Eletrônico", "modoDisputaNome": "Aberto", "tipoInstrumentoConvocatorioCodigo":
+        1, "tipoInstrumentoConvocatorioNome": "Edital", "fontesOrcamentarias": [], "situacaoCompraId": 1, "situacaoCompraNome":
+        "Divulgada no PNCP", "usuarioNome": "Compras.gov.br"}, {"dataAtualizacao": "2025-01-02T09:04:52", "orgaoEntidade":
+        {"cnpj": "15519361000116", "razaoSocial": "DEPARTAMENTO ESTADUAL DE TRANSITO", "poderId": "E", "esferaId": "E"}, "anoCompra":
+        2024, "sequencialCompra": 69, "numeroCompra": "90017", "processo": "14000602908202442", "objetoCompra": "Prestação
+        de serviços de manutenção completa de extintores de incêndio, hidrantes e mangueiras, incluindo recargas, testes hidrostáticos
+        e instalação de placas de sinalização, no DETRAN-SP. ", "orgaoSubRogado": null, "unidadeOrgao": {"ufNome": "São Paulo",
+        "codigoUnidade": "532401", "ufSigla": "SP", "municipioNome": "São Paulo", "nomeUnidade": "ESP-DEP. ESTADUAL DE TRANSITO-DETRAN-SP",
+        "codigoIbge": "3550308"}, "unidadeSubRogada": null, "valorTotalHomologado": 89775.0, "srp": false, "dataInclusao":
+        "2025-01-02T09:04:52", "amparoLegal": {"codigo": 1, "nome": "Lei 14.133/2021, Art. 28, I", "descricao": "pregão: modalidade
+        de licitação obrigatória para aquisição de bens e serviços comuns"}, "dataAberturaProposta": "2025-01-02T08:00:00",
+        "dataEncerramentoProposta": "2025-01-16T10:00:00", "informacaoComplementar": "Em caso de eventual divergência entre
+        a descrição do item do catálogo do sistema  Compras.gov.br e as disposições deste Termo de Referência, prevalecem
+        as disposições deste Termo de  Referência. Para as respostas de esclarecimentos e impugnações deste edital acesse
+        o link: https://cnetmobile.estaleiro.serpro.gov.br/comprasnet-web/public/landing?destino=quadro-informativo&compra=53240105900172024",
+        "linkSistemaOrigem": "https://cnetmobile.estaleiro.serpro.gov.br/comprasnet-web/public/landing?destino=acompanhamento-compra&compra=53240105900172024",
+        "justificativaPresencial": null, "dataPublicacaoPncp": "2025-01-02T09:04:52", "dataAtualizacaoGlobal": "2025-01-27T11:59:36",
+        "numeroControlePNCP": "15519361000116-1-000069/2024", "modalidadeId": 6, "linkProcessoEletronico": null, "modoDisputaId":
+        1, "valorTotalEstimado": 214889.63, "modalidadeNome": "Pregão - Eletrônico", "modoDisputaNome": "Aberto", "tipoInstrumentoConvocatorioCodigo":
+        1, "tipoInstrumentoConvocatorioNome": "Edital", "fontesOrcamentarias": [], "situacaoCompraId": 1, "situacaoCompraNome":
+        "Divulgada no PNCP", "usuarioNome": "Compras.gov.br"}, {"dataAtualizacao": "2025-01-02T09:05:31", "orgaoEntidade":
+        {"cnpj": "62070362000106", "razaoSocial": "(UO) ESP-CIA.DO METROPOLIT DE SAO PAULO-METRO", "poderId": "E", "esferaId":
+        "E"}, "anoCompra": 2024, "sequencialCompra": 587, "numeroCompra": "90600", "processo": "10021238", "objetoCompra":
+        "Transdutor de corrente", "orgaoSubRogado": null, "unidadeOrgao": {"ufNome": "São Paulo", "codigoUnidade": "373301",
+        "ufSigla": "SP", "municipioNome": "São Paulo", "nomeUnidade": "ESP-CIA. METROPOLITANA DE SAO PAULO-METRO", "codigoIbge":
+        "3550308"}, "unidadeSubRogada": null, "valorTotalHomologado": 38780.0, "srp": false, "dataInclusao": "2025-01-02T09:05:31",
+        "amparoLegal": {"codigo": 1, "nome": "Lei 14.133/2021, Art. 28, I", "descricao": "pregão: modalidade de licitação
+        obrigatória para aquisição de bens e serviços comuns"}, "dataAberturaProposta": "2025-01-03T08:00:00", "dataEncerramentoProposta":
+        "2025-01-17T09:00:00", "informacaoComplementar": " Para as respostas de esclarecimentos e impugnações deste edital
+        acesse o link: https://cnetmobile.estaleiro.serpro.gov.br/comprasnet-web/public/landing?destino=quadro-informativo&compra=37330105906002024",
+        "linkSistemaOrigem": "https://cnetmobile.estaleiro.serpro.gov.br/comprasnet-web/public/landing?destino=acompanhamento-compra&compra=37330105906002024",
+        "justificativaPresencial": null, "dataPublicacaoPncp": "2025-01-02T09:05:31", "dataAtualizacaoGlobal": "2025-01-21T15:18:46",
+        "numeroControlePNCP": "62070362000106-1-000587/2024", "modalidadeId": 6, "linkProcessoEletronico": null, "modoDisputaId":
+        1, "valorTotalEstimado": 55288.4, "modalidadeNome": "Pregão - Eletrônico", "modoDisputaNome": "Aberto", "tipoInstrumentoConvocatorioCodigo":
+        1, "tipoInstrumentoConvocatorioNome": "Edital", "fontesOrcamentarias": [], "situacaoCompraId": 1, "situacaoCompraNome":
+        "Divulgada no PNCP", "usuarioNome": "Compras.gov.br"}], "totalRegistros": 26, "totalPaginas": 3, "numeroPagina": 1,
+        "paginasRestantes": 2, "empty": false}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+    url: https://pncp.gov.br/api/consulta/v1/contratacoes/publicacao?dataInicial=20250101&dataFinal=20250103&codigoModalidadeContratacao=6&codigoMunicipioIbge=3550308&pagina=1&tamanhoPagina=10
+version: 1

--- a/tests/integration/test_pncp_cassettes.py
+++ b/tests/integration/test_pncp_cassettes.py
@@ -29,6 +29,7 @@ REQUIRED_CASSETTES = [
     "publicacao_pregao_page1.yaml",
     "publicacao_dispensa_page1.yaml",
     "publicacao_inexigibilidade_page1.yaml",
+    "publicacao_municipio_pregao_page1.yaml",
 ]
 
 
@@ -163,6 +164,37 @@ class TestPublicacaoInexigibilidadeSchema:
     def test_data_array(self):
         assert isinstance(self.data["data"], list)
         assert len(self.data["data"]) > 0
+
+
+class TestPublicacaoMunicipioSchema:
+    """Validates the publicacao endpoint filtered by município IBGE code.
+
+    Covers the LocalBids / CompararView use case where the web UI passes
+    codigoMunicipioIbge to narrow results to a specific city.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _data(self):
+        self.data = _cassette_body("publicacao_municipio_pregao_page1.yaml")
+
+    def test_pagination_present(self):
+        assert "totalRegistros" in self.data
+
+    def test_data_array(self):
+        assert isinstance(self.data["data"], list)
+        assert len(self.data["data"]) > 0
+
+    def test_all_records_belong_to_municipality(self):
+        """Every returned record must be from IBGE 3550308 (São Paulo)."""
+        for item in self.data["data"]:
+            ibge = item.get("unidadeOrgao", {}).get("codigoIbge")
+            assert ibge == "3550308", f"Unexpected IBGE code {ibge!r} in municipio-filtered result"
+
+    def test_publicacao_fields(self):
+        item = self.data["data"][0]
+        assert "numeroControlePNCP" in item
+        assert "orgaoEntidade" in item
+        assert "dataPublicacaoPncp" in item
 
 
 # ---------------------------------------------------------------------------

--- a/web/features/journeys/02_public_buyer.feature
+++ b/web/features/journeys/02_public_buyer.feature
@@ -36,6 +36,13 @@ Feature: Journey 2 — Public buyer
     Given the user types "papel sulfite branco A4 75g" into a catalog input
     Then the user sees the most likely CATMAT codes ranked by match confidence
 
+  @green @catmat
+  Scenario: Look up a short CATMAT code by typing its 2-digit number
+    # catmat.json has 83 codes with 1–2 digit codes (e.g. "37" AGENDA).
+    # The search threshold must be ≤ 2 so exact-code lookups are not blocked.
+    Given the user types "37" into a catalog input
+    Then the user sees the CATMAT entry for code "37"
+
   @green @frameworks
   Scenario: Inspect the legal basis cited by peers in similar exemptions
     # Covered by DispensasView at /dispensas?objeto= — paginates modality 8

--- a/web/src/components/__steps__/journeys/02_public_buyer.steps.ts
+++ b/web/src/components/__steps__/journeys/02_public_buyer.steps.ts
@@ -220,6 +220,33 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
     });
   });
 
+  Scenario('Look up a short CATMAT code by typing its 2-digit number', ({ Given, Then }) => {
+    Given('the user types "37" into a catalog input', async () => {
+      cleanup();
+      __setCatmatEntriesForTest([
+        { code: '37', description: 'AGENDA', type: 'CATMAT' },
+        { code: '3700', description: 'PRODUTOS FARMACÊUTICOS', type: 'CATMAT' },
+      ]);
+      render(CatmatSearch);
+      await tick();
+      const input = screen.getByLabelText('Descrição do item para busca CATMAT');
+      await fireEvent.input(input, { target: { value: '37' } });
+      await tick();
+    });
+
+    Then('the user sees the CATMAT entry for code "37"', async () => {
+      await waitFor(
+        () => expect(screen.getByTestId('catmat-results')).toBeTruthy(),
+        { timeout: 2000 },
+      );
+      const items = screen.getAllByTestId('catmat-result-item');
+      expect(items.length).toBeGreaterThan(0);
+      // Exact code match must appear and code "37" must be surfaced.
+      const texts = items.map((el) => el.textContent ?? '');
+      expect(texts.some((t) => t.includes('37'))).toBe(true);
+    });
+  });
+
   Scenario(
     "Crossover with journey 3 — buyer audits a peer's contract before riding on it",
     ({ Given, Then, And }) => {

--- a/web/src/components/__steps__/journeys/02_public_buyer.steps.ts
+++ b/web/src/components/__steps__/journeys/02_public_buyer.steps.ts
@@ -241,9 +241,9 @@ describeFeature(feature, ({ Scenario, BeforeEachScenario }) => {
       );
       const items = screen.getAllByTestId('catmat-result-item');
       expect(items.length).toBeGreaterThan(0);
-      // Exact code match must appear and code "37" must be surfaced.
+      // The exact code "37" must be present — not merely a prefix like "3700".
       const texts = items.map((el) => el.textContent ?? '');
-      expect(texts.some((t) => t.includes('37'))).toBe(true);
+      expect(texts.some((t) => /\b37\b/.test(t))).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Five improvements in one shot, all from the post-#530 sprint plan:

- **Enable pytest suite in CI** — `test.yml` now runs all 117 Python tests; cassette tests are excluded since they live in the dedicated `pncp-cassette-check` workflow
- **Weekly cassette refresh** — `pncp-cassette-check.yml` gains a Monday 06:00 UTC cron that re-records cassettes from the live API and opens a PR if any response changed; also adds a `refresh_cassettes` manual dispatch input
- **Municipality filter cassette** — new `publicacao_municipio_pregao_page1.yaml` covering `codigoMunicipioIbge=3550308` (São Paulo) + pregão; includes a `test_all_records_belong_to_municipality` assertion to catch if the API ever ignores the filter; 22 cassette tests total
- **Recording script updated** — `scripts/record_pncp_cassettes.py` includes the município endpoint so the weekly refresh captures it too
- **CATMAT 2-char BDD `@green`** — new scenario "Look up a short CATMAT code by typing its 2-digit number"; validates the threshold fix from #530 (83 real 1-2 digit CATMAT codes exist, e.g. code `37` = AGENDA)

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration/test_pncp_cassettes.py -q` → 117 passed
- [x] `uv run pytest tests/integration/test_pncp_cassettes.py -q` → 22 passed
- [x] Web vitest — 591 passed (new CATMAT 2-char scenario ✓), 24 skipped
- [x] `uv run ruff check src/ tests/` → clean
- [x] `npm run lint` (web) → clean

https://claude.ai/code/session_01Uhwg477URmu3n8fMEGUoc8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uhwg477URmu3n8fMEGUoc8)_