### PR TITLE
Tighten semantics; extract HubHeader and Skeleton components

### DIFF
--- a/web/src/components/AgencyDetailView.svelte
+++ b/web/src/components/AgencyDetailView.svelte
@@ -203,7 +203,7 @@
   {#snippet metaRow()}
     {#if data}
       <small>CNPJ: <code>{data.cnpj}</code></small>
-      <small>Fonte: <mark>{data.archived ? 'Arquivo Parquet (IA)' : 'PNCP V1'}</mark></small>
+      <small>Fonte: <span data-badge>{data.archived ? 'Arquivo Parquet (IA)' : 'PNCP V1'}</span></small>
     {/if}
   {/snippet}
 

--- a/web/src/components/AtasView.svelte
+++ b/web/src/components/AtasView.svelte
@@ -12,6 +12,8 @@
   import { resolve } from '../lib/baseUrl';
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
+  import HubHeader from './HubHeader.svelte';
+  import Skeleton from './Skeleton.svelte';
 
   setQueryClientContext(getQueryClient());
 
@@ -83,15 +85,11 @@
 </script>
 
 <section>
-  <header>
-    <hgroup>
-      <small><mark>📒 ATAS VIGENTES</mark></small>
-      <h1>Atas de Registro de Preços</h1>
-      <p>
-        Busca contratos vigentes cujo objeto corresponde ao termo pesquisado. Fonte: arquivo Parquet (IA).
-      </p>
-    </hgroup>
-  </header>
+  <HubHeader kicker="📒 Atas vigentes" title="Atas de Registro de Preços">
+    {#snippet lede()}
+      <p>Busca contratos vigentes cujo objeto corresponde ao termo pesquisado. Fonte: arquivo Parquet (IA).</p>
+    {/snippet}
+  </HubHeader>
 
   <form role="search" onsubmit={handleSubmit}>
     <label for="atas-objeto-input" class="sr-only">Objeto a pesquisar</label>
@@ -111,9 +109,7 @@
       message="Use ao menos 3 caracteres para buscar atas vigentes pelo objeto contratado."
     />
   {:else if loading}
-    <article aria-busy="true" class="is-skeleton" aria-label="Buscando atas vigentes">
-      <p>&nbsp;</p><p>&nbsp;</p><p>&nbsp;</p>
-    </article>
+    <Skeleton label="Buscando atas vigentes" rows={3} />
   {:else if error}
     <AlertBanner title="Não foi possível buscar as atas" message={error.message} level="error" />
   {:else if rows.length === 0}

--- a/web/src/components/BuscaView.svelte
+++ b/web/src/components/BuscaView.svelte
@@ -20,6 +20,8 @@
   } from '../lib/searchFilters';
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
+  import HubHeader from './HubHeader.svelte';
+  import Skeleton from './Skeleton.svelte';
   import PaginatedList from './PaginatedList.svelte';
   import { addWatch, isWatched, hydrateWatches } from '../lib/watchStore.svelte';
 
@@ -302,21 +304,19 @@
 </script>
 
 <section>
-  <header>
-    <hgroup>
-      <small><mark>🔎 BUSCA LIVRE</mark></small>
-      <h1>Busca livre no PNCP</h1>
+  <HubHeader kicker="🔎 Busca livre" title="Busca livre no PNCP">
+    {#snippet lede()}
       <p>
         Busca texto-livre nas contratações publicadas no PNCP nos últimos 365 dias.
         Informe também um número de controle PNCP (<code>cnpj-tipo-sequencial/ano</code>)
         para ir direto ao contrato.
       </p>
-    </hgroup>
-  </header>
+    {/snippet}
+  </HubHeader>
 
   <form role="search" onsubmit={handleSubmit}>
-    <fieldset>
-      <label for="busca-input" class="sr-only">Termo a pesquisar</label>
+    <label for="busca-input" class="sr-only">Termo a pesquisar</label>
+    <div role="group" aria-label="Buscar contratações">
       <input
         id="busca-input"
         type="search"
@@ -325,11 +325,12 @@
         aria-label="Termo a pesquisar"
       />
       <button type="submit">Buscar</button>
-    </fieldset>
+    </div>
 
     <details open={draftHasAny}>
       <summary>Filtros Avançados (API do PNCP)</summary>
       <fieldset class="grid">
+        <legend class="sr-only">Filtros avançados de busca no PNCP</legend>
         {#each Object.values(FILTERS) as def (def.key)}
           <label>
             {def.label}
@@ -346,9 +347,7 @@
       message="Use ao menos 3 caracteres no termo ou preencha um filtro avançado para buscar."
     />
   {:else if loading}
-    <article aria-busy="true" class="is-skeleton" aria-label="Buscando contratações">
-      <p>&nbsp;</p><p>&nbsp;</p><p>&nbsp;</p><p>&nbsp;</p>
-    </article>
+    <Skeleton label="Buscando contratações" rows={4} />
   {:else if error}
     <AlertBanner title="Não foi possível buscar" message={error.message} level="error" />
   {:else if results.length === 0}
@@ -368,6 +367,7 @@
     {/if}
   {:else}
     <fieldset data-testid="busca-filters" class="grid">
+      <legend class="sr-only">Refinar resultados visíveis</legend>
       <label>
         UF
         <select bind:value={selectedUf} aria-label="Filtrar por UF" data-testid="busca-filter-uf">
@@ -420,7 +420,7 @@
                   <a href={linkFor(c)}>
                     <header>
                       <strong>{c.orgaoEntidade?.razaoSocial ?? 'Órgão'}</strong>
-                      <small><mark>{c.modalidadeNome ?? ''}</mark></small>
+                      <small data-badge>{c.modalidadeNome ?? ''}</small>
                     </header>
                     <p title={c.objetoContratacao}>{truncate(c.objetoContratacao, 180)}</p>
                     <footer>

--- a/web/src/components/CatmatSearch.svelte
+++ b/web/src/components/CatmatSearch.svelte
@@ -51,7 +51,7 @@
       {#each results as entry (entry.type + ':' + entry.code)}
         <li data-testid="catmat-result-item" role="option" aria-selected="false">
           <code>{entry.code}</code>
-          <small><mark>{entry.type}</mark></small>
+          <small data-badge>{entry.type}</small>
           <p>{entry.description}</p>
         </li>
       {/each}

--- a/web/src/components/CityDetailView.svelte
+++ b/web/src/components/CityDetailView.svelte
@@ -118,7 +118,7 @@
   {#snippet metaRow()}
     {#if data}
       <small>Cód. IBGE: <code>{data.ibge}</code></small>
-      <small>Fonte: <mark>{data.archived ? 'Arquivo Parquet (IA)' : 'PNCP V1'}</mark></small>
+      <small>Fonte: <span data-badge>{data.archived ? 'Arquivo Parquet (IA)' : 'PNCP V1'}</span></small>
     {/if}
   {/snippet}
 

--- a/web/src/components/CityHero.svelte
+++ b/web/src/components/CityHero.svelte
@@ -59,7 +59,7 @@
 <section aria-labelledby="city-hero-title">
   <header>
     <hgroup>
-      <small><mark>Painel cívico · O que é o Baliza?</mark></small>
+      <p class="eyebrow">Painel cívico · O que é o Baliza?</p>
       <h1 id="city-hero-title">
         O que <em>{cityState.nome}{cityState.uf ? ` / ${cityState.uf}` : ''}</em> está comprando?
       </h1>
@@ -73,7 +73,7 @@
     {#if cityState.source !== 'default'}
       <input type="hidden" name="ibge" value={cityState.ibge} />
     {/if}
-    <fieldset>
+    <div role="group">
       <input
         type="search"
         name="q"
@@ -83,7 +83,7 @@
         aria-label="Buscar no PNCP"
       />
       <button type="submit">Buscar</button>
-    </fieldset>
+    </div>
   </form>
 
   <div role="group" class="actions">

--- a/web/src/components/CityPicker.svelte
+++ b/web/src/components/CityPicker.svelte
@@ -130,7 +130,7 @@
     {/if}
   </header>
 
-  <fieldset>
+  <div role="group" aria-label="Buscar município">
     <input
       type="search"
       role="combobox"
@@ -149,7 +149,7 @@
     <button type="button" class="outline" onclick={useMyLocation} disabled={geoStatus === 'locating'} aria-busy={geoStatus === 'locating'} aria-label="Usar minha localização atual">
       {geoStatus === 'locating' ? 'Buscando…' : '📍 minha localização'}
     </button>
-  </fieldset>
+  </div>
 
   {#if loading}
     <small aria-live="polite" aria-busy="true">Buscando municípios…</small>

--- a/web/src/components/CityWowStrip.svelte
+++ b/web/src/components/CityWowStrip.svelte
@@ -10,6 +10,7 @@
     prefetchArchive,
     type CityArchiveAggregates,
   } from '../lib/parquetFallback';
+  import Skeleton from './Skeleton.svelte';
 
   setQueryClientContext(getQueryClient());
   hydrateCityContext();
@@ -71,7 +72,7 @@
     <div class="grid">
       {#if loading}
         {#each [1, 2, 3, 4] as _, col (col)}
-          <article aria-busy="true" class="is-skeleton"><p>&nbsp;</p><p>&nbsp;</p></article>
+          <Skeleton />
         {/each}
       {:else if data}
         <article>

--- a/web/src/components/CompararView.svelte
+++ b/web/src/components/CompararView.svelte
@@ -6,6 +6,8 @@
 
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
+  import HubHeader from './HubHeader.svelte';
+  import Skeleton from './Skeleton.svelte';
 
   setQueryClientContext(getQueryClient());
 
@@ -90,26 +92,24 @@
 </script>
 
 <section>
-  <header>
-    <hgroup>
-      <small><mark>🌍 COMPARAR</mark></small>
-      <h1>Comparação de Municípios</h1>
+  <HubHeader kicker="🌍 Comparar" title="Comparação de Municípios">
+    {#snippet lede()}
       <p>Gastos per-capita e comparação com municípios do mesmo porte.</p>
-    </hgroup>
-  </header>
+    {/snippet}
+  </HubHeader>
 
   <form role="search" onsubmit={handleSubmit}>
-    <fieldset>
+    <div role="group" aria-label="Comparar municípios">
       <input type="text" bind:value={searchIbge} placeholder="Código IBGE (ex: 3550308)" aria-label="Código IBGE" />
       <input type="text" bind:value={searchObjeto} placeholder="Objeto (ex: merenda)" aria-label="Objeto" />
       <button type="submit">Comparar</button>
-    </fieldset>
+    </div>
   </form>
 
   {#if (!submittedIbge || submittedIbge.length !== 7) || (!submittedObjeto || submittedObjeto.length < 3)}
     <EmptyState title="Preencha os campos" message="Informe o IBGE (7 dígitos) e o objeto para comparar." />
   {:else if loading}
-    <article aria-busy="true" class="is-skeleton" aria-label="Buscando dados"><p>&nbsp;</p></article>
+    <Skeleton label="Buscando dados" rows={1} />
   {:else if error}
     <AlertBanner title="Não foi possível buscar dados" message={error.message} level="error" />
   {:else}

--- a/web/src/components/ContractDetailView.svelte
+++ b/web/src/components/ContractDetailView.svelte
@@ -118,7 +118,7 @@
       <small>Publicação: {formatDate(data.dataPublicacaoPncp)}</small>
       {#if effectiveSnapshot}
         <small data-testid="snapshot-date">
-          Snapshot: <mark><time datetime={effectiveSnapshot}>{formatParticao(effectiveSnapshot)}</time></mark>
+          Snapshot: <time datetime={effectiveSnapshot} data-badge>{formatParticao(effectiveSnapshot)}</time>
         </small>
       {/if}
     {/if}

--- a/web/src/components/CoverageReport.svelte
+++ b/web/src/components/CoverageReport.svelte
@@ -5,6 +5,7 @@
   import { resolve } from '../lib/baseUrl';
   import { formatInteger, formatParticao } from '../lib/format';
   import { queryPublishingCnpjRaizes } from '../lib/parquetFallback';
+  import Skeleton from './Skeleton.svelte';
 
   setQueryClientContext(getQueryClient());
 
@@ -158,7 +159,7 @@
       </p>
     </article>
   {:else if loading && !stats}
-    <article aria-busy="true" class="is-skeleton"><p>&nbsp;</p><p>&nbsp;</p><p>&nbsp;</p></article>
+    <Skeleton rows={3} />
   {:else if stats}
     <article>
       <hgroup>

--- a/web/src/components/Dashboard.svelte
+++ b/web/src/components/Dashboard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import StatCard from './StatCard.svelte';
   import AlertBanner from './AlertBanner.svelte';
+  import Skeleton from './Skeleton.svelte';
   import { SyncStatsSchema, type SyncStats } from '../schema';
   import { formatInteger, formatRelativeTime } from '../lib/format';
   import { resolve } from '../lib/baseUrl';
@@ -36,7 +37,7 @@
 {:else if loading}
   <div class="grid" aria-busy="true" aria-label="Carregando estatísticas">
     {#each [1, 2, 3] as _, i (i)}
-      <article aria-busy="true" class="is-skeleton"><p>&nbsp;</p><p>&nbsp;</p></article>
+      <Skeleton />
     {/each}
   </div>
 {:else if stats}

--- a/web/src/components/DispensasView.svelte
+++ b/web/src/components/DispensasView.svelte
@@ -6,6 +6,8 @@
   import type { PNCPContract } from '../lib/pncp';
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
+  import HubHeader from './HubHeader.svelte';
+  import Skeleton from './Skeleton.svelte';
 
   setQueryClientContext(getQueryClient());
 
@@ -69,26 +71,24 @@
 </script>
 
 <section>
-  <header>
-    <hgroup>
-      <small><mark>⚖️ DISPENSAS</mark></small>
-      <h1>Dispensas — Bases Legais</h1>
+  <HubHeader kicker="⚖️ Dispensas" title="Dispensas — Bases Legais">
+    {#snippet lede()}
       <p>Quais artigos da lei são mais citados em dispensas similares. Fonte: API PNCP, modalidade 8 (Dispensa).</p>
-    </hgroup>
-  </header>
+    {/snippet}
+  </HubHeader>
 
   <form role="search" onsubmit={handleSubmit}>
     <label for="dispensas-objeto-input" class="sr-only">Objeto a pesquisar</label>
-    <fieldset>
+    <div role="group" aria-label="Buscar dispensas">
       <input id="dispensas-objeto-input" type="search" bind:value={searchInput} placeholder="Ex.: papel A4, manutenção de veículos..." aria-label="Objeto a pesquisar" />
       <button type="submit">Buscar</button>
-    </fieldset>
+    </div>
   </form>
 
   {#if !submittedObjeto || submittedObjeto.length < 3}
     <EmptyState title="Digite o objeto da dispensa" message="Use ao menos 3 caracteres para ver os artigos legais mais citados em dispensas similares." />
   {:else if loading}
-    <article aria-busy="true" class="is-skeleton" aria-label="Buscando dispensas"><p>&nbsp;</p><p>&nbsp;</p></article>
+    <Skeleton label="Buscando dispensas" />
   {:else if error}
     <AlertBanner title="Não foi possível buscar dispensas" message={error.message} level="error" />
   {:else if citations.length === 0}
@@ -98,7 +98,7 @@
       {#each citations as cit (cit.article)}
         <article data-testid="dispensas-legal-item">
           <header>
-            <small><mark>{cit.count} contrato{cit.count > 1 ? 's' : ''}</mark></small>
+            <small data-badge>{cit.count} contrato{cit.count > 1 ? 's' : ''}</small>
             <h2><code>{cit.article}</code></h2>
           </header>
           <ul>

--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -190,7 +190,7 @@
         </div>
       </details>
 
-      <fieldset data-editor-zone>
+      <div data-editor-zone role="group" aria-label="Editor de consulta">
         <label>
           <span class="sr-only">Consulta SQL</span>
           <textarea bind:value={query} spellcheck="false" aria-label="Consulta SQL" rows="6"></textarea>
@@ -203,7 +203,7 @@
         <button onclick={runQuery} disabled={loading || hasUnresolvedUrl} aria-busy={loading}>
           {loading ? "Executando..." : "Explorar Dados"}
         </button>
-      </fieldset>
+      </div>
 
       {#if error}
         <AlertBanner title="Erro SQL" message={error} level="error" />

--- a/web/src/components/EntityDetailLayout.svelte
+++ b/web/src/components/EntityDetailLayout.svelte
@@ -3,6 +3,7 @@
   import { resolve } from '../lib/baseUrl';
   import EntityNotFound from './EntityNotFound.svelte';
   import AlertBanner from './AlertBanner.svelte';
+  import Skeleton from './Skeleton.svelte';
 
   interface Props {
     id?: string;
@@ -58,9 +59,7 @@
 {:else if !idValid}
   <EntityNotFound id={id} type={entityType} error={idFormatError} />
 {:else if loading}
-  <article aria-busy="true" class="is-skeleton" aria-label={`Carregando dados do ${entityType}`}>
-    {#each [1, 2, 3, 4, 5] as _, i (i)}<p>&nbsp;</p>{/each}
-  </article>
+  <Skeleton label={`Carregando dados do ${entityType}`} rows={5} />
 {:else if error}
   <article data-invalid="true">
     <AlertBanner title={errorTitle || defaultErrorTitle} message={error.message} level="error" />
@@ -72,7 +71,7 @@
     {/if}
     <header>
       <hgroup>
-        <small><mark>{kicker}</mark></small>
+        <p class="eyebrow">{kicker}</p>
         <h1>{title}</h1>
         {#if metaRow}
           <p data-testid={metaTestId}>{@render metaRow()}</p>

--- a/web/src/components/HomeBuscaForm.svelte
+++ b/web/src/components/HomeBuscaForm.svelte
@@ -8,7 +8,7 @@
 
 <form role="search" method="get" action={action}>
   <label for="home-busca-input" class="sr-only">Buscar no PNCP</label>
-  <fieldset>
+  <div role="group">
     <input
       id="home-busca-input"
       type="search"
@@ -17,6 +17,6 @@
       aria-label="Buscar no PNCP"
     />
     <button type="submit">Buscar</button>
-  </fieldset>
+  </div>
 </form>
 

--- a/web/src/components/HubHeader.svelte
+++ b/web/src/components/HubHeader.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  // Top-of-page header used by every "hub" view (Atas, Busca, Comparar,
+  // Dispensas, Mercado): eyebrow kicker + h1 title + optional lede body.
+  // Centralized so the kicker treatment, hgroup nesting, and a11y
+  // semantics stay consistent across views.
+  import type { Snippet } from 'svelte';
+
+  let {
+    kicker,
+    title,
+    lede,
+  }: {
+    kicker: string;
+    title: string;
+    lede?: Snippet;
+  } = $props();
+</script>
+
+<header>
+  <hgroup>
+    <p class="eyebrow">{kicker}</p>
+    <h1>{title}</h1>
+    {#if lede}{@render lede()}{/if}
+  </hgroup>
+</header>

--- a/web/src/components/LocalBids.svelte
+++ b/web/src/components/LocalBids.svelte
@@ -12,6 +12,7 @@
   import { resolve } from '../lib/baseUrl';
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
+  import Skeleton from './Skeleton.svelte';
 
   setQueryClientContext(getQueryClient());
 
@@ -102,10 +103,7 @@
     />
   {:else if geoStatus === 'ready'}
     {#if loadingData}
-      <article aria-busy="true" class="is-skeleton" aria-label={`Consultando PNCP para ${cityInfo?.name ?? 'seu município'}`}>
-        <p>&nbsp;</p>
-        {#each [1, 2, 3] as _, i (i)}<p>&nbsp;</p>{/each}
-      </article>
+      <Skeleton label={`Consultando PNCP para ${cityInfo?.name ?? 'seu município'}`} rows={4} />
     {:else if data}
       {#if data.archived}
         <AlertBanner

--- a/web/src/components/ManifestTable.svelte
+++ b/web/src/components/ManifestTable.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { fetchManifestRows, IA_MANIFEST_URL, type ManifestRow } from '../lib/ia-manifest';
   import AlertBanner from './AlertBanner.svelte';
+  import Skeleton from './Skeleton.svelte';
 
   // Cap so the table stays scannable; the full CSV is one click away.
   const ROW_LIMIT = 24;
@@ -34,7 +35,7 @@
 
 <figure>
   {#if loading}
-    <article aria-busy="true" class="is-skeleton" aria-label="Carregando manifesto"><p>&nbsp;</p><p>&nbsp;</p><p>&nbsp;</p></article>
+    <Skeleton label="Carregando manifesto" rows={3} />
   {:else if failed}
     <AlertBanner
       title="Manifesto indisponível"

--- a/web/src/components/MercadoView.svelte
+++ b/web/src/components/MercadoView.svelte
@@ -6,6 +6,8 @@
 
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
+  import HubHeader from './HubHeader.svelte';
+  import Skeleton from './Skeleton.svelte';
   import { resolve } from '../lib/baseUrl';
 
   setQueryClientContext(getQueryClient());
@@ -90,26 +92,24 @@
 </script>
 
 <section>
-  <header>
-    <hgroup>
-      <small><mark>📊 MERCADO</mark></small>
-      <h1>Análise de Mercado</h1>
+  <HubHeader kicker="📊 Mercado" title="Análise de Mercado">
+    {#snippet lede()}
       <p>Top compradores, fornecedores e faixa de preço. Fonte: API PNCP.</p>
-    </hgroup>
-  </header>
+    {/snippet}
+  </HubHeader>
 
   <form role="search" onsubmit={handleSubmit}>
     <label for="mercado-objeto-input" class="sr-only">Objeto a pesquisar</label>
-    <fieldset>
+    <div role="group" aria-label="Buscar mercado">
       <input id="mercado-objeto-input" type="search" bind:value={searchInput} placeholder="Ex.: merenda escolar..." aria-label="Objeto a pesquisar" />
       <button type="submit">Buscar</button>
-    </fieldset>
+    </div>
   </form>
 
   {#if !submittedObjeto || submittedObjeto.length < 3}
     <EmptyState title="Digite o objeto a pesquisar" message="Use ao menos 3 caracteres para ver o panorama do mercado." />
   {:else if loading}
-    <article aria-busy="true" class="is-skeleton" aria-label="Buscando mercado"><p>&nbsp;</p><p>&nbsp;</p></article>
+    <Skeleton label="Buscando mercado" />
   {:else if error}
     <AlertBanner title="Não foi possível buscar mercado" message={error.message} level="error" />
   {:else if contracts.length === 0}

--- a/web/src/components/RawArchiveStatus.svelte
+++ b/web/src/components/RawArchiveStatus.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import AlertBanner from './AlertBanner.svelte';
   import StatCard from './StatCard.svelte';
+  import Skeleton from './Skeleton.svelte';
   import { fetchRawArchiveStatus, type RawArchiveStatus } from '../lib/ia-raw-status';
   import { formatInteger, formatRelativeTime } from '../lib/format';
 
@@ -54,7 +55,7 @@
 {:else if loading}
   <div class="grid" aria-busy="true" aria-label="Carregando metadados do Internet Archive">
     {#each [1, 2, 3, 4] as _, i (i)}
-      <article aria-busy="true" class="is-skeleton"><p>&nbsp;</p><p>&nbsp;</p></article>
+      <Skeleton />
     {/each}
   </div>
 {:else if status}

--- a/web/src/components/SchemaChangelogView.svelte
+++ b/web/src/components/SchemaChangelogView.svelte
@@ -101,7 +101,7 @@
         <article>
           <header>
             <time>{entry.date}</time>
-            <small><mark>{kindLabel[entry.kind]}</mark></small>
+            <small data-badge>{kindLabel[entry.kind]}</small>
             <small><code>{entry.table}</code></small>
           </header>
           <p><code>{entry.column}</code></p>

--- a/web/src/components/Skeleton.svelte
+++ b/web/src/components/Skeleton.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  // Loading placeholder built on Pico's aria-busy=true plus the
+  // .is-skeleton hook in global.css. Centralized so every loading
+  // state has the same shape and a11y treatment.
+  let {
+    label = 'Carregando',
+    rows = 2,
+  }: {
+    label?: string;
+    rows?: number;
+  } = $props();
+</script>
+
+<article aria-busy="true" class="is-skeleton" aria-label={label}>
+  {#each { length: rows } as _, i (i)}<p>&nbsp;</p>{/each}
+</article>

--- a/web/src/components/SupplierDetailView.svelte
+++ b/web/src/components/SupplierDetailView.svelte
@@ -186,7 +186,7 @@
   {#snippet metaRow()}
     {#if data}
       <small>CNPJ: <code>{data.cnpj}</code></small>
-      <small>Fonte: <mark>Arquivo Parquet (IA)</mark></small>
+      <small>Fonte: <span data-badge>Arquivo Parquet (IA)</span></small>
     {/if}
   {/snippet}
 

--- a/web/src/components/WatchDetailView.svelte
+++ b/web/src/components/WatchDetailView.svelte
@@ -140,7 +140,7 @@
   {:else if entry}
     <header>
       <hgroup>
-        <small><mark>Vigilância</mark></small>
+        <p class="eyebrow">🔔 Vigilância</p>
         <h1>{entry.label}</h1>
         <p><code>{entry.filter}</code></p>
       </hgroup>

--- a/web/src/components/WatchList.svelte
+++ b/web/src/components/WatchList.svelte
@@ -34,7 +34,7 @@
   <section aria-labelledby="watch-title">
     <header>
       <hgroup>
-        <small><mark>🔔 Você está acompanhando</mark></small>
+        <p class="eyebrow">🔔 Você está acompanhando</p>
         <h2 id="watch-title">
           {entries.length === 1 ? '1 item salvo' : `${entries.length} itens salvos`}
         </h2>
@@ -49,7 +49,7 @@
       {#each entries as entry (entry.id)}
         <article>
           <header>
-            <small><mark>{labelForType(entry.type)}</mark></small>
+            <small data-badge>{labelForType(entry.type)}</small>
             <code>{entry.filter}</code>
           </header>
           <p><strong>{entry.label}</strong></p>

--- a/web/src/pages/status.astro
+++ b/web/src/pages/status.astro
@@ -12,7 +12,7 @@ import CoverageReport from '../components/CoverageReport.svelte';
     <header>
       <hgroup>
         <h1>📡 Status do Pipeline</h1>
-        <p><mark class="secondary">🟢 Operacional</mark></p>
+        <p><span data-badge data-tone="success">🟢 Operacional</span></p>
       </hgroup>
       <p>
         Acompanhe o estado do item bruto no Internet Archive. Esta tela lê

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -119,6 +119,42 @@ h1, h2, hgroup > h1, hgroup > h2 {
   max-width: 56rem;
 }
 
+/* WHY: pre-heading "eyebrow" / kicker line above an h1/h2. Using
+   <small> for this is wrong (small is fine-print/asides), and
+   wrapping in <mark> for color was a stretch (mark is for
+   highlighting relevance in surrounding prose). A <p class="eyebrow">
+   inside <hgroup> is the semantically correct slot per the latest
+   HTML spec. */
+.eyebrow {
+  margin-bottom: 0;
+  font-size: 0.85em;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--pico-muted-color);
+}
+
+/* WHY: small "pill" tags for status / modality / type labels next to
+   list items. Previously rendered as <small><mark>...</mark></small>,
+   but <mark> is for highlighting relevance in prose, not decoration.
+   <small data-badge> is honest (it really is fine print) and lets us
+   keep the visual pill via this dedicated hook. */
+[data-badge] {
+  display: inline-block;
+  padding: 0.1em 0.5em;
+  border: 1px solid var(--pico-muted-border-color);
+  border-radius: 999px;
+  background: var(--pico-card-sectioning-background-color);
+  color: var(--pico-color);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+[data-badge][data-tone="success"] {
+  border-color: var(--baliza-verde, currentcolor);
+  color: var(--baliza-verde);
+}
+
 /* WHY: Pico's aria-invalid styles only apply to form elements; we
    need an "error card" treatment on <article role=alert> too. Using a
    data-attribute (instead of aria-invalid) keeps the markup valid:


### PR DESCRIPTION
Follow-up to #534 / #536. Tightens HTML semantics, removes a layer of redundant wrappers, and pulls shared structure into two small components.

## Semantics

- **Eyebrow / kicker**: every `<small><mark>KICKER</mark></small>` inside an `<hgroup>` becomes `<p class="eyebrow">`. `<small>` means *fine print* and `<mark>` means *highlighted relevance in prose* — neither is what a kicker is. Adds an `.eyebrow` utility to `global.css` with a `WHY` comment.
- **Status pills** (modality, source, snapshot, type label, change-kind): `<small data-badge>` / `<span data-badge>` instead of `<mark>`. Adds `[data-badge]` (rounded pill) + `[data-badge][data-tone="success"]` for the /status badge.
- **Form input-groups**: bare `<fieldset>` without `<legend>` (only used for visual layout) → `<div role="group">`. The two real fieldsets in `BuscaView` (advanced filters, results filters) get `<legend class="sr-only">` labels. `DuckDBExplorer`'s editor-zone follows the same pattern.

## Components

- **`HubHeader.svelte`**: header + hgroup + eyebrow + h1 + optional lede snippet. Adopted by Atas / Busca / Comparar / Dispensas / Mercado.
- **`Skeleton.svelte`**: `<article aria-busy="true" class="is-skeleton">` with configurable `label` and `rows`. Adopted by 12 call sites (Atas/Busca/Comparar/Dispensas/Mercado/CityWowStrip/CoverageReport/Dashboard/EntityDetailLayout/LocalBids/ManifestTable/RawArchiveStatus).

## Nesting

Spot-fix `/status` (`<mark class="secondary">🟢 Operacional</mark>` → `<span data-badge data-tone="success">`). The earlier #534 already cleared the worst offenders (outer `<article>` wrapping alternates in `EntityDetailLayout`, `<div>` wrappers in HomeSection).

## Verification

- `astro check` + `svelte-check` → 0 errors / 0 warnings
- `eslint` clean
- `vitest` → 610 passing / 7 skipped (had to disambiguate two duplicate `aria-label`s the new `role="group"` wrappers introduced — the form/input below them already supplied the accessible name).

## Test plan

- [ ] `/atas`, `/busca`, `/comparar`, `/dispensas`, `/mercado` render with the new `HubHeader` (kicker + h1 + lede in that visual order).
- [ ] Loading states (skeletons) still appear and animate on each view.
- [ ] Modality and source pills on result cards still look pill-shaped via the new `[data-badge]` rule.
- [ ] `/status` badge ("🟢 Operacional") reads as a green pill.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BTsciqfUZMfK2xM8D2r2y3)_