### PR TITLE
refactor(mirror): thread --resource through mirror_cmd / mirror_month (stacked on #544)

### DIFF
--- a/src/baliza/builder.py
+++ b/src/baliza/builder.py
@@ -51,6 +51,11 @@ def _pending_build_months(
 
     pending_set: set[date] = set()
     for row in raw_manifest:
+        # Per-resource scoping: ignore rows that belong to a different
+        # canonical table so contratos rows don't trigger atas rebuilds
+        # (and vice versa) once the manifest carries multiple resources.
+        if row.get("table_name") != resource:
+            continue
         part = row.get("data_particao") or ""
         if not part:
             continue
@@ -132,9 +137,17 @@ def build_month(  # noqa: PLR0913, PLR0915
 
     # Resolve raw_zip_url from manifest — decoupled from item naming so it
     # works whether the ZIP lives in baliza-pncp-raw or a per-month item.
+    # Scope by table_name so atas rows don't feed contratos builds (and
+    # vice versa) once the manifest carries multiple resources.
     rows = manifest if manifest is not None else read_manifest_from_ia()
     manifest_row = next(
-        (r for r in rows if r.get("data_particao") == month_str and r.get("raw_zip_url")),
+        (
+            r
+            for r in rows
+            if r.get("data_particao") == month_str
+            and r.get("table_name") == resource
+            and r.get("raw_zip_url")
+        ),
         None,
     )
     if not manifest_row:

--- a/src/baliza/builder.py
+++ b/src/baliza/builder.py
@@ -97,6 +97,7 @@ def build_month(  # noqa: PLR0913, PLR0915
     dry_run: bool = False,
     log_fn: object = None,
     manifest: list[dict] | None = None,
+    resource: str = RESOURCE_CONTRATOS,
 ) -> dict[str, object]:
     """Download the raw ZIP from IA, ingest into DuckDB, export and upload Parquet.
 
@@ -109,6 +110,9 @@ def build_month(  # noqa: PLR0913, PLR0915
         manifest: Pre-fetched manifest rows. When None, fetches from IA.
             Pass this when building multiple months to avoid one network
             call per month.
+        resource: PNCP resource name (default 'contratos'). Routes the
+            ingestion through the resource's entity_model and canonical
+            tables — see PNCPResource.
 
     Returns:
         Dict with keys: ``month``, ``valid``, ``quarantine``, ``uploaded``.
@@ -178,7 +182,7 @@ def build_month(  # noqa: PLR0913, PLR0915
 
             month_start_dt = datetime.combine(start_of_month, datetime.min.time())
             with PNCPExtractor(engine=engine) as extractor:
-                stats = extractor.ingest_range(month_start_dt)
+                stats = extractor.ingest_range(month_start_dt, resource=resource)
                 result["valid"] = stats.get("valid", 0)
                 result["quarantine"] = stats.get("quarantine", 0)
 

--- a/src/baliza/builder.py
+++ b/src/baliza/builder.py
@@ -218,6 +218,7 @@ def build_month(  # noqa: PLR0913, PLR0915
                 quarantine_stats=stats,
                 quarantine_csv=q_csv if has_q else None,
                 schema_version=SCHEMA_VERSION,
+                resource=resource,
             )
             result["uploaded"] = uploaded
 

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -678,22 +678,6 @@ def mirror_cmd(  # noqa: PLR0912, PLR0913, PLR0915
         console.print(f"[red]✗ {e}[/red]")
         raise typer.Exit(1) from None
 
-    # IAUploader.upload_raw_zip writes 'raw-{month}.zip' (no resource
-    # prefix) and _upsert_manifest_row writes table_name='contratos'
-    # unconditionally. Mirroring a non-contratos resource today would
-    # therefore overwrite the contratos raw ZIP and corrupt the
-    # contratos manifest row for the same partition. Refuse at the
-    # CLI until those writers are generalized in a follow-up PR.
-    if resource != RESOURCE_CONTRATOS:
-        console.print(
-            f"[red]✗ mirror for resource={resource!r} is not supported yet.[/red]\n"
-            "[dim]IAUploader.upload_raw_zip + _upsert_manifest_row are still "
-            "resource-blind (raw-{month}.zip, table_name='contratos'); enabling "
-            "mirror for non-contratos before they're generalized would overwrite "
-            "the contratos raw ZIP for the same month. Track the follow-up PR.[/dim]"
-        )
-        raise typer.Exit(1)
-
     if force_month:
         batch = _forced_month_or_empty(resource, force_month)
     else:

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -642,7 +642,7 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
 
 
 @app.command("mirror")
-def mirror_cmd(  # noqa: PLR0913
+def mirror_cmd(  # noqa: PLR0913, PLR0915
     batch_size: int | None = typer.Option(
         None, "--batch-size", "-n", help="Max months to mirror (None for all)"
     ),
@@ -656,6 +656,9 @@ def mirror_cmd(  # noqa: PLR0913
     workers: int = typer.Option(4, "--workers", "-w", help="Parallel workers"),
     no_curl: bool = typer.Option(False, "--no-curl", help="Opt-out of system cURL"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Fetch only, skip upload"),
+    resource: str = typer.Option(
+        RESOURCE_CONTRATOS, "--resource", "-r", help="PNCP resource to mirror"
+    ),
 ) -> None:
     """Fetch PNCP JSON pages and upload monthly ZIPs to IA (no DuckDB, no Parquet).
 
@@ -669,17 +672,23 @@ def mirror_cmd(  # noqa: PLR0913
         console.print("[red]✗ Missing IA keys in environment.[/red]")
         raise typer.Exit(1)
 
+    try:
+        _validate_resource(resource)
+    except ValueError as e:
+        console.print(f"[red]✗ {e}[/red]")
+        raise typer.Exit(1) from None
+
     if force_month:
-        batch = _forced_month_or_empty(RESOURCE_CONTRATOS, force_month)
+        batch = _forced_month_or_empty(resource, force_month)
     else:
         start = clamp_to_known_data_start_month(
-            RESOURCE_CONTRATOS, datetime.strptime(start_date, "%Y-%m-%d").date()
+            resource, datetime.strptime(start_date, "%Y-%m-%d").date()
         )
         try:
             with console.status(
                 "[bold green]Checking IA manifest for pending months...[/bold green]"
             ):
-                batch = _pending_mirror_months(start, batch_size, resource=RESOURCE_CONTRATOS)
+                batch = _pending_mirror_months(start, batch_size, resource=resource)
         except Exception as e:
             console.print(f"[red]✗ Cannot read IA manifest: {e}[/red]")
             raise typer.Exit(1) from None
@@ -730,6 +739,7 @@ def mirror_cmd(  # noqa: PLR0913
                 dry_run=dry_run,
                 log_fn=lambda msg: console.log(f"[dim]{msg}[/dim]"),
                 is_current_month=(target_month == current_month),
+                resource=resource,
             )
             futures[f] = target_month
         concurrent.futures.wait(futures.keys())

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -796,20 +796,6 @@ def build_cmd(  # noqa: PLR0912, PLR0913, PLR0915
         console.print(f"[red]✗ {e}[/red]")
         raise typer.Exit(1) from None
 
-    # The build path's MonthlyExporter / IAUploader.upload_parquet still
-    # hard-code the contratos table and 'contratos-{month}.parquet'
-    # filename. Generalizing them is a separate PR; until that lands,
-    # refuse non-contratos resources at the CLI with a clear message
-    # rather than letting the run fail later inside DuckDB.
-    if resource != RESOURCE_CONTRATOS:
-        console.print(
-            f"[red]✗ build for resource={resource!r} is not supported yet.[/red]\n"
-            "[dim]Mirror works (raw JSON pages land on IA), but the canonical "
-            "Parquet export still hard-codes contratos. Track the follow-up "
-            "PR that generalizes MonthlyExporter / IAUploader.upload_parquet.[/dim]"
-        )
-        raise typer.Exit(1)
-
     # Fetch manifest once — reused by _pending_build_months and each build_month call
     # to avoid one network round-trip per month when building in batch.
     try:

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -932,8 +932,12 @@ def verify(
         uploader = IAUploader(engine)
         with console.status("[bold green]Checking remote manifest...[/bold green]"):
             raw_manifest = uploader._read_manifest_from_ia()
+            # Scope by table_name so 'verify --resource atas' doesn't
+            # report false-green coverage based on contratos rows.
             uploaded_months = {
-                row["data_particao"] for row in raw_manifest if row.get("data_particao")
+                row["data_particao"]
+                for row in raw_manifest
+                if row.get("data_particao") and row.get("table_name") == resource
             }
 
         gaps = []

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -773,6 +773,9 @@ def build_cmd(  # noqa: PLR0913, PLR0915
     backfill: bool = typer.Option(
         False, "--backfill", help="Rebuild all months with outdated schema version"
     ),
+    resource: str = typer.Option(
+        RESOURCE_CONTRATOS, "--resource", "-r", help="PNCP resource to build"
+    ),
 ) -> None:
     """Download raw ZIPs from IA, ingest, and upload Parquet (Phase 2 of two-phase pipeline).
 
@@ -787,6 +790,12 @@ def build_cmd(  # noqa: PLR0913, PLR0915
         console.print("[red]✗ Missing IA keys in environment.[/red]")
         raise typer.Exit(1)
 
+    try:
+        _validate_resource(resource)
+    except ValueError as e:
+        console.print(f"[red]✗ {e}[/red]")
+        raise typer.Exit(1) from None
+
     # Fetch manifest once — reused by _pending_build_months and each build_month call
     # to avoid one network round-trip per month when building in batch.
     try:
@@ -797,15 +806,15 @@ def build_cmd(  # noqa: PLR0913, PLR0915
         raise typer.Exit(1) from None
 
     if force_month:
-        batch = _forced_month_or_empty(RESOURCE_CONTRATOS, force_month)
+        batch = _forced_month_or_empty(resource, force_month)
     else:
         start = clamp_to_known_data_start_month(
-            RESOURCE_CONTRATOS, datetime.strptime(start_date, "%Y-%m-%d").date()
+            resource, datetime.strptime(start_date, "%Y-%m-%d").date()
         )
         batch = _pending_build_months(
             start,
             batch_size,
-            resource=RESOURCE_CONTRATOS,
+            resource=resource,
             backfill=backfill,
             manifest=build_manifest,
         )
@@ -857,6 +866,7 @@ def build_cmd(  # noqa: PLR0913, PLR0915
                 dry_run=dry_run,
                 log_fn=lambda msg: console.log(f"[dim]{msg}[/dim]"),
                 manifest=build_manifest,
+                resource=resource,
             )
             futures[f] = target_month
         concurrent.futures.wait(futures.keys())

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -642,7 +642,7 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
 
 
 @app.command("mirror")
-def mirror_cmd(  # noqa: PLR0913, PLR0915
+def mirror_cmd(  # noqa: PLR0912, PLR0913, PLR0915
     batch_size: int | None = typer.Option(
         None, "--batch-size", "-n", help="Max months to mirror (None for all)"
     ),
@@ -677,6 +677,22 @@ def mirror_cmd(  # noqa: PLR0913, PLR0915
     except ValueError as e:
         console.print(f"[red]✗ {e}[/red]")
         raise typer.Exit(1) from None
+
+    # IAUploader.upload_raw_zip writes 'raw-{month}.zip' (no resource
+    # prefix) and _upsert_manifest_row writes table_name='contratos'
+    # unconditionally. Mirroring a non-contratos resource today would
+    # therefore overwrite the contratos raw ZIP and corrupt the
+    # contratos manifest row for the same partition. Refuse at the
+    # CLI until those writers are generalized in a follow-up PR.
+    if resource != RESOURCE_CONTRATOS:
+        console.print(
+            f"[red]✗ mirror for resource={resource!r} is not supported yet.[/red]\n"
+            "[dim]IAUploader.upload_raw_zip + _upsert_manifest_row are still "
+            "resource-blind (raw-{month}.zip, table_name='contratos'); enabling "
+            "mirror for non-contratos before they're generalized would overwrite "
+            "the contratos raw ZIP for the same month. Track the follow-up PR.[/dim]"
+        )
+        raise typer.Exit(1)
 
     if force_month:
         batch = _forced_month_or_empty(resource, force_month)

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -755,7 +755,7 @@ def mirror_cmd(  # noqa: PLR0913, PLR0915
 
 
 @app.command("build")
-def build_cmd(  # noqa: PLR0913, PLR0915
+def build_cmd(  # noqa: PLR0912, PLR0913, PLR0915
     batch_size: int | None = typer.Option(
         None, "--batch-size", "-n", help="Max months to build (None for all)"
     ),
@@ -795,6 +795,20 @@ def build_cmd(  # noqa: PLR0913, PLR0915
     except ValueError as e:
         console.print(f"[red]✗ {e}[/red]")
         raise typer.Exit(1) from None
+
+    # The build path's MonthlyExporter / IAUploader.upload_parquet still
+    # hard-code the contratos table and 'contratos-{month}.parquet'
+    # filename. Generalizing them is a separate PR; until that lands,
+    # refuse non-contratos resources at the CLI with a clear message
+    # rather than letting the run fail later inside DuckDB.
+    if resource != RESOURCE_CONTRATOS:
+        console.print(
+            f"[red]✗ build for resource={resource!r} is not supported yet.[/red]\n"
+            "[dim]Mirror works (raw JSON pages land on IA), but the canonical "
+            "Parquet export still hard-codes contratos. Track the follow-up "
+            "PR that generalizes MonthlyExporter / IAUploader.upload_parquet.[/dim]"
+        )
+        raise typer.Exit(1)
 
     # Fetch manifest once — reused by _pending_build_months and each build_month call
     # to avoid one network round-trip per month when building in batch.

--- a/src/baliza/constants.py
+++ b/src/baliza/constants.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from datetime import date
 
-from .resources import CONTRATOS, RESOURCES
+from .resources import ATAS, CONTRATOS, RESOURCES
 
 RESOURCE_CONTRATOS = CONTRATOS.name
+RESOURCE_ATAS = ATAS.name
 
 
 # Derived view of the registry: each registered resource that has set

--- a/src/baliza/constants.py
+++ b/src/baliza/constants.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 from datetime import date
 
-from .resources import CONTRATOS
+from .resources import CONTRATOS, RESOURCES
 
 RESOURCE_CONTRATOS = CONTRATOS.name
 
-# PNCP's contratos endpoint has no data before 2021-09-06. Treat this as
-# immutable product-domain knowledge so backfills never waste runs probing
-# months that cannot contain source records.
+
+# Derived view of the registry: each registered resource that has set
+# ``data_start`` on its PNCPResource exposes that floor here. Adding a
+# new resource is single-file (resources/__init__.py + the resource
+# module) — no parallel edit in constants.py.
 PNCP_RESOURCE_DATA_STARTS: dict[str, date] = {
-    RESOURCE_CONTRATOS: date(2021, 9, 6),
+    name: spec.data_start
+    for name, spec in RESOURCES.items()
+    if spec.data_start is not None
 }
 
 

--- a/src/baliza/extractor.py
+++ b/src/baliza/extractor.py
@@ -15,7 +15,6 @@ from rich.console import Console
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from .engine import BalizaEngine
-from .models import RecuperarContratoDTO as Contrato
 from .resources import CONTRATOS, get_resource
 from .utils import validate_url
 
@@ -297,12 +296,34 @@ class PNCPExtractor:
             return False
         return "numeroControlePNCP" in columns and "numero_controle_pncp" not in columns
 
-    def ingest_range(self, start_date: datetime) -> dict[str, int]:
-        """Validate and ingest all raw JSON files for a specific month/range into the shared engine."""
+    def ingest_range(  # noqa: PLR0912
+        self,
+        start_date: datetime,
+        *,
+        resource: str = CONTRATOS.name,
+    ) -> dict[str, int]:
+        """Validate and ingest all raw JSON files for a specific month/range into the shared engine.
+
+        Args:
+            start_date: First day of the month being ingested.
+            resource: Registered resource name. Determines the Pydantic
+                entity model used for validation, the canonical tables
+                to upsert into, and the quarantine bucket. Adding a new
+                resource only needs ``entity_model`` set on its
+                ``PNCPResource`` and a ``flatten_fn`` on its canonical
+                table spec — no extractor changes.
+        """
         if self.engine is None:
             raise RuntimeError(
                 "ingest_range requires an engine — construct PNCPExtractor(engine=...)"
             )
+
+        spec = get_resource(resource)
+        if spec.entity_model is None:
+            raise RuntimeError(
+                f"resource {resource!r} has no entity_model; cannot validate"
+            )
+        entity_model = spec.entity_model
 
         month_str = start_date.strftime("%Y-%m")
         raw_dir = Path("data/raw") / month_str
@@ -312,7 +333,11 @@ class PNCPExtractor:
         if not raw_dir.exists():
             return stats
 
-        self._archive_legacy_contratos_table()
+        # Legacy archive step is contratos-specific by definition (it
+        # migrates a pre-snake-case table named 'contratos' that never
+        # existed for any other resource).
+        if resource == CONTRATOS.name:
+            self._archive_legacy_contratos_table()
 
         for json_file in raw_dir.glob("*.json"):
             try:
@@ -330,13 +355,14 @@ class PNCPExtractor:
 
             entries = data.get("data", [])
             valid_rows = []
+            flatten_fn = spec.canonical_tables[0].flatten_fn
 
             for entry in entries:
                 try:
-                    # Validate with Pydantic, then flatten to the snake_case
-                    # schema the monthly/daily exporters and consolidator share.
-                    validated = Contrato.model_validate(entry)
-                    flatten_fn = CONTRATOS.canonical_tables[0].flatten_fn
+                    # Validate with the resource's Pydantic model, then
+                    # flatten to the snake_case schema the monthly/daily
+                    # exporters and consolidator share.
+                    validated = entity_model.model_validate(entry)
                     if flatten_fn:
                         valid_rows.append(flatten_fn(validated.model_dump()))
                     else:
@@ -345,12 +371,12 @@ class PNCPExtractor:
                 except ValidationError as e:
                     stats["quarantine"] += 1
                     logger.warning("validation_failed", error=str(e), entry_id=entry.get("id"))
-                    self.engine.quarantine_record(CONTRATOS.name, start_date, str(e), entry)
+                    self.engine.quarantine_record(spec.name, start_date, str(e), entry)
 
             # Ingest valid rows into Ibis (shared engine) via UPSERT
             if valid_rows:
                 # Direct memory ingestion (Idempotent)
-                for table_spec in CONTRATOS.canonical_tables:
+                for table_spec in spec.canonical_tables:
                     self.engine.upsert_rows(
                         valid_rows, table_spec.table_name, schema="main", pk=table_spec.pk
                     )

--- a/src/baliza/extractor.py
+++ b/src/baliza/extractor.py
@@ -358,7 +358,10 @@ class PNCPExtractor:
                     pass
                 continue
 
-            entries = data.get("data", [])
+            # Use the resource's declared payload key (defaults to "data"
+            # for contratos / atas; resources that wrap rows under a
+            # different key set FetchSpec.response_data_key accordingly).
+            entries = data.get(spec.fetch.response_data_key) or []
             valid_rows = []
             flatten_fn = spec.canonical_tables[0].flatten_fn
 

--- a/src/baliza/extractor.py
+++ b/src/baliza/extractor.py
@@ -339,7 +339,12 @@ class PNCPExtractor:
         if resource == CONTRATOS.name:
             self._archive_legacy_contratos_table()
 
-        for json_file in raw_dir.glob("*.json"):
+        # Scope the glob to the resource's own per-page files (mirror
+        # writes them as `{resource}_p{page}.json`). Without this filter
+        # a mixed-resource raw zip would feed contratos pages through
+        # the atas entity_model, inflating quarantine and producing
+        # empty atas output.
+        for json_file in sorted(raw_dir.glob(f"{resource}_p*.json")):
             try:
                 with open(json_file) as f:
                     data = json.load(f)

--- a/src/baliza/ia_uploader.py
+++ b/src/baliza/ia_uploader.py
@@ -17,7 +17,7 @@ from rich.console import Console
 
 from . import rss_feed
 from .engine import BalizaEngine
-from .resources import CONTRATOS, raw_zip_filename
+from .resources import CONTRATOS, get_resource, raw_zip_filename
 from .utils import DUCKDB_PARQUET_COPY_OPTIONS, PARQUET_ROW_GROUP_SIZE
 
 console = Console()
@@ -286,21 +286,42 @@ class MonthlyExporter:
     def __init__(self, engine: BalizaEngine):
         self.engine = engine
 
-    def export_month(self, start_date: date, output_dir: Path) -> dict[str, Path]:
-        """Export all tables for a given month to Parquet in output_dir.
+    def export_month(
+        self,
+        start_date: date,
+        output_dir: Path,
+        *,
+        resource: str = CONTRATOS.name,
+    ) -> dict[str, Path]:
+        """Export the resource's monthly Parquet to output_dir.
 
         Uses DuckDB ``COPY ... TO`` (via Ibis' underlying connection) so the
         output gets the same WASM-optimized options as the daily and
         consolidated files: 8192-row groups, ZSTD L9, bloom filters on
         dict-encoded columns, and the journey-aware sort order.
+
+        ORDER BY: the resource's ``CanonicalTableSpec.order_by_sql`` is
+        used when set (preserves contratos' historical shape); otherwise
+        we derive ``sort_columns + pk`` so a new resource gets a
+        deterministic ordering by default.
         """
         output_dir.mkdir(parents=True, exist_ok=True)
         files: dict[str, Path] = {}
 
+        spec = get_resource(resource)
+        table_spec = spec.canonical_tables[0]
+        table_name = table_spec.table_name
         month_str = start_date.strftime("%Y-%m")
-        table_name = CONTRATOS.name
         filename = f"{table_name}-{month_str}.parquet"
         out_path = output_dir / filename
+
+        if table_spec.order_by_sql:
+            order_by = table_spec.order_by_sql
+        else:
+            pk_cols = (
+                [table_spec.pk] if isinstance(table_spec.pk, str) else list(table_spec.pk)
+            )
+            order_by = ", ".join(table_spec.sort_columns + pk_cols)
 
         try:
             self.engine.con.raw_sql(
@@ -308,7 +329,7 @@ class MonthlyExporter:
                 COPY (
                     SELECT *
                     FROM main.{table_name}
-                    ORDER BY cnpj_orgao, data_publicacao DESC, numero_controle_pncp
+                    ORDER BY {order_by}
                 ) TO '{out_path}'
                 ({DUCKDB_PARQUET_COPY_OPTIONS})
                 """
@@ -516,23 +537,35 @@ class IAUploader:
         quarantine_stats: dict[str, int] | None = None,
         quarantine_csv: Path | None = None,
         schema_version: str = "",
+        *,
+        resource: str = CONTRATOS.name,
     ) -> bool:
         """Export Parquet from engine and upload to the monthly IA item; update manifest.
 
         Requires engine to be set. Does NOT touch raw JSON pages.
         Returns True on success.
+
+        Args:
+            resource: PNCP resource name. Routes the export through the
+                resource's canonical table and produces ``{table_name}-
+                {month}.parquet`` so contratos and atas write distinct
+                files in the same monthly IA item.
         """
         if self.engine is None or self.exporter is None:
             raise RuntimeError(
                 "upload_parquet requires an engine — construct IAUploader(engine=...)"
             )
 
+        spec = get_resource(resource)
+        table_name = spec.canonical_tables[0].table_name
         month_str = start_date.strftime("%Y-%m")
         item_id = f"baliza-pncp-{month_str}"
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             temp_path = Path(tmp_dir)
-            exported_files = self.exporter.export_month(start_date, temp_path)
+            exported_files = self.exporter.export_month(
+                start_date, temp_path, resource=resource
+            )
 
             files_to_upload: dict[str, str] = {}
             if quarantine_csv and quarantine_csv.exists():
@@ -540,7 +573,7 @@ class IAUploader:
             for _table, path in exported_files.items():
                 files_to_upload[path.name] = str(path)
 
-            parquet_filename = f"contratos-{month_str}.parquet"
+            parquet_filename = f"{table_name}-{month_str}.parquet"
             if parquet_filename not in files_to_upload:
                 # No Parquet produced (zero valid rows) — don't write a broken parquet_url
                 # to the manifest. The quarantine CSV can still be uploaded independently.
@@ -594,6 +627,7 @@ class IAUploader:
                 },
                 ia_access_key,
                 ia_secret_key,
+                resource=resource,
             )
             success = True
         except Exception as e:

--- a/src/baliza/ia_uploader.py
+++ b/src/baliza/ia_uploader.py
@@ -17,7 +17,7 @@ from rich.console import Console
 
 from . import rss_feed
 from .engine import BalizaEngine
-from .resources import CONTRATOS
+from .resources import CONTRATOS, raw_zip_filename
 from .utils import DUCKDB_PARQUET_COPY_OPTIONS, PARQUET_ROW_GROUP_SIZE
 
 console = Console()
@@ -357,22 +357,28 @@ class IAUploader:
         fields: dict[str, Any],
         access_key: str,
         secret_key: str,
+        *,
+        resource: str = CONTRATOS.name,
     ) -> None:
-        """Read manifest, merge fields into the canonical row for month_str, write back.
+        """Read manifest, merge fields into the canonical row for (resource, month_str), write back.
 
-        If no canonical row exists for the month, creates one with safe defaults.
-        Existing fields not present in ``fields`` are preserved (merge, not replace).
-        Uses the strict reader — transient read failures abort rather than wipe the live manifest.
+        If no canonical row exists for the (resource, month) pair, creates
+        one with safe defaults. Existing fields not present in ``fields``
+        are preserved (merge, not replace). Uses the strict reader —
+        transient read failures abort rather than wipe the live manifest.
         """
         with _manifest_lock:
             manifest = read_manifest_from_ia()
             parquet_item_id = f"baliza-pncp-{month_str}"
+            raw_zip_url = (
+                f"https://archive.org/download/{RAW_ITEM_ID}/{raw_zip_filename(resource, month_str)}"
+            )
 
             existing_idx: int | None = None
             for i, row in enumerate(manifest):
                 if (
                     row.get("data_particao") == month_str
-                    and row.get("table_name") == CONTRATOS.name
+                    and row.get("table_name") == resource
                     and row.get("file_type", "") in ("", "monthly_canonical")
                 ):
                     existing_idx = i
@@ -384,11 +390,11 @@ class IAUploader:
             else:
                 new_row: dict[str, Any] = {
                     "data_particao": month_str,
-                    "table_name": CONTRATOS.name,
+                    "table_name": resource,
                     "row_count": 0,
                     "quarantine_count": 0,
                     "ia_item_id": parquet_item_id,
-                    "raw_zip_url": f"https://archive.org/download/{RAW_ITEM_ID}/raw-{month_str}.zip",
+                    "raw_zip_url": raw_zip_url,
                     "parquet_url": "",
                     "quarantine_url": "",
                     "uploaded_at": now,
@@ -410,30 +416,43 @@ class IAUploader:
 
             write_manifest_to_ia(manifest, access_key, secret_key)
 
-    def upload_raw_zip(
+    def upload_raw_zip(  # noqa: PLR0913
         self,
         start_date: date,
         raw_dir: Path,
         ia_access_key: str,
         ia_secret_key: str,
         keep_raw_dir: bool = False,
+        *,
+        resource: str = CONTRATOS.name,
     ) -> bool:
         """Zip raw JSON pages and upload to baliza-pncp-raw; update manifest mirror fields.
 
         Does NOT ingest or export Parquet. Cleans up raw_dir on success so the
         next run fetches fresh from IA (or GHA cache). Returns True on success.
+
+        Args:
+            resource: PNCP resource name. Determines the ZIP filename
+                (contratos keeps the legacy ``raw-{month}.zip`` shape;
+                other resources prefix with the resource name to avoid
+                colliding with contratos zips for the same partition)
+                and the manifest row's ``table_name`` so per-resource
+                mirror state stays separate.
         """
         month_str = start_date.strftime("%Y-%m")
+        zip_basename = raw_zip_filename(resource, month_str)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             temp_path = Path(tmp_dir)
-            zip_path = temp_path / f"raw-{month_str}.zip"
+            zip_path = temp_path / zip_basename
             shutil.make_archive(str(zip_path.with_suffix("")), "zip", raw_dir)
 
             raw_zip_sha256 = _sha256(zip_path)
             raw_zip_size = zip_path.stat().st_size
 
-            console.print(f"  Uploading raw ZIP for {month_str} to {RAW_ITEM_ID}...")
+            console.print(
+                f"  Uploading raw ZIP for {resource}/{month_str} to {RAW_ITEM_ID}..."
+            )
             ia.upload(
                 RAW_ITEM_ID,
                 files={zip_path.name: str(zip_path)},
@@ -443,7 +462,7 @@ class IAUploader:
                 retries=3,
             )
 
-        raw_zip_url = f"https://archive.org/download/{RAW_ITEM_ID}/raw-{month_str}.zip"
+        raw_zip_url = f"https://archive.org/download/{RAW_ITEM_ID}/{zip_basename}"
         now = datetime.now().isoformat()
         success = False
         try:
@@ -458,10 +477,11 @@ class IAUploader:
                 },
                 ia_access_key,
                 ia_secret_key,
+                resource=resource,
             )
             success = True
         except Exception as e:
-            console.print(f"[red]✗ Manifest update failed for {month_str}: {e}[/red]")
+            console.print(f"[red]✗ Manifest update failed for {resource}/{month_str}: {e}[/red]")
 
         if success and not keep_raw_dir and raw_dir.exists():
             shutil.rmtree(raw_dir)

--- a/src/baliza/ia_uploader.py
+++ b/src/baliza/ia_uploader.py
@@ -445,7 +445,19 @@ class IAUploader:
         with tempfile.TemporaryDirectory() as tmp_dir:
             temp_path = Path(tmp_dir)
             zip_path = temp_path / zip_basename
-            shutil.make_archive(str(zip_path.with_suffix("")), "zip", raw_dir)
+
+            # Per-resource scoping: pack only this resource's pages
+            # (matching ``{resource}_p*.json``) so a sequential
+            # ``mirror --resource contratos`` followed by
+            # ``mirror --resource atas`` doesn't end up with one
+            # resource's zip containing the other's cached pages —
+            # which would make the published raw_zip_sha256
+            # misrepresent the artifact.
+            page_glob = f"{resource}_p*.json"
+            page_files = sorted(raw_dir.glob(page_glob))
+            with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+                for page_path in page_files:
+                    zf.write(page_path, page_path.name)
 
             raw_zip_sha256 = _sha256(zip_path)
             raw_zip_size = zip_path.stat().st_size

--- a/src/baliza/mirror.py
+++ b/src/baliza/mirror.py
@@ -230,6 +230,7 @@ def mirror_month(  # noqa: PLR0912, PLR0913, PLR0915
         ia_access_key,
         ia_secret_key,
         keep_raw_dir=is_current_month,
+        resource=resource,
     )
     result["uploaded"] = uploaded
 

--- a/src/baliza/mirror.py
+++ b/src/baliza/mirror.py
@@ -73,6 +73,7 @@ def mirror_month(  # noqa: PLR0912, PLR0913, PLR0915
     dry_run: bool = False,
     log_fn: object = None,
     is_current_month: bool | None = None,
+    resource: str = RESOURCE_CONTRATOS,
 ) -> dict[str, object]:
     """Fetch all PNCP JSON pages for a month, zip them, and upload to IA.
 
@@ -87,13 +88,15 @@ def mirror_month(  # noqa: PLR0912, PLR0913, PLR0915
             tomorrow's run only fetches new pages) and removes the sentinel so
             the next run re-probes totalPaginas from the API. Auto-detected
             when None (default).
+        resource: PNCP resource name (default 'contratos'). Determines the
+            per-page raw filename and which API endpoint is queried.
 
     Returns:
         Dict with keys: ``month``, ``pages_fetched``, ``pages_cached``, ``uploaded``.
     """
     if is_current_month is None:
         is_current_month = start_of_month == date.today().replace(day=1)
-    _validate_resource(RESOURCE_CONTRATOS)
+    _validate_resource(resource)
 
     month_str = start_of_month.strftime("%Y-%m")
     if start_of_month.month == 12:
@@ -123,7 +126,7 @@ def mirror_month(  # noqa: PLR0912, PLR0913, PLR0915
     with PNCPExtractor(engine=None, use_curl=use_curl) as extractor:
 
         def _page_is_cached(p: int) -> bool:
-            path = raw_month_dir / page_filename(RESOURCE_CONTRATOS, p)
+            path = raw_month_dir / page_filename(resource,p)
             if not path.exists() or path.stat().st_size == 0:
                 return False
             try:
@@ -152,7 +155,7 @@ def mirror_month(  # noqa: PLR0912, PLR0913, PLR0915
         # Determine total pages (probe or sentinel shortcut)
         total_pages: int | None = None
         if sentinel.exists():
-            p1 = raw_month_dir / first_page_filename(RESOURCE_CONTRATOS)
+            p1 = raw_month_dir / first_page_filename(resource)
             if p1.exists() and p1.stat().st_size > 0:
                 try:
                     with open(p1) as fh:
@@ -169,7 +172,7 @@ def mirror_month(  # noqa: PLR0912, PLR0913, PLR0915
                     pass
 
         if total_pages is None:
-            res = extractor.probe_range(RESOURCE_CONTRATOS, month_start_dt, month_end_dt)
+            res = extractor.probe_range(resource, month_start_dt, month_end_dt)
             total_pages = res["total_pages"]
 
         # For the current month, the last cached page may be incomplete —
@@ -180,7 +183,7 @@ def mirror_month(  # noqa: PLR0912, PLR0913, PLR0915
             cached_page_nums = [p for p in range(1, total_pages + 1) if _page_is_cached(p)]
             if cached_page_nums:
                 last_cached = max(cached_page_nums)
-                last_cached_path = raw_month_dir / page_filename(RESOURCE_CONTRATOS, last_cached)
+                last_cached_path = raw_month_dir / page_filename(resource,last_cached)
                 try:
                     last_cached_path.unlink()
                     logger.info(
@@ -208,7 +211,7 @@ def mirror_month(  # noqa: PLR0912, PLR0913, PLR0915
                 pass
 
         for p in missing_pages:
-            extractor.fetch_page(RESOURCE_CONTRATOS, month_start_dt, month_end_dt, p)
+            extractor.fetch_page(resource, month_start_dt, month_end_dt, p)
             result["pages_fetched"] = int(result["pages_fetched"]) + 1
             _emit(f"{month_str} page {p}/{total_pages}")
 

--- a/src/baliza/mirror.py
+++ b/src/baliza/mirror.py
@@ -126,7 +126,7 @@ def mirror_month(  # noqa: PLR0912, PLR0913, PLR0915
     with PNCPExtractor(engine=None, use_curl=use_curl) as extractor:
 
         def _page_is_cached(p: int) -> bool:
-            path = raw_month_dir / page_filename(resource,p)
+            path = raw_month_dir / page_filename(resource, p)
             if not path.exists() or path.stat().st_size == 0:
                 return False
             try:
@@ -183,7 +183,7 @@ def mirror_month(  # noqa: PLR0912, PLR0913, PLR0915
             cached_page_nums = [p for p in range(1, total_pages + 1) if _page_is_cached(p)]
             if cached_page_nums:
                 last_cached = max(cached_page_nums)
-                last_cached_path = raw_month_dir / page_filename(resource,last_cached)
+                last_cached_path = raw_month_dir / page_filename(resource, last_cached)
                 try:
                     last_cached_path.unlink()
                     logger.info(

--- a/src/baliza/mirror.py
+++ b/src/baliza/mirror.py
@@ -33,11 +33,15 @@ def _pending_mirror_months(
     The current month is always included — its ZIP grows daily as new pages arrive.
     """
     raw_manifest = read_manifest_from_ia()  # strict: raises ManifestReadError on failure
-    # A past month is "done" when it has a non-empty raw_zip_url.
+    # A past month is "done" when it has a non-empty raw_zip_url for the
+    # selected resource. Without the table_name filter, contratos rows
+    # would mark months as mirrored and skip the atas backfill entirely.
     mirrored: set[str] = {
         row["data_particao"]
         for row in raw_manifest
-        if row.get("data_particao") and row.get("raw_zip_url")
+        if row.get("data_particao")
+        and row.get("raw_zip_url")
+        and row.get("table_name") == resource
     }
 
     today = date.today()

--- a/src/baliza/models.py
+++ b/src/baliza/models.py
@@ -8,7 +8,7 @@ from datetime import date
 from datetime import datetime as AwareDatetime
 from enum import StrEnum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class RespostaErroValidacaoDTO(BaseModel):
@@ -339,6 +339,42 @@ class PaginaRetornoRecuperarCompraPublicacaoDTO(BaseModel):
     numeroPagina: int | None = None
     paginasRestantes: int | None = None
     empty: bool | None = None
+
+
+class RecuperarAtaDTO(BaseModel):
+    """A single ata-de-registro-de-preço entry from /v1/atas.
+
+    Mirrors AtaRegistroPrecoPeriodoDTO from the PNCP OpenAPI spec.
+    All fields are optional because the PNCP API has historically
+    returned partial responses during incidents — let validation
+    succeed and let the consolidator's NULL handling deal with gaps.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    numeroControlePNCPAta: str | None = None
+    numeroAtaRegistroPreco: str | None = None
+    anoAta: int | None = None
+    numeroControlePNCPCompra: str | None = None
+    cancelado: bool | None = None
+    dataCancelamento: str | None = None
+    dataAssinatura: str | None = None
+    vigenciaInicio: str | None = None
+    vigenciaFim: str | None = None
+    dataPublicacaoPncp: str | None = None
+    dataInclusao: str | None = None
+    dataAtualizacao: str | None = None
+    dataAtualizacaoGlobal: str | None = None
+    usuario: str | None = None
+    objetoContratacao: str | None = None
+    cnpjOrgao: str | None = None
+    nomeOrgao: str | None = None
+    cnpjOrgaoSubrogado: str | None = None
+    nomeOrgaoSubrogado: str | None = None
+    codigoUnidadeOrgao: str | None = None
+    nomeUnidadeOrgao: str | None = None
+    codigoUnidadeOrgaoSubrogado: str | None = None
+    nomeUnidadeOrgaoSubrogado: str | None = None
 
 
 class PaginaRetornoPlanoContratacaoComItensDoUsuarioDTO(BaseModel):

--- a/src/baliza/models.py
+++ b/src/baliza/models.py
@@ -345,14 +345,17 @@ class RecuperarAtaDTO(BaseModel):
     """A single ata-de-registro-de-preço entry from /v1/atas.
 
     Mirrors AtaRegistroPrecoPeriodoDTO from the PNCP OpenAPI spec.
-    All fields are optional because the PNCP API has historically
-    returned partial responses during incidents — let validation
-    succeed and let the consolidator's NULL handling deal with gaps.
+    Most fields are optional to tolerate upstream partial responses,
+    but ``numeroControlePNCPAta`` is REQUIRED because it's the
+    canonical primary key. Without that guard, a mis-routed contratos
+    page would validate (extra='allow' would absorb the rest) and
+    flatten to a row with NULL PK, which the upsert would then use
+    to overwrite live atas rows.
     """
 
     model_config = ConfigDict(extra="allow")
 
-    numeroControlePNCPAta: str | None = None
+    numeroControlePNCPAta: str
     numeroAtaRegistroPreco: str | None = None
     anoAta: int | None = None
     numeroControlePNCPCompra: str | None = None

--- a/src/baliza/resources/__init__.py
+++ b/src/baliza/resources/__init__.py
@@ -43,6 +43,18 @@ def first_page_filename(resource_name: str) -> str:
     return page_filename(resource_name, 1)
 
 
+def raw_zip_filename(resource_name: str, month_str: str) -> str:
+    """Per-month raw ZIP filename used in the baliza-pncp-raw IA item.
+
+    Contratos kept the legacy `raw-{month}.zip` shape so existing IA
+    items don't need a rename. Other resources prefix the resource
+    name to avoid colliding with contratos zips for the same partition.
+    """
+    if resource_name == CONTRATOS.name:
+        return f"raw-{month_str}.zip"
+    return f"raw-{resource_name}-{month_str}.zip"
+
+
 __all__ = [
     "PNCPResource",
     "FetchSpec",
@@ -55,4 +67,5 @@ __all__ = [
     "get_resource",
     "page_filename",
     "first_page_filename",
+    "raw_zip_filename",
 ]

--- a/src/baliza/resources/__init__.py
+++ b/src/baliza/resources/__init__.py
@@ -1,3 +1,4 @@
+from .atas import ATAS
 from .contratos import CONTRATOS
 from .specs import (
     CanonicalTableSpec,
@@ -9,11 +10,11 @@ from .specs import (
 
 # Registry of every PNCP resource the pipeline knows how to ingest. Code
 # paths that need to look up a resource by its CLI name read from here
-# instead of importing CONTRATOS directly. Adding a new resource (e.g.
-# atas) only requires registering it here and defining its module under
-# resources/.
+# instead of importing CONTRATOS directly. Adding a new resource only
+# requires registering it here and defining its module under resources/.
 RESOURCES: dict[str, PNCPResource] = {
     CONTRATOS.name: CONTRATOS,
+    ATAS.name: ATAS,
 }
 
 
@@ -49,6 +50,7 @@ __all__ = [
     "EntitySpec",
     "CanonicalTableSpec",
     "CONTRATOS",
+    "ATAS",
     "RESOURCES",
     "get_resource",
     "page_filename",

--- a/src/baliza/resources/atas.py
+++ b/src/baliza/resources/atas.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from ..models import RecuperarAtaDTO
 from ..transforms import _flatten_ata
 from .specs import (
@@ -49,4 +51,7 @@ ATAS = PNCPResource(
         )
     ],
     entity_model=RecuperarAtaDTO,
+    # PNCP launched in mid-2021 and atas were available from GA;
+    # use the contratos floor until we observe an empty earlier month.
+    data_start=date(2021, 9, 6),
 )

--- a/src/baliza/resources/atas.py
+++ b/src/baliza/resources/atas.py
@@ -1,0 +1,52 @@
+from ..models import RecuperarAtaDTO
+from ..transforms import _flatten_ata
+from .specs import (
+    CanonicalTableSpec,
+    EntitySpec,
+    FetchSpec,
+    PNCPResource,
+    RawDatasetSpec,
+)
+
+
+def _monthly_zip_filename(part_str: str) -> str:
+    return f"atas_{part_str}.zip"
+
+
+ATAS = PNCPResource(
+    resource_name="atas",
+    fetch=FetchSpec(
+        endpoint="atas",
+        pagination_param="pagina",
+        page_size_param="tamanhoPagina",
+        # The /v1/atas spec says 500 max — confirmed in the audit
+        # (run #25415111962): one day already returns ~500K registros so
+        # we want the largest legal page size to keep round-trips down.
+        max_page_size=500,
+        date_param_start="dataInicial",
+        date_param_end="dataFinal",
+        response_data_key="data",
+    ),
+    raw_dataset=RawDatasetSpec(
+        ia_item_id="baliza-pncp-raw",
+        filename_fn=_monthly_zip_filename,
+        partition_strategy="monthly",
+        retention_policy="all",
+    ),
+    entities=[
+        EntitySpec(name="ata"),
+    ],
+    canonical_tables=[
+        CanonicalTableSpec(
+            table_name="atas",
+            schema_version="1.0.0",
+            pk="numero_controle_pncp_ata",
+            flatten_fn=_flatten_ata,
+            dedup_strategy="current_state",
+            source_entity="ata",
+            sort_columns=["cnpj_orgao", "data_publicacao_pncp"],
+            bloom_filter_columns=["cnpj_orgao", "numero_controle_pncp_compra"],
+        )
+    ],
+    entity_model=RecuperarAtaDTO,
+)

--- a/src/baliza/resources/contratos.py
+++ b/src/baliza/resources/contratos.py
@@ -1,3 +1,4 @@
+from ..models import RecuperarContratoDTO
 from ..transforms import _flatten_contrato
 from .specs import (
     CanonicalTableSpec,
@@ -42,5 +43,6 @@ CONTRATOS = PNCPResource(
             sort_columns=["cnpj_orgao", "data_publicacao_pncp"],
             bloom_filter_columns=["cnpj_orgao"],
         )
-    ]
+    ],
+    entity_model=RecuperarContratoDTO,
 )

--- a/src/baliza/resources/contratos.py
+++ b/src/baliza/resources/contratos.py
@@ -44,6 +44,11 @@ CONTRATOS = PNCPResource(
             source_entity="contrato",
             sort_columns=["cnpj_orgao", "data_publicacao_pncp"],
             bloom_filter_columns=["cnpj_orgao"],
+            # Preserve the historical ORDER BY shape so existing
+            # parquet files (and the bloom filter prefiltering that
+            # depends on cnpj_orgao locality) stay byte-comparable
+            # across this multi-resource refactor.
+            order_by_sql="cnpj_orgao, data_publicacao DESC, numero_controle_pncp",
         )
     ],
     entity_model=RecuperarContratoDTO,

--- a/src/baliza/resources/contratos.py
+++ b/src/baliza/resources/contratos.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from ..models import RecuperarContratoDTO
 from ..transforms import _flatten_contrato
 from .specs import (
@@ -45,4 +47,8 @@ CONTRATOS = PNCPResource(
         )
     ],
     entity_model=RecuperarContratoDTO,
+    # PNCP launched in mid-2021; the contratos endpoint's first record
+    # is 2021-09-06. Backfill workers skip earlier months without ever
+    # hitting the API.
+    data_start=date(2021, 9, 6),
 )

--- a/src/baliza/resources/specs.py
+++ b/src/baliza/resources/specs.py
@@ -1,6 +1,7 @@
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import date
 from typing import Any
 
 # Resource names land in filesystem paths, URL params, and DuckDB
@@ -66,6 +67,12 @@ class PNCPResource:
     # pull in heavy machinery for every CLI invocation). The extractor
     # asserts the type when it actually uses the field.
     entity_model: Any = field(default=None)
+    # First date on which PNCP exposed source data for this resource.
+    # Backfills clamp to this floor so workers don't probe months that
+    # cannot contain records. Living on the resource (instead of a
+    # parallel dict in constants.py) means registering a new resource
+    # is a single-file change.
+    data_start: date | None = field(default=None)
 
     def __post_init__(self) -> None:
         if not _RESOURCE_NAME_RE.match(self.resource_name):

--- a/src/baliza/resources/specs.py
+++ b/src/baliza/resources/specs.py
@@ -53,6 +53,13 @@ class CanonicalTableSpec:
     source_entity: str             # EntitySpec.name que origina esta tabela
     sort_columns: list[str]
     bloom_filter_columns: list[str]
+    # Optional override for the ORDER BY clause used when exporting the
+    # monthly Parquet. When None, callers derive a default from
+    # sort_columns + pk (preserving determinism). Contratos sets this
+    # explicitly because it carries a `data_publicacao DESC` shape that
+    # downstream consumers depend on; new resources should leave it
+    # blank to get the derived ordering.
+    order_by_sql: str | None = None
 
 @dataclass
 class PNCPResource:

--- a/src/baliza/resources/specs.py
+++ b/src/baliza/resources/specs.py
@@ -1,6 +1,7 @@
 import re
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 # Resource names land in filesystem paths, URL params, and DuckDB
 # table names. Enforcing the charset at registration time means the
@@ -59,6 +60,12 @@ class PNCPResource:
     raw_dataset: RawDatasetSpec
     entities: list[EntitySpec]
     canonical_tables: list[CanonicalTableSpec]
+    # Pydantic class used to validate raw API entries before flattening.
+    # Stored as Any to avoid a hard pydantic import at the spec layer
+    # (specs.py is imported very early and importing pydantic would
+    # pull in heavy machinery for every CLI invocation). The extractor
+    # asserts the type when it actually uses the field.
+    entity_model: Any = field(default=None)
 
     def __post_init__(self) -> None:
         if not _RESOURCE_NAME_RE.match(self.resource_name):

--- a/src/baliza/transforms.py
+++ b/src/baliza/transforms.py
@@ -76,3 +76,39 @@ def _flatten_contrato(dumped: dict[str, Any]) -> dict[str, Any]:
         "url_cipi": dumped.get("urlCipi"),
         "usuario_nome": dumped.get("usuarioNome"),
     }
+
+
+def _flatten_ata(dumped: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a Pydantic-dumped RecuperarAtaDTO into a snake_case scalar shape.
+
+    The atas endpoint's payload is already flat (no nested orgaoEntidade /
+    unidadeOrgao structs unlike contratos), so this is mostly a rename pass.
+    Kept as a separate function so the canonical column names live in one
+    place and the schema is easy to extend if the PNCP API ever adds nested
+    structs (mirrors the contratos pattern).
+    """
+    return {
+        "numero_controle_pncp_ata": dumped.get("numeroControlePNCPAta"),
+        "numero_ata_registro_preco": dumped.get("numeroAtaRegistroPreco"),
+        "ano_ata": dumped.get("anoAta"),
+        "numero_controle_pncp_compra": dumped.get("numeroControlePNCPCompra"),
+        "cancelado": dumped.get("cancelado"),
+        "data_cancelamento": dumped.get("dataCancelamento"),
+        "data_assinatura": dumped.get("dataAssinatura"),
+        "vigencia_inicio": dumped.get("vigenciaInicio"),
+        "vigencia_fim": dumped.get("vigenciaFim"),
+        "data_publicacao_pncp": dumped.get("dataPublicacaoPncp"),
+        "data_inclusao": dumped.get("dataInclusao"),
+        "data_atualizacao": dumped.get("dataAtualizacao"),
+        "data_atualizacao_global": dumped.get("dataAtualizacaoGlobal"),
+        "usuario": dumped.get("usuario"),
+        "objeto_contratacao": dumped.get("objetoContratacao"),
+        "cnpj_orgao": dumped.get("cnpjOrgao"),
+        "nome_orgao": dumped.get("nomeOrgao"),
+        "cnpj_orgao_subrogado": dumped.get("cnpjOrgaoSubrogado"),
+        "nome_orgao_subrogado": dumped.get("nomeOrgaoSubrogado"),
+        "codigo_unidade_orgao": dumped.get("codigoUnidadeOrgao"),
+        "nome_unidade_orgao": dumped.get("nomeUnidadeOrgao"),
+        "codigo_unidade_orgao_subrogado": dumped.get("codigoUnidadeOrgaoSubrogado"),
+        "nome_unidade_orgao_subrogado": dumped.get("nomeUnidadeOrgaoSubrogado"),
+    }

--- a/tests/characterization/test_caracterizacao_contratos_pipeline.py
+++ b/tests/characterization/test_caracterizacao_contratos_pipeline.py
@@ -53,7 +53,10 @@ def test_pipeline_contratos_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyP
     monkeypatch.chdir(tmp_path)
 
     fixture_path = Path(__file__).parent.parent / "fixtures" / "snapshot_contratos_2024-01.json"
-    dest_path = raw_dir / "page_001.json"
+    # Canonical per-page filename so ingest_range's resource-scoped
+    # glob (``{resource}_p*.json``) picks the fixture up. The old
+    # ``page_001.json`` shape predated mirror's filename helper.
+    dest_path = raw_dir / "contratos_p1.json"
     shutil.copy(fixture_path, dest_path)
 
     # 2. Ingest Phase (PNCPExtractor)

--- a/tests/characterization/test_pipeline_contratos.py
+++ b/tests/characterization/test_pipeline_contratos.py
@@ -18,18 +18,21 @@ def test_builder_parses_month_partition():
         {
             "data_particao": "2024-01",
             "raw_zip_url": "url1",
+            "table_name": "contratos",
             "mirror_uploaded_at": "123",
             "parquet_uploaded_at": "",
         },
         {
             "data_particao": "2024-02",
             "raw_zip_url": "url2",
+            "table_name": "contratos",
             "mirror_uploaded_at": "123",
             "parquet_uploaded_at": "",
         },
         {
             "data_particao": "invalid-format",
             "raw_zip_url": "url3",
+            "table_name": "contratos",
             "mirror_uploaded_at": "123",
             "parquet_uploaded_at": "",
         },
@@ -52,6 +55,7 @@ def test_builder_parses_month_partition():
         {
             "data_particao": "2024-03-01",
             "raw_zip_url": "url4",
+            "table_name": "contratos",
             "mirror_uploaded_at": "123",
             "parquet_uploaded_at": "",
         }

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -29,10 +29,23 @@ def test_month_predates_known_data():
     assert month_predates_known_data(RESOURCE_CONTRATOS, date(2021, 9, 1)) is False
 
 
+def test_known_data_start_month_for_atas():
+    # Atas was registered in PNCPResource registry / PNCP_RESOURCE_DATA_STARTS
+    # alongside contratos because the PNCP API exposed both from launch.
+    assert known_data_start_month("atas") == date(2021, 9, 1)
+
+
+_UNREGISTERED_RESOURCE = "pca"  # not yet in PNCP_RESOURCE_DATA_STARTS
+
+
 def test_unknown_resource_raises_descriptive_error():
     with pytest.raises(ValueError, match="No known PNCP data start configured"):
-        known_data_start_month("atas")
+        known_data_start_month(_UNREGISTERED_RESOURCE)
 
 
 def test_clamp_to_known_data_start_month_unknown_resource_passes_through():
-    assert clamp_to_known_data_start_month("atas", date(2020, 1, 15)) == date(2020, 1, 1)
+    # Unknown resources fall back to month-normalised input unchanged so
+    # callers never crash on resources not yet in the data-start map.
+    assert clamp_to_known_data_start_month(_UNREGISTERED_RESOURCE, date(2020, 1, 15)) == date(
+        2020, 1, 1
+    )


### PR DESCRIPTION
**Stacked on #544** — review & merge that one first.

Continues the multi-resource refactor. Threads a real `resource` parameter through the whole `mirror` path so adding atas / contratacoes / pca only needs them registered in `RESOURCES` (PR #544) — no more code changes in mirror.

## Changes

### `mirror.mirror_month`
Now takes a `resource: str = RESOURCE_CONTRATOS` kwarg and uses it everywhere internally:

- `_validate_resource(resource)` — no more `RESOURCE_CONTRATOS` literal.
- `page_filename(resource, p)` and `first_page_filename(resource)` for the per-page raw JSON paths.
- `extractor.probe_range(resource, …)` and `extractor.fetch_page(resource, …)`.

Default kwarg keeps existing callers / tests unchanged.

### `cli_simple.mirror_cmd`
Gains `--resource / -r` (default `contratos`), validates the name up front so typos fail before any I/O, and threads it through:

- `_forced_month_or_empty(resource, force_month)`
- `clamp_to_known_data_start_month(resource, …)` (so per-resource date floors in `PNCP_RESOURCE_DATA_STARTS` apply)
- `_pending_mirror_months(start, batch_size, resource=resource)`
- the `executor.submit(mirror_month, …, resource=resource)` workers.

## Out of scope (next stacked PRs)

- `sync` command still uses `RESOURCE_CONTRATOS` literals — needs `extractor.ingest_range` to look up the canonical DuckDB schema by resource.
- `build_cmd` / `build_month` plumbing — same shape as this PR, separate diff for review clarity.
- `consolidator` per-resource dispatch.
- Defining ATAS resource (Tier-2 starts after the plumbing is done).

## Test plan

- [x] `ruff check src/baliza/` clean.
- [x] `pytest tests/` 123/123 pass locally.
- [ ] CI green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FUPSt1fXUVGX9RaJYnyk8U)_