### PR TITLE
feat(ops): tier-0 backup hygiene — doctor command, weekly check, scheduled backfill

### DIFF
--- a/.github/workflows/pncp-backfill.yml
+++ b/.github/workflows/pncp-backfill.yml
@@ -50,6 +50,16 @@ jobs:
           if [[ "$DRY_RUN" == "true" ]]; then
             extra+=(--dry-run)
           fi
+          # Mirror first so months that were never previously fetched
+          # (no manifest row, no raw ZIP) become buildable. The builder
+          # in src/baliza/builder.py only iterates manifest rows that
+          # already have raw_zip_url set, so a build-only run silently
+          # skips truly absent months — defeating the point of a
+          # historical backfill.
+          uv run baliza mirror \
+            --start-date "${START_YEAR}-01-01" \
+            --workers 2 \
+            "${extra[@]}"
           uv run baliza build \
             --backfill \
             --start-date "${START_YEAR}-01-01" \

--- a/.github/workflows/pncp-backfill.yml
+++ b/.github/workflows/pncp-backfill.yml
@@ -1,6 +1,12 @@
 name: PNCP Backfill
 
 on:
+  # First of each month at 04:00 UTC. Picks up any historical month
+  # that the cron sync missed (e.g. transient PNCP outage during the
+  # original window). The workflow is idempotent — already-uploaded
+  # months are skipped via the manifest check.
+  schedule:
+    - cron: '0 4 1 * *'
   workflow_dispatch:
     inputs:
       start_year:
@@ -31,9 +37,17 @@ jobs:
       - env:
           IA_ACCESS_KEY: ${{ secrets.IA_ACCESS_KEY }}
           IA_SECRET_KEY: ${{ secrets.IA_SECRET_KEY }}
