### PR TITLE
feat(stats): regenerate sync_stats.json from live IA manifest + dedupe failure issues

### DIFF
--- a/.github/workflows/pncp-sync.yml
+++ b/.github/workflows/pncp-sync.yml
@@ -23,13 +23,19 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'schedule' }}
 
 permissions:
-  contents: write
+  contents: read
   issues: write
 
 jobs:
   sync:
     runs-on: ubuntu-latest
     timeout-minutes: 360
+    permissions:
+      # Only the sync job needs to push the refreshed sync_stats.json
+      # commit. The report-failure / report-recovery jobs operate on
+      # issues only (workflow-level issues:write covers them).
+      contents: write
+      issues: write
     env:
       # Keep a 3-minute buffer vs timeout-minutes=360 so the CLI exits gracefully first.
       SYNC_LIMIT_MINUTES: 357

--- a/.github/workflows/pncp-sync.yml
+++ b/.github/workflows/pncp-sync.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'schedule' }}
 
 permissions:
-  contents: read
+  contents: write
   issues: write
 
 jobs:
@@ -59,37 +59,98 @@ jobs:
 
           uv run baliza sync "${sync_args[@]}"
 
+      - name: Refresh sync_stats.json from live IA manifest
+        run: uv run python scripts/build_sync_stats.py
+
+      - name: Commit sync_stats.json if it changed
+        run: |
+          set -e
+          if git diff --quiet -- web/public/data/sync_stats.json; then
+            echo "sync_stats.json unchanged; skipping commit"
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add web/public/data/sync_stats.json
+          git commit -m "chore(stats): refresh sync_stats.json from manifest [skip ci]"
+          # Avoid clobbering any human commit that landed in parallel.
+          for i in 1 2 3 4 5; do
+            if git push origin HEAD:${GITHUB_REF_NAME}; then
+              exit 0
+            fi
+            git pull --rebase origin "${GITHUB_REF_NAME}" || true
+          done
+          echo "could not push refreshed sync_stats.json after retries" >&2
+          exit 1
+
   report-failure:
     name: Report workflow failure
     if: ${{ failure() }}
     needs: sync
     runs-on: ubuntu-latest
     steps:
-      - name: Open issue for failure
+      - name: Open or update single tracking issue for sync failures
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            // Single rolling tracking issue. The previous behavior filed a
+            // fresh issue per failed run, which produced 67 open duplicates
+            // in a single bad week. Now we keep one open issue and append
+            // a comment per recurrence, so triagers see the failure cadence
+            // without drowning in stacked tickets.
             const { owner, repo } = context.repo;
             const runId = context.runId;
             const runUrl = `${context.payload.repository.html_url}/actions/runs/${runId}`;
-            const identifier = `run_id:${runId}`;
+            const TRACKING_TITLE = '🚨 PNCP Sync workflow is failing';
 
-            const search = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${owner}/${repo} "${identifier}" state:open type:issue`
+            const open = await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: 'ci-failure', per_page: 100,
             });
-            if (search.data.total_count > 0) return;
+            const existing = open.data.find((i) => i.title === TRACKING_TITLE);
+            const body = [
+              `Latest failure: [run #${context.runNumber}](${runUrl})`,
+              '',
+              'Comments below track every subsequent failed run. The issue',
+              'is auto-closed by the next successful run.',
+            ].join('\n');
 
-            await github.rest.issues.create({
-              owner,
-              repo,
-              title: `🚨 Falha no workflow "PNCP Sync" (run #${context.runNumber})`,
-              body: [
-                '@codex há uma falha automática no workflow de sync.',
-                '',
-                `- **Workflow**: PNCP Sync`,
-                `- **Execução**: [#${context.runNumber}](${runUrl})`,
-                `- **Identificador**: ${identifier}`,
-              ].join('\n'),
-              labels: ['ci-failure']
+            if (!existing) {
+              await github.rest.issues.create({
+                owner, repo,
+                title: TRACKING_TITLE,
+                body,
+                labels: ['ci-failure'],
+              });
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: existing.number,
+              body: `Failure recurred: [run #${context.runNumber}](${runUrl})`,
+            });
+
+  report-recovery:
+    name: Auto-close tracking issue on green run
+    if: ${{ success() }}
+    needs: sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const TRACKING_TITLE = '🚨 PNCP Sync workflow is failing';
+            const open = await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: 'ci-failure', per_page: 100,
+            });
+            const existing = open.data.find((i) => i.title === TRACKING_TITLE);
+            if (!existing) return;
+            const runUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: existing.number,
+              body: `Sync recovered: [run #${context.runNumber}](${runUrl}). Closing.`,
+            });
+            await github.rest.issues.update({
+              owner, repo, issue_number: existing.number, state: 'closed',
             });

