### PR TITLE
fix(web): home design quick wins (wave ornament, italic H1, tools cards)

### DIFF
--- a/web/src/components/CityHero.svelte
+++ b/web/src/components/CityHero.svelte
@@ -61,7 +61,7 @@
     <hgroup>
       <p class="eyebrow">Painel cívico · O que é o Baliza?</p>
       <h1 id="city-hero-title">
-        O que <em>{cityState.nome}{cityState.uf ? ` / ${cityState.uf}` : ''}</em> está comprando?
+        O que <mark>{cityState.nome}{cityState.uf ? ` / ${cityState.uf}` : ''}</mark> está comprando?
       </h1>
       <p>
         <strong>B</strong>ackup <strong>A</strong>berto de <strong>Li</strong>citações <strong>Z</strong>elando pelo <strong>A</strong>cesso.

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -103,6 +103,7 @@ const TOOLS: Array<{
           <p>{tool.blurb}</p>
           <a
             href={tool.href}
+            aria-label={`Abrir ${tool.label}${tool.external ? ' (em nova aba)' : ''}`}
             rel={tool.external ? 'noopener' : undefined}
             target={tool.external ? '_blank' : undefined}
           >

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -92,24 +92,22 @@ const TOOLS: Array<{
        grid — no second hero. The single search input lives in section 2b. -->
   <section aria-labelledby="tools-title">
     <hgroup>
-      <small>Utilidades avançadas</small>
+      <p class="eyebrow">Utilidades avançadas</p>
       <h2 id="tools-title">Outras entradas no arquivo</h2>
       <p>Para quem já sabe o que procurar: análise, dados brutos e metodologia.</p>
     </hgroup>
     <div class="grid">
       {TOOLS.map((tool) => (
         <article>
+          <h3>{tool.label}</h3>
+          <p>{tool.blurb}</p>
           <a
             href={tool.href}
             rel={tool.external ? 'noopener' : undefined}
             target={tool.external ? '_blank' : undefined}
           >
-            <strong>
-              {tool.label}
-              {tool.external && <span aria-hidden="true"> ↗</span>}
-            </strong>
+            Abrir{tool.external ? ' ↗' : ' →'}
           </a>
-          <p>{tool.blurb}</p>
         </article>
       ))}
     </div>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -232,9 +232,12 @@ hr[data-ornament="wave"] {
   background: linear-gradient(
     180deg,
     var(--baliza-bg) 0 50%,
-    var(--baliza-accent) 50% 100%
+    var(--baliza-azul) 50% 100%
   );
-  mask: radial-gradient(circle at 50% 0, transparent 12px, #000 13px) 0 0 / 24px 100%;
+  -webkit-mask: radial-gradient(circle at 50% 0, transparent 12px, #000 13px) 0 0 / 24px 100% repeat-x;
+  mask: radial-gradient(circle at 50% 0, transparent 12px, #000 13px) 0 0 / 24px 100% repeat-x;
+  mask-repeat: repeat-x;
+  -webkit-mask-repeat: repeat-x;
 }
 
 hr[data-ornament="volpi"] {


### PR DESCRIPTION
Análise visual rápida em https://franklinbaldo.github.io/baliza/ (screenshots desktop 1440 e mobile 390) revelou alguns problemas de baixo esforço — todos corrigíveis sem sair do Pico CSS.

## Mudanças

- **Onda ornamental**: a banda `<hr data-ornament="wave">` aparecia como um retângulo vermelho sólido em vez de festonada porque `mask: radial-gradient(...)` faltava `-webkit-mask` e `repeat-x` consistente. Agora renderiza as escalopas e usa `--baliza-azul` em vez do vermelho de acento, devolvendo ao CTA "Buscar" o monopólio do vermelho.
- **H1 da hero**: `O que <em>Porto Velho / RO</em> está comprando?` ficava com Fraunces italic numa barra `/` — feio. Trocado por `<mark>`, que usa o token `--pico-mark-*` já mapeado no brand.
- **Cartões "Outras entradas no arquivo"**: o título inteiro era um `<a><strong>`, então 6 títulos vermelhos sublinhados em sequência saturavam a seção. Movido para `<h3>` neutro + `<a>` "Abrir →" no rodapé do card. Aproveita o utilitário `.eyebrow` (já em `global.css`) no kicker da seção.

## Follow-up

Os problemas maiores (skeletons vazios dominando o primeiro paint, header apertado no mobile, linha de ações da busca desbalanceada, footer atravancado, ícones-emoji desalinhados) estão documentados no plano de follow-up que acompanha o PR. Eles exigem mudança de marcação/SSR e merecem uma sessão dedicada.

## Test plan

- [ ] `cd web && npm run build` (astro check + bundle size)
- [ ] Inspecionar a home em desktop (1440px) — onda festonada azul, H1 com destaque ouro/mark, cards de utilidades sem títulos vermelhos
- [ ] Inspecionar a home em mobile (390px) — confirmar que a onda continua bem renderizada com `repeat-x`
- [ ] Conferir tema escuro — `<mark>` continua legível

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHhF7dhRQQ6D6umgjQMkgD)_