+          # Cron runs have empty `inputs.*`; default to the same window
+          # the manual dispatch uses so the substitution stays valid.
+          START_YEAR: ${{ inputs.start_year || '2023' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
+          extra=()
+          if [[ "$DRY_RUN" == "true" ]]; then
+            extra+=(--dry-run)
+          fi
           uv run baliza build \
             --backfill \
-            --start-date "${{ inputs.start_year }}-01-01" \
+            --start-date "${START_YEAR}-01-01" \
             --workers 2 \
-            ${{ inputs.dry_run && '--dry-run' || '' }}
+            "${extra[@]}"

--- a/.github/workflows/pncp-backfill.yml
+++ b/.github/workflows/pncp-backfill.yml
@@ -42,6 +42,10 @@ jobs:
           START_YEAR: ${{ inputs.start_year || '2023' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
+          if [[ ! "$START_YEAR" =~ ^[0-9]{4}$ ]]; then
+            echo "::error::start_year must be a 4-digit year, got: $START_YEAR"
+            exit 1
+          fi
           extra=()
           if [[ "$DRY_RUN" == "true" ]]; then
             extra+=(--dry-run)

--- a/.github/workflows/pncp-doctor.yml
+++ b/.github/workflows/pncp-doctor.yml
@@ -1,0 +1,90 @@
+name: PNCP Doctor
+
+# Weekly read-only check on the live IA manifest. Runs `baliza doctor`
+# with --head-check so deleted IA files surface, and opens (or appends
+# to) a single rolling tracking issue if anything is wrong. Mirrors the
+# tracker pattern used by PNCP Sync to avoid issue-spam.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: pncp-doctor
+  cancel-in-progress: false
+
+jobs:
+  doctor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v4
+      - run: uv run baliza doctor --resource contratos --head-check
+
+  report-failure:
+    name: Open or update tracking issue
+    if: ${{ failure() && github.ref_name == github.event.repository.default_branch }}
+    needs: doctor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const runUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
+            const TITLE = '🩺 PNCP Doctor found backup integrity issues';
+            const open = await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: 'ci-failure', per_page: 100,
+            });
+            const existing = open.data.find((i) => i.title === TITLE);
+            if (!existing) {
+              await github.rest.issues.create({
+                owner, repo,
+                title: TITLE,
+                body: [
+                  `Latest finding: [run #${context.runNumber}](${runUrl})`,
+                  '',
+                  'Comments below track every subsequent failed run. The',
+                  'issue is auto-closed by the next clean doctor run.',
+                ].join('\n'),
+                labels: ['ci-failure'],
+              });
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: existing.number,
+              body: `Recurred: [run #${context.runNumber}](${runUrl})`,
+            });
+
+  report-recovery:
+    name: Auto-close on clean run
+    if: ${{ success() && github.ref_name == github.event.repository.default_branch }}
+    needs: doctor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const TITLE = '🩺 PNCP Doctor found backup integrity issues';
+            const open = await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: 'ci-failure', per_page: 100,
+            });
+            const existing = open.data.find((i) => i.title === TITLE);
+            if (!existing) return;
+            const runUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: existing.number,
+              body: `Doctor clean: [run #${context.runNumber}](${runUrl}). Closing.`,
+            });
+            await github.rest.issues.update({
+              owner, repo, issue_number: existing.number, state: 'closed',
+            });

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -954,7 +954,7 @@ def doctor(  # noqa: PLR0912, PLR0915
     """
     try:
         _validate_resource(resource)
-        start_date = clamp_to_known_data_start_month(
+        effective_start = clamp_to_known_data_start_month(
             resource, datetime.strptime(start, "%Y-%m-%d").date()
         )
     except ValueError as exc:
@@ -978,7 +978,7 @@ def doctor(  # noqa: PLR0912, PLR0915
     # Gap check (same window as `verify`).
     today = date.today()
     last_month_end = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
-    curr = start_date.replace(day=1)
+    curr = effective_start.replace(day=1)
     expected: list[str] = []
     while curr <= last_month_end:
         expected.append(curr.strftime("%Y-%m"))
@@ -992,7 +992,9 @@ def doctor(  # noqa: PLR0912, PLR0915
     for r in canonical:
         rid = f"{r.get('table_name','?')}/{r.get('data_particao','?')}"
         sha = r.get("sha256") or ""
-        if sha and not sha_re.match(sha):
+        if not sha:
+            findings.append(f"{rid}: missing sha256")
+        elif not sha_re.match(sha):
             findings.append(f"{rid}: sha256 not 64-hex ({sha!r})")
         for url_col in ("parquet_url", "raw_zip_url"):
             u = r.get(url_col) or ""
@@ -1008,7 +1010,13 @@ def doctor(  # noqa: PLR0912, PLR0915
 
     # Optional: probe URLs with HEAD to catch deleted IA files.
     if head_check:
-        with httpx.Client(follow_redirects=True, timeout=15.0) as client:
+        # Retry transient HEAD failures so a 1s IA blip doesn't cry wolf.
+        # 3 attempts, exponential backoff 1s/2s/4s. A genuine deletion
+        # is still surfaced because IA returns 4xx, not a transport error.
+        transport = httpx.HTTPTransport(retries=3)
+        with httpx.Client(
+            follow_redirects=True, timeout=15.0, transport=transport
+        ) as client:
             for r in canonical:
                 rid = f"{r.get('table_name','?')}/{r.get('data_particao','?')}"
                 for url_col in ("parquet_url", "raw_zip_url"):
@@ -1026,12 +1034,16 @@ def doctor(  # noqa: PLR0912, PLR0915
     if not findings:
         console.print(
             f"[green]✓ {resource}: {len(canonical)} canonical month(s), "
-            f"{start_date.strftime('%Y-%m')} .. {last_month_end.strftime('%Y-%m')}, "
+            f"{effective_start.strftime('%Y-%m')} .. {last_month_end.strftime('%Y-%m')}, "
             f"no findings.[/green]"
         )
         return
 
-    console.print(f"[red]✗ {resource}: {len(findings)} finding(s)[/red]")
+    shown = min(len(findings), 50)
+    console.print(
+        f"[red]✗ {resource}: {len(findings)} finding(s) "
+        f"(showing first {shown})[/red]"
+    )
     for f in findings[:50]:
         console.print(f"  • {f}")
     if len(findings) > 50:
@@ -1070,9 +1082,11 @@ def orphans(
         raise typer.Exit(1)
 
     expected_per_item = {
-        # Files the current pipeline is allowed to produce per IA monthly item.
+        # Files the current pipeline is allowed to produce per IA monthly
+        # item — see IAUploader.upload_month in src/baliza/ia_uploader.py.
         "{resource}-{month}.parquet",
         "quarentena-{month}.csv",
+        "raw-{month}.zip",
     }
 
     total_orphans = 0

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -1019,8 +1019,8 @@ def doctor(  # noqa: PLR0912, PLR0915
     # Optional: probe URLs with HEAD to catch deleted IA files.
     if head_check:
         # Retry transient HEAD failures so a 1s IA blip doesn't cry wolf.
-        # 3 attempts, exponential backoff 1s/2s/4s. A genuine deletion
-        # is still surfaced because IA returns 4xx, not a transport error.
+        # 3 attempts. A genuine deletion is still surfaced because IA
+        # returns 4xx, not a transport error.
         transport = httpx.HTTPTransport(retries=3)
         with httpx.Client(
             follow_redirects=True, timeout=15.0, transport=transport
@@ -1030,6 +1030,17 @@ def doctor(  # noqa: PLR0912, PLR0915
                 for url_col in ("parquet_url", "raw_zip_url"):
                     u = r.get(url_col) or ""
                     if not u:
+                        continue
+                    # Defense in depth: never let doctor make outbound
+                    # requests to a host the manifest validator already
+                    # rejected. A malicious/accidental external URL
+                    # would otherwise turn the scheduled cron into an
+                    # SSRF probe from the GHA runner.
+                    host = urlparse(u).netloc
+                    if not (
+                        u.startswith("https://")
+                        and (host == "archive.org" or host.endswith(".archive.org"))
+                    ):
                         continue
                     try:
                         resp = client.head(u)

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -998,7 +998,15 @@ def doctor(  # noqa: PLR0912, PLR0915
             findings.append(f"{rid}: sha256 not 64-hex ({sha!r})")
         for url_col in ("parquet_url", "raw_zip_url"):
             u = r.get(url_col) or ""
-            if u and not (u.startswith("https://") and urlparse(u).netloc.endswith("archive.org")):
+            if not u:
+                continue
+            host = urlparse(u).netloc
+            # Require an exact archive.org host or a true subdomain so
+            # 'evilarchive.org' doesn't pass the integrity check.
+            on_ia = u.startswith("https://") and (
+                host == "archive.org" or host.endswith(".archive.org")
+            )
+            if not on_ia:
                 findings.append(f"{rid}: {url_col} not on archive.org ({u!r})")
         if not r.get("parquet_url"):
             findings.append(f"{rid}: missing parquet_url")
@@ -1090,7 +1098,9 @@ def orphans(
     }
 
     total_orphans = 0
-    with httpx.Client(timeout=30.0) as client:
+    fetch_failures = 0
+    transport = httpx.HTTPTransport(retries=3)
+    with httpx.Client(timeout=30.0, transport=transport) as client:
         for r in canonical:
             month = r["data_particao"]
             item_id = r.get("ia_item_id") or f"baliza-pncp-{month}"
@@ -1098,6 +1108,7 @@ def orphans(
                 meta = client.get(f"https://archive.org/metadata/{item_id}").json()
             except Exception as exc:
                 console.print(f"[red]{item_id}: metadata fetch failed: {exc}[/red]")
+                fetch_failures += 1
                 continue
             allowed = {
                 t.format(resource=resource, month=month) for t in expected_per_item
@@ -1118,6 +1129,17 @@ def orphans(
             for f in orphan_files:
                 console.print(f"  • {f}")
 
-    console.print(f"\n[bold]{total_orphans} orphan file(s) across {len(canonical)} month(s).[/bold]")
-    if total_orphans:
+    console.print(
+        f"\n[bold]{total_orphans} orphan file(s) across "
+        f"{len(canonical) - fetch_failures}/{len(canonical)} month(s) "
+        f"inspected.[/bold]"
+    )
+    if fetch_failures:
+        console.print(
+            f"[red]✗ {fetch_failures} month(s) could not be inspected; "
+            "result is partial.[/red]"
+        )
+    # Treat fetch failures as orphan-like: a partial scan must not look
+    # green because callers (CI) cannot tell it apart from a true clean.
+    if total_orphans or fetch_failures:
         raise typer.Exit(1)

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -931,3 +931,183 @@ def consolidate_cmd(
     except Exception as e:
         console.print(f"[red]✗ Consolidation failed: {e}")
         raise typer.Exit(1) from e
+
+
+@app.command("doctor")
+def doctor(
+    resource: str = typer.Option(RESOURCE_CONTRATOS, "--resource", "-r", help="Resource to check"),
+    start: str = typer.Option("2021-01-01", "--start", help="Earliest month to check (YYYY-MM-DD)"),
+    head_check: bool = typer.Option(
+        False,
+        "--head-check/--no-head-check",
+        help="HTTP HEAD every parquet_url and raw_zip_url. Slower but catches deleted IA files.",
+    ),
+) -> None:
+    """Read-only health check on the live IA manifest.
+
+    Reports any of: missing months, malformed manifest rows, broken URLs,
+    invalid sha256, table_name mismatch with --resource. Exits 1 on any
+    finding so it can drive a CI alert.
+    """
+    import re
+    from urllib.parse import urlparse
+
+    import httpx
+
+    try:
+        _validate_resource(resource)
+        start_date = clamp_to_known_data_start_month(
+            resource, datetime.strptime(start, "%Y-%m-%d").date()
+        )
+    except ValueError as exc:
+        console.print(f"[red]✗ {exc}[/red]")
+        raise typer.Exit(1) from None
+
+    try:
+        rows = read_manifest_from_ia()
+    except Exception as exc:
+        console.print(f"[red]✗ Could not read manifest: {exc}[/red]")
+        raise typer.Exit(1) from None
+
+    findings: list[str] = []
+    canonical = [
+        r for r in rows
+        if r.get("table_name") == resource
+        and (r.get("file_type") or "monthly_canonical") == "monthly_canonical"
+    ]
+    months_present = {r["data_particao"] for r in canonical if r.get("data_particao")}
+
+    # Gap check (same window as `verify`).
+    today = date.today()
+    last_month_end = (today.replace(day=1) - timedelta(days=1)).replace(day=1)
+    curr = start_date.replace(day=1)
+    expected: list[str] = []
+    while curr <= last_month_end:
+        expected.append(curr.strftime("%Y-%m"))
+        curr = curr.replace(year=curr.year + 1, month=1) if curr.month == 12 else curr.replace(month=curr.month + 1)
+    gaps = [m for m in expected if m not in months_present]
+    if gaps:
+        findings.append(f"missing canonical months for {resource}: {len(gaps)} (e.g. {gaps[:5]})")
+
+    # Per-row schema sanity.
+    sha_re = re.compile(r"^[0-9a-f]{64}$")
+    for r in canonical:
+        rid = f"{r.get('table_name','?')}/{r.get('data_particao','?')}"
+        sha = r.get("sha256") or ""
+        if sha and not sha_re.match(sha):
+            findings.append(f"{rid}: sha256 not 64-hex ({sha!r})")
+        for url_col in ("parquet_url", "raw_zip_url"):
+            u = r.get(url_col) or ""
+            if u and not (u.startswith("https://") and urlparse(u).netloc.endswith("archive.org")):
+                findings.append(f"{rid}: {url_col} not on archive.org ({u!r})")
+        if not r.get("parquet_url"):
+            findings.append(f"{rid}: missing parquet_url")
+        if not r.get("raw_zip_url"):
+            findings.append(f"{rid}: missing raw_zip_url")
+        # uf_sigla must be empty on canonical rows.
+        if r.get("uf_sigla"):
+            findings.append(f"{rid}: canonical row has uf_sigla={r['uf_sigla']!r}")
+
+    # Optional: probe URLs with HEAD to catch deleted IA files.
+    if head_check:
+        with httpx.Client(follow_redirects=True, timeout=15.0) as client:
+            for r in canonical:
+                rid = f"{r.get('table_name','?')}/{r.get('data_particao','?')}"
+                for url_col in ("parquet_url", "raw_zip_url"):
+                    u = r.get(url_col) or ""
+                    if not u:
+                        continue
+                    try:
+                        resp = client.head(u)
+                    except Exception as exc:
+                        findings.append(f"{rid}: {url_col} HEAD failed ({exc})")
+                        continue
+                    if resp.status_code >= 400:
+                        findings.append(f"{rid}: {url_col} HEAD {resp.status_code}")
+
+    if not findings:
+        console.print(
+            f"[green]✓ {resource}: {len(canonical)} canonical month(s), "
+            f"{start_date.strftime('%Y-%m')} .. {last_month_end.strftime('%Y-%m')}, "
+            f"no findings.[/green]"
+        )
+        return
+
+    console.print(f"[red]✗ {resource}: {len(findings)} finding(s)[/red]")
+    for f in findings[:50]:
+        console.print(f"  • {f}")
+    if len(findings) > 50:
+        console.print(f"  ... and {len(findings) - 50} more.")
+    raise typer.Exit(1)
+
+
+@app.command("orphans")
+def orphans(
+    resource: str = typer.Option(RESOURCE_CONTRATOS, "--resource", "-r", help="Resource to check"),
+    months: int = typer.Option(3, "--months", help="How many recent months to inspect"),
+) -> None:
+    """List files inside per-month IA items that aren't in the manifest.
+
+    Read-only. Surfaces legacy daily/per-supplier parquets left over by
+    older pipeline shapes (the live audit found ~28 stale files per
+    month in baliza-pncp-{YYYY-MM}). Garbage collection is intentionally
+    a separate, destructive command — do not add it here without a
+    --apply flag and explicit IA credentials.
+    """
+    import httpx
+
+    try:
+        rows = read_manifest_from_ia()
+    except Exception as exc:
+        console.print(f"[red]✗ Could not read manifest: {exc}[/red]")
+        raise typer.Exit(1) from None
+
+    canonical = [
+        r for r in rows
+        if r.get("table_name") == resource
+        and (r.get("file_type") or "monthly_canonical") == "monthly_canonical"
+    ]
+    canonical.sort(key=lambda r: r.get("data_particao", ""), reverse=True)
+    canonical = canonical[:months]
+    if not canonical:
+        console.print(f"[yellow]No canonical rows for {resource}.[/yellow]")
+        raise typer.Exit(1)
+
+    expected_per_item = {
+        # Files the current pipeline is allowed to produce per IA monthly item.
+        "{resource}-{month}.parquet",
+        "quarentena-{month}.csv",
+    }
+
+    total_orphans = 0
+    with httpx.Client(timeout=30.0) as client:
+        for r in canonical:
+            month = r["data_particao"]
+            item_id = r.get("ia_item_id") or f"baliza-pncp-{month}"
+            try:
+                meta = client.get(f"https://archive.org/metadata/{item_id}").json()
+            except Exception as exc:
+                console.print(f"[red]{item_id}: metadata fetch failed: {exc}[/red]")
+                continue
+            allowed = {
+                t.format(resource=resource, month=month) for t in expected_per_item
+            } | {
+                # IA-managed sidecars never count as orphans.
+                f"{item_id}_archive.torrent",
+                f"{item_id}_files.xml",
+                f"{item_id}_meta.sqlite",
+                f"{item_id}_meta.xml",
+            }
+            files = [f["name"] for f in meta.get("files", [])]
+            orphan_files = [f for f in files if f not in allowed]
+            if not orphan_files:
+                console.print(f"[green]{item_id}: clean ({len(files)} files)[/green]")
+                continue
+            total_orphans += len(orphan_files)
+            console.print(f"[yellow]{item_id}: {len(orphan_files)} orphan(s)[/yellow]")
+            for f in orphan_files:
+                console.print(f"  • {f}")
+
+    console.print(f"\n[bold]{total_orphans} orphan file(s) across {len(canonical)} month(s).[/bold]")
+    if total_orphans:
+        raise typer.Exit(1)

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -9,11 +9,14 @@ from __future__ import annotations
 import concurrent.futures
 import json
 import os
+import re
 import sys
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
+import httpx
 import structlog
 import typer
 from rich.console import Console
@@ -934,7 +937,7 @@ def consolidate_cmd(
 
 
 @app.command("doctor")
-def doctor(
+def doctor(  # noqa: PLR0912, PLR0915
     resource: str = typer.Option(RESOURCE_CONTRATOS, "--resource", "-r", help="Resource to check"),
     start: str = typer.Option("2021-01-01", "--start", help="Earliest month to check (YYYY-MM-DD)"),
     head_check: bool = typer.Option(
@@ -949,11 +952,6 @@ def doctor(
     invalid sha256, table_name mismatch with --resource. Exits 1 on any
     finding so it can drive a CI alert.
     """
-    import re
-    from urllib.parse import urlparse
-
-    import httpx
-
     try:
         _validate_resource(resource)
         start_date = clamp_to_known_data_start_month(
@@ -1054,8 +1052,6 @@ def orphans(
     a separate, destructive command — do not add it here without a
     --apply flag and explicit IA credentials.
     """
-    import httpx
-
     try:
         rows = read_manifest_from_ia()
     except Exception as exc:


### PR DESCRIPTION
Tier-0 from the backup-completeness plan: small operational wins that lock in hygiene before the bigger multi-resource refactor.

## What this ships

### `baliza doctor`  (`src/baliza/cli_simple.py`)
Read-only health check on the live IA manifest. Per resource it asserts:

- **Coverage:** no gap in the canonical-month series from `--start` to last completed month.
- **Schema sanity:** `sha256` is 64-hex, `parquet_url` and `raw_zip_url` are on `archive.org`, neither is empty, `uf_sigla` is blank on canonical rows.
- **(`--head-check`)** HEADs every `parquet_url` + `raw_zip_url` to catch IA files that have been deleted out from under the manifest.

Exits non-zero on any finding so it drives CI.

### `baliza orphans`
Read-only listing of files inside per-month IA items that the current pipeline doesn't produce. The live audit found ~28 legacy daily/`fornecedores` parquets per month inside `baliza-pncp-{YYYY-MM}` items — leftovers from an older pipeline shape. **Garbage collection is intentionally separate** — this command only surfaces them so the destructive step gets its own PR with explicit credentials.

### `.github/workflows/pncp-doctor.yml`
Weekly cron (`0 6 * * 1`) running `baliza doctor --head-check`. Same single-rolling-tracker pattern as the dedupe in PR #541 — one issue, comments per recurrence, auto-closed by the next clean run. Default-branch-gated so feature-branch dispatches don't pollute it.

### `.github/workflows/pncp-backfill.yml`
Adds a monthly cron (`0 4 1 * *`) on top of the existing `workflow_dispatch`. The build is idempotent so already-uploaded months are skipped; the cron just makes sure historical coverage advances without manual dispatch. Env vars now default so a cron run with no inputs still produces a valid command line.

## Test plan

- [ ] `uv run baliza doctor --resource contratos` locally → green for the 56-month current window.
- [ ] `uv run baliza doctor --head-check` → still green after probing every URL.
- [ ] `uv run baliza orphans --months 1` → lists the legacy daily files in `baliza-pncp-2026-04`.
- [ ] First cron tick of `pncp-doctor.yml` after merge → green with no tracking issue filed.

## Out of scope (later PRs)

- Actually deleting orphan files (separate destructive PR with `--apply` flag).
- Multi-resource refactor (Tier 1) — unblocks atas / contratacoes / pca ingestion.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FUPSt1fXUVGX9RaJYnyk8U)_