--- a/.github/workflows/pncp-sync.yml
+++ b/.github/workflows/pncp-sync.yml
@@ -60,6 +60,11 @@ jobs:
           uv run baliza sync "${sync_args[@]}"
 
       - name: Refresh sync_stats.json from live IA manifest
+        # Transient IA outage shouldn't mark the sync run failed —
+        # the script exits non-zero rather than overwriting last-known
+        # numbers with zeros, so we tolerate it here and let the next
+        # cron tick refresh the file.
+        continue-on-error: true
         run: uv run python scripts/build_sync_stats.py
 
       - name: Commit sync_stats.json if it changed

--- a/.github/workflows/pncp-sync.yml
+++ b/.github/workflows/pncp-sync.yml
@@ -96,7 +96,10 @@ jobs:
 
   report-failure:
     name: Report workflow failure
-    if: ${{ failure() }}
+    # Only the production cadence (cron on default branch) updates the
+    # shared tracking issue. Feature-branch workflow_dispatch runs are
+    # experiments — their failures shouldn't pollute the incident thread.
+    if: ${{ failure() && github.ref_name == github.event.repository.default_branch }}
     needs: sync
     runs-on: ubuntu-latest
     steps:
@@ -142,7 +145,9 @@ jobs:
 
   report-recovery:
     name: Auto-close tracking issue on green run
-    if: ${{ success() }}
+    # Same default-branch guard as report-failure: a green feature-branch
+    # dispatch must not falsely declare the production sync recovered.
+    if: ${{ success() && github.ref_name == github.event.repository.default_branch }}
     needs: sync
     runs-on: ubuntu-latest
     steps:

--- a/scripts/build_sync_stats.py
+++ b/scripts/build_sync_stats.py
@@ -69,13 +69,23 @@ def main() -> int:
         print("manifest is empty; leaving existing sync_stats.json", file=sys.stderr)
         return 1
 
-    total_contracts = sum(_to_int(r.get("row_count"), field="row_count") for r in rows)
+    # Restrict to canonical monthly partitions so non-canonical shards
+    # (e.g. monthly_uf splits introduced by consolidation) don't
+    # double-count rows already present in the canonical monthly file.
+    # Empty file_type is treated as canonical for backward compatibility
+    # with manifest entries written before the column was added.
+    canonical = [
+        r for r in rows
+        if (r.get("file_type") or "monthly_canonical") == "monthly_canonical"
+    ]
+
+    total_contracts = sum(_to_int(r.get("row_count"), field="row_count") for r in canonical)
     total_quarantine = sum(
-        _to_int(r.get("quarantine_count"), field="quarantine_count") for r in rows
+        _to_int(r.get("quarantine_count"), field="quarantine_count") for r in canonical
     )
 
     partitions = sorted(
-        {p for r in rows if (p := r.get("data_particao"))}
+        {p for r in canonical if (p := r.get("data_particao"))}
     )
     days_on_ia = 0
     if partitions:

--- a/scripts/build_sync_stats.py
+++ b/scripts/build_sync_stats.py
@@ -18,7 +18,10 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
-from baliza.ia_uploader import try_read_manifest_from_ia  # noqa: E402
+from baliza.ia_uploader import (  # noqa: E402
+    ManifestReadError,
+    read_manifest_from_ia,
+)
 
 
 def _to_int(raw: object) -> int:
@@ -40,7 +43,22 @@ def _partition_to_date(p: str) -> datetime | None:
 
 
 def main() -> int:
