### PR TITLE
fix(web): home structural follow-up — meaningful skeletons, Pico nav, footer split

### DIFF
--- a/web/src/components/AlertBanner.svelte
+++ b/web/src/components/AlertBanner.svelte
@@ -7,12 +7,6 @@
 
   let { title, message, level = 'info' }: Props = $props();
 
-  const levelEmoji: Record<NonNullable<Props['level']>, string> = {
-    info: 'ℹ️',
-    success: '✅',
-    warning: '⚠️',
-    error: '🚨',
-  };
 </script>
 
 <article
@@ -21,7 +15,20 @@
   data-invalid={level === 'error' || level === 'warning' ? 'true' : undefined}
   data-level={level}
 >
-  <header><strong><span aria-hidden="true">{levelEmoji[level]}</span> {title}</strong></header>
+  <header>
+    <strong>
+      {#if level === 'success'}
+        <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="m8.5 12 2.5 2.5L15.5 10"></path></svg>
+      {:else if level === 'warning'}
+        <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><path d="M12 3 2.5 20h19L12 3Z"></path><path d="M12 10v4"></path><circle cx="12" cy="17" r="0.5" fill="currentColor"></circle></svg>
+      {:else if level === 'error'}
+        <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="m9 9 6 6M15 9l-6 6"></path></svg>
+      {:else}
+        <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="M12 8v.01M12 11v5"></path></svg>
+      {/if}
+      {title}
+    </strong>
+  </header>
   <p>{message}</p>
 </article>
 

--- a/web/src/components/AlertBanner.svelte
+++ b/web/src/components/AlertBanner.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
+  import type { IconName } from '../lib/icons';
+
   interface Props {
     title: string;
     message: string;
@@ -7,6 +10,12 @@
 
   let { title, message, level = 'info' }: Props = $props();
 
+  const levelIcon: Record<NonNullable<Props['level']>, IconName> = {
+    info: 'info',
+    success: 'check-circle',
+    warning: 'warning',
+    error: 'x-circle',
+  };
 </script>
 
 <article
@@ -17,18 +26,9 @@
 >
   <header>
     <strong>
-      {#if level === 'success'}
-        <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="m8.5 12 2.5 2.5L15.5 10"></path></svg>
-      {:else if level === 'warning'}
-        <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><path d="M12 3 2.5 20h19L12 3Z"></path><path d="M12 10v4"></path><circle cx="12" cy="17" r="0.5" fill="currentColor"></circle></svg>
-      {:else if level === 'error'}
-        <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="m9 9 6 6M15 9l-6 6"></path></svg>
-      {:else}
-        <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="M12 8v.01M12 11v5"></path></svg>
-      {/if}
+      <Icon name={levelIcon[level]} />
       {title}
     </strong>
   </header>
   <p>{message}</p>
 </article>
-

--- a/web/src/components/CityHero.svelte
+++ b/web/src/components/CityHero.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CityPicker from './CityPicker.svelte';
+  import Icon from './Icon.svelte';
   import { cityState, hydrateCityContext, setCity } from '../lib/cityContext.svelte';
   import { resolve } from '../lib/baseUrl';
   import { resolveCityFromBrowserLocation } from '../lib/geo';
@@ -91,7 +92,7 @@
 
     {#if geoStatus !== 'ready'}
       <button type="button" class="outline contrast" onclick={handleFindLocal} disabled={geoStatus === 'locating'} aria-busy={geoStatus === 'locating'}>
-        <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><path d="M12 22s7-7.5 7-13a7 7 0 1 0-14 0c0 5.5 7 13 7 13Z"></path><circle cx="12" cy="9" r="2.5"></circle></svg>
+        <Icon name="map-pin" />
         {geoStatus === 'locating' ? 'Localizando…' : 'Usar minha localização'}
       </button>
     {/if}

--- a/web/src/components/CityHero.svelte
+++ b/web/src/components/CityHero.svelte
@@ -86,19 +86,28 @@
     </div>
   </form>
 
-  <div role="group" class="actions">
+  <div role="group">
     <a href={dashboardHref} role="button">Ver painel de {cityState.nome}</a>
 
     {#if geoStatus !== 'ready'}
-      <button type="button" class="outline" onclick={handleFindLocal} disabled={geoStatus === 'locating'} aria-busy={geoStatus === 'locating'}>
-        {geoStatus === 'locating' ? 'Localizando...' : '📍 Usar minha localização'}
+      <button type="button" class="outline contrast" onclick={handleFindLocal} disabled={geoStatus === 'locating'} aria-busy={geoStatus === 'locating'}>
+        <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><path d="M12 22s7-7.5 7-13a7 7 0 1 0-14 0c0 5.5 7 13 7 13Z"></path><circle cx="12" cy="9" r="2.5"></circle></svg>
+        {geoStatus === 'locating' ? 'Localizando…' : 'Usar minha localização'}
       </button>
     {/if}
-
-    <button type="button" class="outline secondary" aria-expanded={pickerOpen} aria-controls="city-hero-picker" onclick={() => (pickerOpen = !pickerOpen)}>
-      {pickerOpen ? 'Fechar seletor' : 'Buscar outra cidade'}
-    </button>
   </div>
+
+  <p>
+    <a
+      href="#city-hero-picker"
+      class="contrast"
+      aria-expanded={pickerOpen}
+      aria-controls="city-hero-picker"
+      onclick={(e) => { e.preventDefault(); pickerOpen = !pickerOpen; }}
+    >
+      {pickerOpen ? 'Fechar seletor' : 'Buscar outra cidade'}
+    </a>
+  </p>
 
   {#if geoStatus === 'denied'}
     <small role="alert" aria-live="polite">Acesso à localização negado. Use o seletor manual.</small>

--- a/web/src/components/CityNavLink.svelte
+++ b/web/src/components/CityNavLink.svelte
@@ -2,7 +2,7 @@
   import { cityState, hydrateCityContext } from '../lib/cityContext.svelte';
   import { resolve } from '../lib/baseUrl';
 
-  let { isActive = false } = $props();
+  let { isActive = false, asLabel = false } = $props();
 
   hydrateCityContext();
 
@@ -14,7 +14,11 @@
   );
 </script>
 
-<a {href} aria-label={`Painel do município de ${cityState.nome}`} aria-current={isActive ? 'page' : undefined}>
-  {label}
-</a>
+{#if asLabel}
+  <span aria-label={`Painel do município de ${cityState.nome}`}>{label}</span>
+{:else}
+  <a {href} aria-label={`Painel do município de ${cityState.nome}`} aria-current={isActive ? 'page' : undefined}>
+    {label}
+  </a>
+{/if}
 

--- a/web/src/components/CityPicker.svelte
+++ b/web/src/components/CityPicker.svelte
@@ -147,7 +147,12 @@
       autocomplete="off"
     />
     <button type="button" class="outline" onclick={useMyLocation} disabled={geoStatus === 'locating'} aria-busy={geoStatus === 'locating'} aria-label="Usar minha localização atual">
-      {geoStatus === 'locating' ? 'Buscando…' : '📍 minha localização'}
+      {#if geoStatus === 'locating'}
+        Buscando…
+      {:else}
+        <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><path d="M12 22s7-7.5 7-13a7 7 0 1 0-14 0c0 5.5 7 13 7 13Z"></path><circle cx="12" cy="9" r="2.5"></circle></svg>
+        minha localização
+      {/if}
     </button>
   </div>
 

--- a/web/src/components/CityPicker.svelte
+++ b/web/src/components/CityPicker.svelte
@@ -10,6 +10,7 @@
     searchMunicipalities,
     type SearchMatch,
   } from '../lib/geo';
+  import Icon from './Icon.svelte';
 
   interface Props {
     autofocus?: boolean;
@@ -150,7 +151,7 @@
       {#if geoStatus === 'locating'}
         Buscando…
       {:else}
-        <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><path d="M12 22s7-7.5 7-13a7 7 0 1 0-14 0c0 5.5 7 13 7 13Z"></path><circle cx="12" cy="9" r="2.5"></circle></svg>
+        <Icon name="map-pin" />
         minha localização
       {/if}
     </button>

--- a/web/src/components/CityWowStrip.svelte
+++ b/web/src/components/CityWowStrip.svelte
@@ -71,9 +71,10 @@
   <section aria-label={`Pulso de ${cityState.nome}`}>
     <div class="grid">
       {#if loading}
-        {#each [1, 2, 3, 4] as _, col (col)}
-          <Skeleton />
-        {/each}
+        <Skeleton label="Calculando contratações" messages={['Calculando contratações…', 'desde —']} />
+        <Skeleton label="Somando valores" messages={['Somando R$ executados…', ' ']} />
+        <Skeleton label="Procurando maior comprador" messages={['Procurando maior comprador…', ' ']} />
+        <Skeleton label="Snapshot do arquivo" messages={['Lendo Internet Archive…', ' ']} />
       {:else if data}
         <article>
           <a href={buscaHref} aria-label={`Ver os ${formatInteger(data.contratos)} contratos arquivados de ${cityState.nome}`}>

--- a/web/src/components/Dashboard.svelte
+++ b/web/src/components/Dashboard.svelte
@@ -7,20 +7,23 @@
   import { resolve } from '../lib/baseUrl';
   import { onMount } from 'svelte';
 
-  let stats = $state<SyncStats | null>(null);
+  let { initialStats }: { initialStats?: SyncStats } = $props();
+
+  let stats = $state<SyncStats | null>(initialStats ?? null);
   let error = $state<string | null>(null);
-  let loading = $state(true);
+  let loading = $state(!initialStats);
 
   async function loadStats() {
-    loading = true;
     error = null;
+    if (!stats) loading = true;
     try {
       const res = await fetch(resolve('data/sync_stats.json'));
       if (!res.ok) throw new Error('Falha ao obter os dados pré-compilados pelo DuckDB.');
       const raw = await res.json();
       stats = SyncStatsSchema.parse(raw);
     } catch (e) {
-      error = (e as Error).message;
+      // Keep the SSR'd initialStats visible if the refresh fetch fails.
+      if (!stats) error = (e as Error).message;
     } finally {
       loading = false;
     }

--- a/web/src/components/DispensasView.svelte
+++ b/web/src/components/DispensasView.svelte
@@ -71,7 +71,7 @@
 </script>
 
 <section>
-  <HubHeader kicker="⚖️ Dispensas" title="Dispensas — Bases Legais">
+  <HubHeader kicker="Dispensas" title="Dispensas — Bases Legais">
     {#snippet lede()}
       <p>Quais artigos da lei são mais citados em dispensas similares. Fonte: API PNCP, modalidade 8 (Dispensa).</p>
     {/snippet}

--- a/web/src/components/Icon.astro
+++ b/web/src/components/Icon.astro
@@ -1,0 +1,19 @@
+---
+import { ICON_PATHS, type IconName } from '../lib/icons';
+
+interface Props {
+  name: IconName;
+  label?: string;
+}
+
+const { name, label } = Astro.props;
+const inner = ICON_PATHS[name];
+---
+<svg
+  data-icon
+  viewBox="0 0 24 24"
+  aria-hidden={label ? undefined : 'true'}
+  aria-label={label}
+  role={label ? 'img' : undefined}
+  set:html={inner}
+/>

--- a/web/src/components/Icon.svelte
+++ b/web/src/components/Icon.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { ICON_PATHS, type IconName } from '../lib/icons';
+
+  let { name, label }: { name: IconName; label?: string } = $props();
+
+  const inner = $derived(ICON_PATHS[name]);
+</script>
+
+<svg
+  data-icon
+  viewBox="0 0 24 24"
+  aria-hidden={label ? undefined : 'true'}
+  aria-label={label}
+  role={label ? 'img' : undefined}
+>
+  {@html inner}
+</svg>

--- a/web/src/components/LocalBids.svelte
+++ b/web/src/components/LocalBids.svelte
@@ -9,6 +9,7 @@
   import { setCity } from '../lib/cityContext.svelte';
   import { archivedContratoToInternalContract, type PNCPContract } from '../lib/pncp';
   import { formatDate, formatParticao, truncate } from '../lib/format';
+  import Icon from './Icon.svelte';
   import { resolve } from '../lib/baseUrl';
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
@@ -79,7 +80,7 @@
 <article>
   <header>
     <hgroup>
-      <small><svg data-icon aria-hidden="true" viewBox="0 0 24 24"><path d="M12 22s7-7.5 7-13a7 7 0 1 0-14 0c0 5.5 7 13 7 13Z"></path><circle cx="12" cy="9" r="2.5"></circle></svg></small>
+      <small><Icon name="map-pin" /></small>
       <h3>Radar Local</h3>
       <p>Encontre oportunidades perto de você usando geolocalização.</p>
     </hgroup>

--- a/web/src/components/LocalBids.svelte
+++ b/web/src/components/LocalBids.svelte
@@ -79,7 +79,7 @@
 <article>
   <header>
     <hgroup>
-      <small>📍</small>
+      <small><svg data-icon aria-hidden="true" viewBox="0 0 24 24"><path d="M12 22s7-7.5 7-13a7 7 0 1 0-14 0c0 5.5 7 13 7 13Z"></path><circle cx="12" cy="9" r="2.5"></circle></svg></small>
       <h3>Radar Local</h3>
       <p>Encontre oportunidades perto de você usando geolocalização.</p>
     </hgroup>

--- a/web/src/components/Navigation.astro
+++ b/web/src/components/Navigation.astro
@@ -24,7 +24,17 @@ const isCityActive = cleanPath === cityPrefix;
     </li>
   </ul>
   <ul>
-    <li><CityNavLink client:load isActive={isCityActive} /></li>
+    <li>
+      <details role="list">
+        <summary aria-haspopup="listbox" aria-current={isCityActive ? 'page' : undefined}>
+          <CityNavLink client:load isActive={isCityActive} asLabel={true} />
+        </summary>
+        <ul role="listbox">
+          <li><a href={BASE}>Trocar cidade</a></li>
+          <li><a href={BASE + 'busca'}>Buscar contratações</a></li>
+        </ul>
+      </details>
+    </li>
     <li><a href={BASE + 'atas'} aria-current={isActive(BASE + 'atas') ? 'page' : undefined}>Atas</a></li>
     <li>
       <details role="list" dir="rtl">
@@ -38,8 +48,8 @@ const isCityActive = cleanPath === cityPrefix;
     </li>
     <li><a href={BASE + 'sobre'} aria-current={isActive(BASE + 'sobre') ? 'page' : undefined}>Sobre</a></li>
     <li>
-      <a href={BASE + 'busca'} role="button" class="outline" aria-label="Buscar">
-        <span aria-hidden="true">🔍</span>
+      <a href={BASE + 'busca'} class="contrast" aria-label="Buscar">
+        <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"></circle><path d="m20 20-3.5-3.5"></path></svg>
         <span class="sr-only">Buscar</span>
       </a>
     </li>

--- a/web/src/components/Navigation.astro
+++ b/web/src/components/Navigation.astro
@@ -1,6 +1,7 @@
 ---
 import ThemeToggle from './ThemeToggle.svelte';
 import CityNavLink from './CityNavLink.svelte';
+import Icon from './Icon.astro';
 
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 const { pathname } = Astro.url;
@@ -50,7 +51,7 @@ const isCityActive = cleanPath === cityPrefix;
     <li><a href={BASE + 'sobre'} aria-current={isActive(BASE + 'sobre') ? 'page' : undefined}>Sobre</a></li>
     <li>
       <a href={BASE + 'busca'} class="contrast" aria-label="Buscar">
-        <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"></circle><path d="m20 20-3.5-3.5"></path></svg>
+        <Icon name="search" />
         <span class="sr-only">Buscar</span>
       </a>
     </li>

--- a/web/src/components/Navigation.astro
+++ b/web/src/components/Navigation.astro
@@ -28,27 +28,36 @@ const isCityActive = cleanPath === cityPrefix;
     <li>
       <details role="list">
         <summary aria-haspopup="listbox" aria-current={isCityActive ? 'page' : undefined}>
+          <Icon name="building" />
           <CityNavLink client:load isActive={isCityActive} asLabel={true} />
         </summary>
         <ul role="listbox">
-          <li><CityNavLink client:load isActive={isCityActive} /></li>
-          <li><a href={BASE}>Trocar cidade</a></li>
-          <li><a href={BASE + 'busca'}>Buscar contratações</a></li>
+          <li><Icon name="building" /> <CityNavLink client:load isActive={isCityActive} /></li>
+          <li><a href={BASE}><Icon name="swap" /> Trocar cidade</a></li>
+          <li><a href={BASE + 'busca'}><Icon name="search" /> Buscar contratações</a></li>
         </ul>
       </details>
     </li>
-    <li><a href={BASE + 'atas'} aria-current={isActive(BASE + 'atas') ? 'page' : undefined}>Atas</a></li>
+    <li>
+      <a href={BASE + 'atas'} aria-current={isActive(BASE + 'atas') ? 'page' : undefined}>
+        <Icon name="document" /> Atas
+      </a>
+    </li>
     <li>
       <details role="list" dir="rtl">
-        <summary aria-haspopup="listbox">Dados Abertos</summary>
+        <summary aria-haspopup="listbox"><Icon name="database" /> Dados Abertos</summary>
         <ul role="listbox">
-          <li><a href={BASE + 'explorador'}>Explorador SQL</a></li>
-          <li><a href={BASE + 'desenvolvedores'}>Devs & API</a></li>
-          <li><a href={BASE + 'status'}>Status do Arquivo</a></li>
+          <li><a href={BASE + 'explorador'}><Icon name="code" /> Explorador SQL</a></li>
+          <li><a href={BASE + 'desenvolvedores'}><Icon name="code" /> Devs & API</a></li>
+          <li><a href={BASE + 'status'}><Icon name="signal" /> Status do Arquivo</a></li>
         </ul>
       </details>
     </li>
-    <li><a href={BASE + 'sobre'} aria-current={isActive(BASE + 'sobre') ? 'page' : undefined}>Sobre</a></li>
+    <li>
+      <a href={BASE + 'sobre'} aria-current={isActive(BASE + 'sobre') ? 'page' : undefined}>
+        <Icon name="info" /> Sobre
+      </a>
+    </li>
     <li>
       <a href={BASE + 'busca'} class="contrast" aria-label="Buscar">
         <Icon name="search" />

--- a/web/src/components/Navigation.astro
+++ b/web/src/components/Navigation.astro
@@ -30,6 +30,7 @@ const isCityActive = cleanPath === cityPrefix;
           <CityNavLink client:load isActive={isCityActive} asLabel={true} />
         </summary>
         <ul role="listbox">
+          <li><CityNavLink client:load isActive={isCityActive} /></li>
           <li><a href={BASE}>Trocar cidade</a></li>
           <li><a href={BASE + 'busca'}>Buscar contratações</a></li>
         </ul>

--- a/web/src/components/Skeleton.svelte
+++ b/web/src/components/Skeleton.svelte
@@ -5,12 +5,17 @@
   let {
     label = 'Carregando',
     rows = 2,
+    messages,
   }: {
     label?: string;
     rows?: number;
+    messages?: string[];
   } = $props();
+
+  const NBSP = ' ';
+  const lines = $derived(messages ?? Array.from({ length: rows }, () => NBSP));
 </script>
 
 <article aria-busy="true" class="is-skeleton" aria-label={label}>
-  {#each { length: rows } as _, i (i)}<p>&nbsp;</p>{/each}
+  {#each lines as line, i (i)}<p>{line}</p>{/each}
 </article>

--- a/web/src/components/StatCard.svelte
+++ b/web/src/components/StatCard.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Icon from './Icon.svelte';
+  import type { IconName } from '../lib/icons';
   type Tone = 'default' | 'success' | 'warning' | 'danger';
 
   let {
@@ -21,26 +23,21 @@
     warning: 'var(--color-warning)',
     danger:  'var(--color-error)',
   };
+  const toneIconName: Record<Tone, IconName> = {
+    default: 'hash',
+    success: 'check-circle',
+    warning: 'warning',
+    danger: 'x-circle',
+  };
   const accent = $derived(accentVar[tone]);
+  const iconName = $derived(toneIconName[tone]);
 </script>
-
-{#snippet toneIcon()}
-  {#if tone === 'success'}
-    <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="m8.5 12 2.5 2.5L15.5 10"></path></svg>
-  {:else if tone === 'warning'}
-    <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><path d="M12 3 2.5 20h19L12 3Z"></path><path d="M12 10v4"></path><circle cx="12" cy="17" r="0.5" fill="currentColor"></circle></svg>
-  {:else if tone === 'danger'}
-    <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="m9 9 6 6M15 9l-6 6"></path></svg>
-  {:else}
-    <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><rect x="4" y="4" width="16" height="16" rx="2"></rect><path d="M8 12h8M12 8v8"></path></svg>
-  {/if}
-{/snippet}
 
 {#if href}
   <article>
     <a {href} role="button" class="contrast outline" style="--pico-primary:{accent}">
       <header>
-        {@render toneIcon()}
+        <Icon name={iconName} />
         <h3>{title}</h3>
       </header>
       <p><strong>{value}</strong></p>
@@ -50,7 +47,7 @@
 {:else}
   <article style="--pico-primary:{accent}">
     <header>
-      {@render toneIcon()}
+      <Icon name={iconName} />
       <h3>{title}</h3>
     </header>
     <p><strong>{value}</strong></p>

--- a/web/src/components/StatCard.svelte
+++ b/web/src/components/StatCard.svelte
@@ -21,21 +21,26 @@
     warning: 'var(--color-warning)',
     danger:  'var(--color-error)',
   };
-  const toneEmoji: Record<Tone, string> = {
-    default: '🔢',
-    success: '✅',
-    warning: '⚠️',
-    danger:  '❌',
-  };
   const accent = $derived(accentVar[tone]);
-  const emoji = $derived(toneEmoji[tone]);
 </script>
+
+{#snippet toneIcon()}
+  {#if tone === 'success'}
+    <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="m8.5 12 2.5 2.5L15.5 10"></path></svg>
+  {:else if tone === 'warning'}
+    <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><path d="M12 3 2.5 20h19L12 3Z"></path><path d="M12 10v4"></path><circle cx="12" cy="17" r="0.5" fill="currentColor"></circle></svg>
+  {:else if tone === 'danger'}
+    <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="m9 9 6 6M15 9l-6 6"></path></svg>
+  {:else}
+    <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><rect x="4" y="4" width="16" height="16" rx="2"></rect><path d="M8 12h8M12 8v8"></path></svg>
+  {/if}
+{/snippet}
 
 {#if href}
   <article>
     <a {href} role="button" class="contrast outline" style="--pico-primary:{accent}">
       <header>
-        <span aria-hidden="true">{emoji}</span>
+        {@render toneIcon()}
         <h3>{title}</h3>
       </header>
       <p><strong>{value}</strong></p>
@@ -45,7 +50,7 @@
 {:else}
   <article style="--pico-primary:{accent}">
     <header>
-      <span aria-hidden="true">{emoji}</span>
+      {@render toneIcon()}
       <h3>{title}</h3>
     </header>
     <p><strong>{value}</strong></p>

--- a/web/src/components/TrustStrip.astro
+++ b/web/src/components/TrustStrip.astro
@@ -4,7 +4,8 @@ const resolve = (href: string) => `${BASE}${href.replace(/^\//, '')}`;
 
 const PILLARS = [
   {
-    kicker: '📦 Arquivo',
+    kicker: 'Arquivo',
+    iconKind: 'archive' as const,
     title: 'Snapshots diários no Internet Archive',
     body: 'Cada dia de contratações vira um Parquet aberto fora do alcance de qualquer servidor único. Mesmo que o PNCP saia do ar, o dia de ontem segue consultável.',
     cta: { label: 'Metodologia', href: 'sobre' },
@@ -33,7 +34,12 @@ const PILLARS = [
   <div class="grid">
     {PILLARS.map((p) => (
       <article>
-        <header><small>{p.kicker}</small></header>
+        <header><small>
+          {p.iconKind === 'archive' && (
+            <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><rect x="3" y="6" width="18" height="4" rx="1"></rect><path d="M5 10v9a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-9"></path><path d="M10 14h4"></path></svg>
+          )}
+          {p.kicker}
+        </small></header>
         <h3>{p.title}</h3>
         <p>{p.body}</p>
         <footer><a href={resolve(p.cta.href)}>{p.cta.label} →</a></footer>

--- a/web/src/components/TrustStrip.astro
+++ b/web/src/components/TrustStrip.astro
@@ -1,4 +1,5 @@
 ---
+import Icon from './Icon.astro';
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 const resolve = (href: string) => `${BASE}${href.replace(/^\//, '')}`;
 
@@ -35,9 +36,7 @@ const PILLARS = [
     {PILLARS.map((p) => (
       <article>
         <header><small>
-          {p.iconKind === 'archive' && (
-            <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><rect x="3" y="6" width="18" height="4" rx="1"></rect><path d="M5 10v9a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-9"></path><path d="M10 14h4"></path></svg>
-          )}
+          {p.iconKind === 'archive' && <Icon name="archive" />}
           {p.kicker}
         </small></header>
         <h3>{p.title}</h3>

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -64,13 +64,16 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     </main>
 
     <footer class="container">
-      <p>🇧🇷 Baliza: Arquivo público das contratações nacionais.</p>
       <nav aria-label="Rodapé">
         <ul>
-          <li><a href="https://github.com/franklinbaldo" target="_blank" rel="noopener">👨‍💻 Codificado por Franklin Baldo</a></li>
-          <li><small>📚 Fonte: PNCP & Internet Archive</small></li>
-          <li><a href={BASE + 'explorador'}>🔬 Explorador SQL (Beta)</a></li>
-          <li><a href={BASE + 'status'}>📡 Status</a></li>
+          <li><strong>Baliza</strong></li>
+          <li><small>Arquivo público das contratações nacionais.</small></li>
+          <li><small>Fonte: PNCP &amp; Internet Archive</small></li>
+        </ul>
+        <ul>
+          <li><a href="https://github.com/franklinbaldo" target="_blank" rel="noopener">Codificado por Franklin Baldo</a></li>
+          <li><a href={BASE + 'explorador'}>Explorador SQL</a></li>
+          <li><a href={BASE + 'status'}>Status</a></li>
         </ul>
       </nav>
     </footer>

--- a/web/src/lib/icons.ts
+++ b/web/src/lib/icons.ts
@@ -1,0 +1,25 @@
+// Heroicons-style outline icons used across the web UI. Kept as raw
+// SVG inner-markup strings so the same source feeds both the Astro
+// and Svelte Icon wrappers (set:html / {@html ...}). Add new icons
+// here, not inline in components — keeps the visual baseline and
+// stroke weight consistent everywhere.
+export const ICON_PATHS = {
+  search:
+    '<circle cx="11" cy="11" r="7"></circle><path d="m20 20-3.5-3.5"></path>',
+  'map-pin':
+    '<path d="M12 22s7-7.5 7-13a7 7 0 1 0-14 0c0 5.5 7 13 7 13Z"></path><circle cx="12" cy="9" r="2.5"></circle>',
+  'check-circle':
+    '<circle cx="12" cy="12" r="9"></circle><path d="m8.5 12 2.5 2.5L15.5 10"></path>',
+  warning:
+    '<path d="M12 3 2.5 20h19L12 3Z"></path><path d="M12 10v4"></path><circle cx="12" cy="17" r="0.5" fill="currentColor"></circle>',
+  'x-circle':
+    '<circle cx="12" cy="12" r="9"></circle><path d="m9 9 6 6M15 9l-6 6"></path>',
+  hash:
+    '<rect x="4" y="4" width="16" height="16" rx="2"></rect><path d="M8 12h8M12 8v8"></path>',
+  info:
+    '<circle cx="12" cy="12" r="9"></circle><path d="M12 8v.01M12 11v5"></path>',
+  archive:
+    '<rect x="3" y="6" width="18" height="4" rx="1"></rect><path d="M5 10v9a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-9"></path><path d="M10 14h4"></path>',
+} as const;
+
+export type IconName = keyof typeof ICON_PATHS;

--- a/web/src/lib/icons.ts
+++ b/web/src/lib/icons.ts
@@ -20,6 +20,18 @@ export const ICON_PATHS = {
     '<circle cx="12" cy="12" r="9"></circle><path d="M12 8v.01M12 11v5"></path>',
   archive:
     '<rect x="3" y="6" width="18" height="4" rx="1"></rect><path d="M5 10v9a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-9"></path><path d="M10 14h4"></path>',
+  building:
+    '<path d="M4 21V5a1 1 0 0 1 1-1h9a1 1 0 0 1 1 1v16"></path><path d="M15 9h4a1 1 0 0 1 1 1v11"></path><path d="M3 21h18"></path><path d="M8 8h2M8 12h2M8 16h2"></path>',
+  document:
+    '<path d="M14 3H6a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V8z"></path><path d="M14 3v5h5"></path><path d="M9 13h6M9 17h6"></path>',
+  database:
+    '<ellipse cx="12" cy="5" rx="8" ry="3"></ellipse><path d="M4 5v6c0 1.7 3.6 3 8 3s8-1.3 8-3V5"></path><path d="M4 11v6c0 1.7 3.6 3 8 3s8-1.3 8-3v-6"></path>',
+  code:
+    '<path d="m9 9-4 3 4 3"></path><path d="m15 9 4 3-4 3"></path><path d="m13 5-2 14"></path>',
+  signal:
+    '<path d="M3 12c2-2 4-3 6-3M3 16c4-4 8-5 12-5M3 20c6-6 12-7 18-7"></path>',
+  swap:
+    '<path d="M4 8h14M14 4l4 4-4 4"></path><path d="M20 16H6M10 12l-4 4 4 4"></path>',
 } as const;
 
 export type IconName = keyof typeof ICON_PATHS;

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -9,6 +9,13 @@ import OrnamentBand from '../components/OrnamentBand.astro';
 import Dashboard from '../components/Dashboard.svelte';
 import WatchList from '../components/WatchList.svelte';
 import { IA_MANIFEST_URL } from '../lib/ia-manifest';
+import { SyncStatsSchema } from '../schema';
+import syncStatsRaw from '../../public/data/sync_stats.json';
+
+// Read at build time so the "Sinal do arquivo" tiles paint with real
+// numbers on first render. The Svelte island still refreshes on mount
+// so a stale build doesn't pin the user to old totals.
+const initialSyncStats = SyncStatsSchema.parse(syncStatsRaw);
 
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 const resolve = (href: string) => `${BASE}${href.replace(/^\//, '')}`;
@@ -77,10 +84,10 @@ const TOOLS: Array<{
   <!-- 5. Sinal do arquivo: preservation signal backed by sync_stats.json. -->
   <HomeSection
     id="signal-title"
-    kicker="📦 Sinal do arquivo"
+    kicker="Sinal do arquivo"
     title="O que Baliza já preservou"
   >
-    <Dashboard client:visible />
+    <Dashboard client:visible initialStats={initialSyncStats} />
   </HomeSection>
 
   <!-- 6. Watchlist: the "Acompanhar" buttons on detail views save to

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -94,6 +94,22 @@ h1, h2, hgroup > h1, hgroup > h2 {
    has no equivalent and removing it would regress UX.
    ============================================================ */
 
+/* WHY: heroicons-style inline SVGs replaced our emoji icons so the
+   visual baseline is constant (emoji rendering varies across OSes).
+   Stays currentColor and sized in em so it inherits from surrounding
+   text. */
+[data-icon] {
+  width: 1.25em;
+  height: 1.25em;
+  vertical-align: -0.15em;
+  display: inline-block;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 /* WHY: Pico has no visually-hidden utility but we still need
    accessible-only labels (search forms, icon-only buttons). */
 .sr-only {


### PR DESCRIPTION
Follow-up to #538. Resolves the structural items that the quick-wins PR left on the table, all inside Pico CSS — no Tailwind, no styled-components, no component-scoped `<style>` blocks.

## Summary

- **Skeletons say what they're loading.** `Skeleton.svelte` gains an optional `messages: string[]` prop. `CityWowStrip` now renders four labeled tiles ("Calculando contratações…", "Somando R$ executados…", "Procurando maior comprador…", "Lendo Internet Archive…") instead of four empty tan boxes.
- **"Sinal do arquivo" paints real numbers on first frame.** `index.astro` imports `public/data/sync_stats.json` at build time and passes it to `Dashboard.svelte` as `initialStats`. The island still refreshes on mount so a stale build never pins the user to old totals.
- **Navigation collapses cleanly on mobile.** The município item is now a `<details role="list">`; the search button drops `outline` for `class="contrast"` and uses an inline heroicon SVG.
- **CityHero actions are balanced.** Primary CTA + "Usar minha localização" share a single `role="group"` segmented control. "Buscar outra cidade" is demoted to a contrast link below.
- **Footer is two `<ul>` inside `<nav>`.** Pico's native split-row treatment, with the leading emojis dropped.
- **Emojis → inline SVG with `[data-icon]`.** New utility in `global.css` keeps icons sized in `em`, baseline-aligned, and `currentColor`. Applied to StatCard, AlertBanner, CityHero, CityPicker, LocalBids, TrustStrip, DispensasView, and the `/` "Sinal do arquivo" kicker. MonitorGrid figure emojis are intentionally kept (they're 2.5rem decorative figures, not inline kickers).
- **`<em>` audit:** no `<em>` is nested inside H1/H2 anywhere in `web/src/`. The four hits (`sobre.astro:35,36,61`, `CitationBlock.svelte:92`) are body prose. No-op for this PR.

## Files

`Skeleton.svelte`, `CityWowStrip.svelte`, `Dashboard.svelte`, `pages/index.astro`, `Navigation.astro`, `CityNavLink.svelte`, `CityHero.svelte`, `CityPicker.svelte`, `LocalBids.svelte`, `TrustStrip.astro`, `DispensasView.svelte`, `StatCard.svelte`, `AlertBanner.svelte`, `layouts/Layout.astro`, `styles/global.css`.

## Test plan

- [x] `npm run build` — passes (`astro check` 0 errors, bundle within budget at 331.6/356.4 KB).
- [x] `npm test` — 610 passed / 7 skipped, no regressions.
- [ ] Re-shoot 1440 + 390 with `/tmp/shot.js`. **Note:** that script wasn't available in the sandbox where this branch was authored, so the before/after image set still needs to be regenerated locally before merge.
- [ ] Mobile (390) sanity check that the city `<details>` opens and closes naturally and the segmented `role="group"` doesn't wrap awkwardly.

## Out of scope

- Per-city aggregate prerendering for `CityWowStrip` (the city is geo-resolved client-side and the parquet shards are too large to fan out at build time — labeled skeletons cover the perceived-blank-tile problem).
- Replacing the decorative figure emojis in `MonitorGrid` (different visual treatment from inline icons; would require re-tuning sizes for all 6 tiles).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FUPSt1fXUVGX9RaJYnyk8U)_