-    rows = try_read_manifest_from_ia()
+    # Use the strict reader so a transient IA outage raises and we exit
+    # with a clear error. Otherwise we'd write zeros and overwrite the
+    # last good snapshot — see Codex review on PR #541.
+    try:
+        rows = read_manifest_from_ia()
+    except ManifestReadError as exc:
+        print(f"manifest unreachable; leaving existing sync_stats.json: {exc}", file=sys.stderr)
+        return 1
+
+    if not rows:
+        # Empty manifest is genuine only on a brand-new IA item that has
+        # never published. In any project with real partitions this means
+        # something is wrong; refuse to publish zeros.
+        print("manifest is empty; leaving existing sync_stats.json", file=sys.stderr)
+        return 1
+
     total_contracts = sum(_to_int(r.get("row_count")) for r in rows)
     total_quarantine = sum(_to_int(r.get("quarantine_count")) for r in rows)
 

--- a/scripts/build_sync_stats.py
+++ b/scripts/build_sync_stats.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env -S uv run --quiet
+"""Regenerate ``web/public/data/sync_stats.json`` from the live IA manifest.
+
+The dashboard's "Sinal do arquivo" tile reads this JSON. Without this
+script the file was hand-edited once and pinned at numbers that drift
+roughly three orders of magnitude from reality. Run it from the
+PNCP sync workflow (so every green sync refreshes the published
+JSON) and from the web build (so dev/CI builds always see real
+numbers).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from baliza.ia_uploader import try_read_manifest_from_ia  # noqa: E402
+
+
+def _to_int(raw: object) -> int:
+    try:
+        return int(raw or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _partition_to_date(p: str) -> datetime | None:
+    # data_particao is "YYYY-MM" today; tolerate "YYYY-MM-DD" too in case
+    # the manifest schema gains daily granularity.
+    for fmt in ("%Y-%m", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(p, fmt).replace(tzinfo=UTC)
+        except ValueError:
+            continue
+    return None
+
+
+def main() -> int:
+    rows = try_read_manifest_from_ia()
+    total_contracts = sum(_to_int(r.get("row_count")) for r in rows)
+    total_quarantine = sum(_to_int(r.get("quarantine_count")) for r in rows)
+
+    partitions = sorted(
+        {p for r in rows if (p := r.get("data_particao"))}
+    )
+    days_on_ia = 0
+    if partitions:
+        oldest = _partition_to_date(partitions[0])
+        newest = _partition_to_date(partitions[-1])
+        if oldest and newest:
+            days_on_ia = (newest - oldest).days
+
+    payload = {
+        "total_contracts": total_contracts,
+        "total_quarantine": total_quarantine,
+        "days_on_ia": days_on_ia,
+        "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+    out = REPO_ROOT / "web" / "public" / "data" / "sync_stats.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {out.relative_to(REPO_ROOT)} :: {payload}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_sync_stats.py
+++ b/scripts/build_sync_stats.py
@@ -69,14 +69,17 @@ def main() -> int:
         print("manifest is empty; leaving existing sync_stats.json", file=sys.stderr)
         return 1
 
-    # Restrict to canonical monthly partitions so non-canonical shards
-    # (e.g. monthly_uf splits introduced by consolidation) don't
-    # double-count rows already present in the canonical monthly file.
-    # Empty file_type is treated as canonical for backward compatibility
-    # with manifest entries written before the column was added.
+    # Restrict to canonical monthly contratos partitions:
+    #   - file_type='monthly_canonical' (or empty for backward compat
+    #     with rows written before the column existed) so non-canonical
+    #     shards like monthly_uf don't double-count.
+    #   - table_name='contratos' so when the manifest grows to carry
+    #     atas / dispensas / itens, those rows don't inflate the
+    #     "Contratos citáveis" total or skew the partition span.
     canonical = [
         r for r in rows
         if (r.get("file_type") or "monthly_canonical") == "monthly_canonical"
+        and r.get("table_name") == "contratos"
     ]
 
     total_contracts = sum(_to_int(r.get("row_count"), field="row_count") for r in canonical)

--- a/scripts/build_sync_stats.py
+++ b/scripts/build_sync_stats.py
@@ -24,10 +24,20 @@ from baliza.ia_uploader import (  # noqa: E402
 )
 
 
-def _to_int(raw: object) -> int:
+def _to_int(raw: object, *, field: str) -> int:
+    if raw is None or raw == "":
+        return 0
     try:
-        return int(raw or 0)
+        return int(raw)
     except (TypeError, ValueError):
+        # Surface corrupt manifest cells loudly. We still default to 0 so
+        # one bad row doesn't block the whole publish, but the warning
+        # makes upstream rot visible rather than silently zeroing the
+        # totals.
+        print(
+            f"warning: could not coerce {field}={raw!r} to int; treating as 0",
+            file=sys.stderr,
+        )
         return 0
 
 
@@ -59,8 +69,10 @@ def main() -> int:
         print("manifest is empty; leaving existing sync_stats.json", file=sys.stderr)
         return 1
 
-    total_contracts = sum(_to_int(r.get("row_count")) for r in rows)
-    total_quarantine = sum(_to_int(r.get("quarantine_count")) for r in rows)
+    total_contracts = sum(_to_int(r.get("row_count"), field="row_count") for r in rows)
+    total_quarantine = sum(
+        _to_int(r.get("quarantine_count"), field="quarantine_count") for r in rows
+    )
 
     partitions = sorted(
         {p for r in rows if (p := r.get("data_particao"))}
@@ -69,7 +81,14 @@ def main() -> int:
     if partitions:
         oldest = _partition_to_date(partitions[0])
         newest = _partition_to_date(partitions[-1])
-        if oldest and newest:
+        if oldest is None or newest is None:
+            print(
+                f"warning: could not parse partition span "
+                f"({partitions[0]!r} .. {partitions[-1]!r}); "
+                "leaving days_on_ia at 0",
+                file=sys.stderr,
+            )
+        else:
             days_on_ia = (newest - oldest).days
 
     payload = {

--- a/web/scripts/build-data.mjs
+++ b/web/scripts/build-data.mjs
@@ -100,6 +100,16 @@ async function build() {
   console.log("Generating frontend config...");
   execSync('python3 scripts/build_frontend_config.py', { stdio: 'inherit', cwd: '..' });
 
+  // Refresh public/data/sync_stats.json from the live IA manifest so the
+  // homepage's "Sinal do arquivo" tile reflects real numbers. Tolerate
+  // failure (offline build, IA outage) — the existing JSON stays put.
+  console.log("Refreshing sync_stats.json from IA manifest...");
+  try {
+    execSync('python3 scripts/build_sync_stats.py', { stdio: 'inherit', cwd: '..' });
+  } catch (err) {
+    console.warn(`sync_stats.json refresh skipped: ${err.message}`);
+  }
+
   if (!fs.existsSync(QUERIES_DIR)) fs.mkdirSync(QUERIES_DIR, { recursive: true });
   await loadManifest();
   await ensureHttpfs();


### PR DESCRIPTION
## Summary

Replaces the hand-edited fiction in `web/public/data/sync_stats.json` (5,804 contracts, 3 in quarantine, 3 days on IA — committed once in #486 and never updated) with numbers regenerated from the live IA manifest.

**Verified ground truth from PR #540's diagnostic run:** 4,829,282 contracts across 56 distinct months (2021-09 → 2026-04), 0 in quarantine. The dashboard was off by ~832×.

### Changes

- `scripts/build_sync_stats.py` — reads the manifest via `baliza.ia_uploader.try_read_manifest_from_ia()`, sums `row_count` / `quarantine_count`, derives `days_on_ia` from the partition span, writes `web/public/data/sync_stats.json`.
- `web/scripts/build-data.mjs` — runs the script after `build_frontend_config.py` so dev/CI builds see real numbers. Tolerates IA outages (keeps the existing JSON in place).
- `.github/workflows/pncp-sync.yml`:
  - Refreshes `sync_stats.json` after each green sync and commits the result back to the branch with `[skip ci]` so the deployed site stays current between manual web releases.
  - Bumped `contents` permission from `read` to `write` for that commit.
  - **Collapses report-failure noise:** instead of opening a fresh issue per failed run (which produced 67 open ci-failure duplicates in one bad week), keeps a single rolling "🚨 PNCP Sync workflow is failing" issue and appends a comment per recurrence.
  - Adds `report-recovery` job that auto-closes the tracking issue on the first successful run.

### Test plan

- [ ] Workflow `dev` / `build` succeed locally (the script gracefully no-ops if IA is unreachable).
- [ ] After merge, the next green `PNCP Sync` cron run commits a fresh `sync_stats.json` with real numbers and the homepage SSR (PR #539) starts paint with them.
- [ ] After merge, the 67 stale ci-failure issues should be bulk-closed manually (out of scope for this PR — handled separately).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FUPSt1fXUVGX9RaJYnyk8U)_