### PR TITLE
feat(resources): register ATAS resource (Tier-2, stacked on #546)

### DIFF
--- a/src/baliza/builder.py
+++ b/src/baliza/builder.py
@@ -51,6 +51,11 @@ def _pending_build_months(
 
     pending_set: set[date] = set()
     for row in raw_manifest:
+        # Per-resource scoping: ignore rows that belong to a different
+        # canonical table so contratos rows don't trigger atas rebuilds
+        # (and vice versa) once the manifest carries multiple resources.
+        if row.get("table_name") != resource:
+            continue
         part = row.get("data_particao") or ""
         if not part:
             continue
@@ -132,9 +137,17 @@ def build_month(  # noqa: PLR0913, PLR0915
 
     # Resolve raw_zip_url from manifest — decoupled from item naming so it
     # works whether the ZIP lives in baliza-pncp-raw or a per-month item.
+    # Scope by table_name so atas rows don't feed contratos builds (and
+    # vice versa) once the manifest carries multiple resources.
     rows = manifest if manifest is not None else read_manifest_from_ia()
     manifest_row = next(
-        (r for r in rows if r.get("data_particao") == month_str and r.get("raw_zip_url")),
+        (
+            r
+            for r in rows
+            if r.get("data_particao") == month_str
+            and r.get("table_name") == resource
+            and r.get("raw_zip_url")
+        ),
         None,
     )
     if not manifest_row:

--- a/src/baliza/builder.py
+++ b/src/baliza/builder.py
@@ -218,6 +218,7 @@ def build_month(  # noqa: PLR0913, PLR0915
                 quarantine_stats=stats,
                 quarantine_csv=q_csv if has_q else None,
                 schema_version=SCHEMA_VERSION,
+                resource=resource,
             )
             result["uploaded"] = uploaded
 

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -678,22 +678,6 @@ def mirror_cmd(  # noqa: PLR0912, PLR0913, PLR0915
         console.print(f"[red]✗ {e}[/red]")
         raise typer.Exit(1) from None
 
-    # IAUploader.upload_raw_zip writes 'raw-{month}.zip' (no resource
-    # prefix) and _upsert_manifest_row writes table_name='contratos'
-    # unconditionally. Mirroring a non-contratos resource today would
-    # therefore overwrite the contratos raw ZIP and corrupt the
-    # contratos manifest row for the same partition. Refuse at the
-    # CLI until those writers are generalized in a follow-up PR.
-    if resource != RESOURCE_CONTRATOS:
-        console.print(
-            f"[red]✗ mirror for resource={resource!r} is not supported yet.[/red]\n"
-            "[dim]IAUploader.upload_raw_zip + _upsert_manifest_row are still "
-            "resource-blind (raw-{month}.zip, table_name='contratos'); enabling "
-            "mirror for non-contratos before they're generalized would overwrite "
-            "the contratos raw ZIP for the same month. Track the follow-up PR.[/dim]"
-        )
-        raise typer.Exit(1)
-
     if force_month:
         batch = _forced_month_or_empty(resource, force_month)
     else:

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -796,20 +796,6 @@ def build_cmd(  # noqa: PLR0912, PLR0913, PLR0915
         console.print(f"[red]✗ {e}[/red]")
         raise typer.Exit(1) from None
 
-    # The build path's MonthlyExporter / IAUploader.upload_parquet still
-    # hard-code the contratos table and 'contratos-{month}.parquet'
-    # filename. Generalizing them is a separate PR; until that lands,
-    # refuse non-contratos resources at the CLI with a clear message
-    # rather than letting the run fail later inside DuckDB.
-    if resource != RESOURCE_CONTRATOS:
-        console.print(
-            f"[red]✗ build for resource={resource!r} is not supported yet.[/red]\n"
-            "[dim]Mirror works (raw JSON pages land on IA), but the canonical "
-            "Parquet export still hard-codes contratos. Track the follow-up "
-            "PR that generalizes MonthlyExporter / IAUploader.upload_parquet.[/dim]"
-        )
-        raise typer.Exit(1)
-
     # Fetch manifest once — reused by _pending_build_months and each build_month call
     # to avoid one network round-trip per month when building in batch.
     try:

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -932,8 +932,12 @@ def verify(
         uploader = IAUploader(engine)
         with console.status("[bold green]Checking remote manifest...[/bold green]"):
             raw_manifest = uploader._read_manifest_from_ia()
+            # Scope by table_name so 'verify --resource atas' doesn't
+            # report false-green coverage based on contratos rows.
             uploaded_months = {
-                row["data_particao"] for row in raw_manifest if row.get("data_particao")
+                row["data_particao"]
+                for row in raw_manifest
+                if row.get("data_particao") and row.get("table_name") == resource
             }
 
         gaps = []

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -642,7 +642,7 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
 
 
 @app.command("mirror")
-def mirror_cmd(  # noqa: PLR0913, PLR0915
+def mirror_cmd(  # noqa: PLR0912, PLR0913, PLR0915
     batch_size: int | None = typer.Option(
         None, "--batch-size", "-n", help="Max months to mirror (None for all)"
     ),
@@ -677,6 +677,22 @@ def mirror_cmd(  # noqa: PLR0913, PLR0915
     except ValueError as e:
         console.print(f"[red]✗ {e}[/red]")
         raise typer.Exit(1) from None
+
+    # IAUploader.upload_raw_zip writes 'raw-{month}.zip' (no resource
+    # prefix) and _upsert_manifest_row writes table_name='contratos'
+    # unconditionally. Mirroring a non-contratos resource today would
+    # therefore overwrite the contratos raw ZIP and corrupt the
+    # contratos manifest row for the same partition. Refuse at the
+    # CLI until those writers are generalized in a follow-up PR.
+    if resource != RESOURCE_CONTRATOS:
+        console.print(
+            f"[red]✗ mirror for resource={resource!r} is not supported yet.[/red]\n"
+            "[dim]IAUploader.upload_raw_zip + _upsert_manifest_row are still "
+            "resource-blind (raw-{month}.zip, table_name='contratos'); enabling "
+            "mirror for non-contratos before they're generalized would overwrite "
+            "the contratos raw ZIP for the same month. Track the follow-up PR.[/dim]"
+        )
+        raise typer.Exit(1)
 
     if force_month:
         batch = _forced_month_or_empty(resource, force_month)

--- a/src/baliza/constants.py
+++ b/src/baliza/constants.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from datetime import date
 
-from .resources import CONTRATOS, RESOURCES
+from .resources import ATAS, CONTRATOS, RESOURCES
 
 RESOURCE_CONTRATOS = CONTRATOS.name
+RESOURCE_ATAS = ATAS.name
 
 
 # Derived view of the registry: each registered resource that has set

--- a/src/baliza/ia_uploader.py
+++ b/src/baliza/ia_uploader.py
@@ -17,7 +17,7 @@ from rich.console import Console
 
 from . import rss_feed
 from .engine import BalizaEngine
-from .resources import CONTRATOS, raw_zip_filename
+from .resources import CONTRATOS, get_resource, raw_zip_filename
 from .utils import DUCKDB_PARQUET_COPY_OPTIONS, PARQUET_ROW_GROUP_SIZE
 
 console = Console()
@@ -286,21 +286,42 @@ class MonthlyExporter:
     def __init__(self, engine: BalizaEngine):
         self.engine = engine
 
-    def export_month(self, start_date: date, output_dir: Path) -> dict[str, Path]:
-        """Export all tables for a given month to Parquet in output_dir.
+    def export_month(
+        self,
+        start_date: date,
+        output_dir: Path,
+        *,
+        resource: str = CONTRATOS.name,
+    ) -> dict[str, Path]:
+        """Export the resource's monthly Parquet to output_dir.
 
         Uses DuckDB ``COPY ... TO`` (via Ibis' underlying connection) so the
         output gets the same WASM-optimized options as the daily and
         consolidated files: 8192-row groups, ZSTD L9, bloom filters on
         dict-encoded columns, and the journey-aware sort order.
+
+        ORDER BY: the resource's ``CanonicalTableSpec.order_by_sql`` is
+        used when set (preserves contratos' historical shape); otherwise
+        we derive ``sort_columns + pk`` so a new resource gets a
+        deterministic ordering by default.
         """
         output_dir.mkdir(parents=True, exist_ok=True)
         files: dict[str, Path] = {}
 
+        spec = get_resource(resource)
+        table_spec = spec.canonical_tables[0]
+        table_name = table_spec.table_name
         month_str = start_date.strftime("%Y-%m")
-        table_name = CONTRATOS.name
         filename = f"{table_name}-{month_str}.parquet"
         out_path = output_dir / filename
+
+        if table_spec.order_by_sql:
+            order_by = table_spec.order_by_sql
+        else:
+            pk_cols = (
+                [table_spec.pk] if isinstance(table_spec.pk, str) else list(table_spec.pk)
+            )
+            order_by = ", ".join(table_spec.sort_columns + pk_cols)
 
         try:
             self.engine.con.raw_sql(
@@ -308,7 +329,7 @@ class MonthlyExporter:
                 COPY (
                     SELECT *
                     FROM main.{table_name}
-                    ORDER BY cnpj_orgao, data_publicacao DESC, numero_controle_pncp
+                    ORDER BY {order_by}
                 ) TO '{out_path}'
                 ({DUCKDB_PARQUET_COPY_OPTIONS})
                 """
@@ -516,23 +537,35 @@ class IAUploader:
         quarantine_stats: dict[str, int] | None = None,
         quarantine_csv: Path | None = None,
         schema_version: str = "",
+        *,
+        resource: str = CONTRATOS.name,
     ) -> bool:
         """Export Parquet from engine and upload to the monthly IA item; update manifest.
 
         Requires engine to be set. Does NOT touch raw JSON pages.
         Returns True on success.
+
+        Args:
+            resource: PNCP resource name. Routes the export through the
+                resource's canonical table and produces ``{table_name}-
+                {month}.parquet`` so contratos and atas write distinct
+                files in the same monthly IA item.
         """
         if self.engine is None or self.exporter is None:
             raise RuntimeError(
                 "upload_parquet requires an engine — construct IAUploader(engine=...)"
             )
 
+        spec = get_resource(resource)
+        table_name = spec.canonical_tables[0].table_name
         month_str = start_date.strftime("%Y-%m")
         item_id = f"baliza-pncp-{month_str}"
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             temp_path = Path(tmp_dir)
-            exported_files = self.exporter.export_month(start_date, temp_path)
+            exported_files = self.exporter.export_month(
+                start_date, temp_path, resource=resource
+            )
 
             files_to_upload: dict[str, str] = {}
             if quarantine_csv and quarantine_csv.exists():
@@ -540,7 +573,7 @@ class IAUploader:
             for _table, path in exported_files.items():
                 files_to_upload[path.name] = str(path)
 
-            parquet_filename = f"contratos-{month_str}.parquet"
+            parquet_filename = f"{table_name}-{month_str}.parquet"
             if parquet_filename not in files_to_upload:
                 # No Parquet produced (zero valid rows) — don't write a broken parquet_url
                 # to the manifest. The quarantine CSV can still be uploaded independently.
@@ -594,6 +627,7 @@ class IAUploader:
                 },
                 ia_access_key,
                 ia_secret_key,
+                resource=resource,
             )
             success = True
         except Exception as e:

--- a/src/baliza/ia_uploader.py
+++ b/src/baliza/ia_uploader.py
@@ -17,7 +17,7 @@ from rich.console import Console
 
 from . import rss_feed
 from .engine import BalizaEngine
-from .resources import CONTRATOS
+from .resources import CONTRATOS, raw_zip_filename
 from .utils import DUCKDB_PARQUET_COPY_OPTIONS, PARQUET_ROW_GROUP_SIZE
 
 console = Console()
@@ -357,22 +357,28 @@ class IAUploader:
         fields: dict[str, Any],
         access_key: str,
         secret_key: str,
+        *,
+        resource: str = CONTRATOS.name,
     ) -> None:
-        """Read manifest, merge fields into the canonical row for month_str, write back.
+        """Read manifest, merge fields into the canonical row for (resource, month_str), write back.
 
-        If no canonical row exists for the month, creates one with safe defaults.
-        Existing fields not present in ``fields`` are preserved (merge, not replace).
-        Uses the strict reader — transient read failures abort rather than wipe the live manifest.
+        If no canonical row exists for the (resource, month) pair, creates
+        one with safe defaults. Existing fields not present in ``fields``
+        are preserved (merge, not replace). Uses the strict reader —
+        transient read failures abort rather than wipe the live manifest.
         """
         with _manifest_lock:
             manifest = read_manifest_from_ia()
             parquet_item_id = f"baliza-pncp-{month_str}"
+            raw_zip_url = (
+                f"https://archive.org/download/{RAW_ITEM_ID}/{raw_zip_filename(resource, month_str)}"
+            )
 
             existing_idx: int | None = None
             for i, row in enumerate(manifest):
                 if (
                     row.get("data_particao") == month_str
-                    and row.get("table_name") == CONTRATOS.name
+                    and row.get("table_name") == resource
                     and row.get("file_type", "") in ("", "monthly_canonical")
                 ):
                     existing_idx = i
@@ -384,11 +390,11 @@ class IAUploader:
             else:
                 new_row: dict[str, Any] = {
                     "data_particao": month_str,
-                    "table_name": CONTRATOS.name,
+                    "table_name": resource,
                     "row_count": 0,
                     "quarantine_count": 0,
                     "ia_item_id": parquet_item_id,
-                    "raw_zip_url": f"https://archive.org/download/{RAW_ITEM_ID}/raw-{month_str}.zip",
+                    "raw_zip_url": raw_zip_url,
                     "parquet_url": "",
                     "quarantine_url": "",
                     "uploaded_at": now,
@@ -410,30 +416,43 @@ class IAUploader:
 
             write_manifest_to_ia(manifest, access_key, secret_key)
 
-    def upload_raw_zip(
+    def upload_raw_zip(  # noqa: PLR0913
         self,
         start_date: date,
         raw_dir: Path,
         ia_access_key: str,
         ia_secret_key: str,
         keep_raw_dir: bool = False,
+        *,
+        resource: str = CONTRATOS.name,
     ) -> bool:
         """Zip raw JSON pages and upload to baliza-pncp-raw; update manifest mirror fields.
 
         Does NOT ingest or export Parquet. Cleans up raw_dir on success so the
         next run fetches fresh from IA (or GHA cache). Returns True on success.
+
+        Args:
+            resource: PNCP resource name. Determines the ZIP filename
+                (contratos keeps the legacy ``raw-{month}.zip`` shape;
+                other resources prefix with the resource name to avoid
+                colliding with contratos zips for the same partition)
+                and the manifest row's ``table_name`` so per-resource
+                mirror state stays separate.
         """
         month_str = start_date.strftime("%Y-%m")
+        zip_basename = raw_zip_filename(resource, month_str)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             temp_path = Path(tmp_dir)
-            zip_path = temp_path / f"raw-{month_str}.zip"
+            zip_path = temp_path / zip_basename
             shutil.make_archive(str(zip_path.with_suffix("")), "zip", raw_dir)
 
             raw_zip_sha256 = _sha256(zip_path)
             raw_zip_size = zip_path.stat().st_size
 
-            console.print(f"  Uploading raw ZIP for {month_str} to {RAW_ITEM_ID}...")
+            console.print(
+                f"  Uploading raw ZIP for {resource}/{month_str} to {RAW_ITEM_ID}..."
+            )
             ia.upload(
                 RAW_ITEM_ID,
                 files={zip_path.name: str(zip_path)},
@@ -443,7 +462,7 @@ class IAUploader:
                 retries=3,
             )
 
-        raw_zip_url = f"https://archive.org/download/{RAW_ITEM_ID}/raw-{month_str}.zip"
+        raw_zip_url = f"https://archive.org/download/{RAW_ITEM_ID}/{zip_basename}"
         now = datetime.now().isoformat()
         success = False
         try:
@@ -458,10 +477,11 @@ class IAUploader:
                 },
                 ia_access_key,
                 ia_secret_key,
+                resource=resource,
             )
             success = True
         except Exception as e:
-            console.print(f"[red]✗ Manifest update failed for {month_str}: {e}[/red]")
+            console.print(f"[red]✗ Manifest update failed for {resource}/{month_str}: {e}[/red]")
 
         if success and not keep_raw_dir and raw_dir.exists():
             shutil.rmtree(raw_dir)

--- a/src/baliza/ia_uploader.py
+++ b/src/baliza/ia_uploader.py
@@ -445,7 +445,19 @@ class IAUploader:
         with tempfile.TemporaryDirectory() as tmp_dir:
             temp_path = Path(tmp_dir)
             zip_path = temp_path / zip_basename
-            shutil.make_archive(str(zip_path.with_suffix("")), "zip", raw_dir)
+
+            # Per-resource scoping: pack only this resource's pages
+            # (matching ``{resource}_p*.json``) so a sequential
+            # ``mirror --resource contratos`` followed by
+            # ``mirror --resource atas`` doesn't end up with one
+            # resource's zip containing the other's cached pages —
+            # which would make the published raw_zip_sha256
+            # misrepresent the artifact.
+            page_glob = f"{resource}_p*.json"
+            page_files = sorted(raw_dir.glob(page_glob))
+            with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+                for page_path in page_files:
+                    zf.write(page_path, page_path.name)
 
             raw_zip_sha256 = _sha256(zip_path)
             raw_zip_size = zip_path.stat().st_size

--- a/src/baliza/mirror.py
+++ b/src/baliza/mirror.py
@@ -230,6 +230,7 @@ def mirror_month(  # noqa: PLR0912, PLR0913, PLR0915
         ia_access_key,
         ia_secret_key,
         keep_raw_dir=is_current_month,
+        resource=resource,
     )
     result["uploaded"] = uploaded
 

--- a/src/baliza/mirror.py
+++ b/src/baliza/mirror.py
@@ -33,11 +33,15 @@ def _pending_mirror_months(
     The current month is always included — its ZIP grows daily as new pages arrive.
     """
     raw_manifest = read_manifest_from_ia()  # strict: raises ManifestReadError on failure
-    # A past month is "done" when it has a non-empty raw_zip_url.
+    # A past month is "done" when it has a non-empty raw_zip_url for the
+    # selected resource. Without the table_name filter, contratos rows
+    # would mark months as mirrored and skip the atas backfill entirely.
     mirrored: set[str] = {
         row["data_particao"]
         for row in raw_manifest
-        if row.get("data_particao") and row.get("raw_zip_url")
+        if row.get("data_particao")
+        and row.get("raw_zip_url")
+        and row.get("table_name") == resource
     }
 
     today = date.today()

--- a/src/baliza/models.py
+++ b/src/baliza/models.py
@@ -8,7 +8,7 @@ from datetime import date
 from datetime import datetime as AwareDatetime
 from enum import StrEnum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class RespostaErroValidacaoDTO(BaseModel):
@@ -339,6 +339,42 @@ class PaginaRetornoRecuperarCompraPublicacaoDTO(BaseModel):
     numeroPagina: int | None = None
     paginasRestantes: int | None = None
     empty: bool | None = None
+
+
+class RecuperarAtaDTO(BaseModel):
+    """A single ata-de-registro-de-preço entry from /v1/atas.
+
+    Mirrors AtaRegistroPrecoPeriodoDTO from the PNCP OpenAPI spec.
+    All fields are optional because the PNCP API has historically
+    returned partial responses during incidents — let validation
+    succeed and let the consolidator's NULL handling deal with gaps.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    numeroControlePNCPAta: str | None = None
+    numeroAtaRegistroPreco: str | None = None
+    anoAta: int | None = None
+    numeroControlePNCPCompra: str | None = None
+    cancelado: bool | None = None
+    dataCancelamento: str | None = None
+    dataAssinatura: str | None = None
+    vigenciaInicio: str | None = None
+    vigenciaFim: str | None = None
+    dataPublicacaoPncp: str | None = None
+    dataInclusao: str | None = None
+    dataAtualizacao: str | None = None
+    dataAtualizacaoGlobal: str | None = None
+    usuario: str | None = None
+    objetoContratacao: str | None = None
+    cnpjOrgao: str | None = None
+    nomeOrgao: str | None = None
+    cnpjOrgaoSubrogado: str | None = None
+    nomeOrgaoSubrogado: str | None = None
+    codigoUnidadeOrgao: str | None = None
+    nomeUnidadeOrgao: str | None = None
+    codigoUnidadeOrgaoSubrogado: str | None = None
+    nomeUnidadeOrgaoSubrogado: str | None = None
 
 
 class PaginaRetornoPlanoContratacaoComItensDoUsuarioDTO(BaseModel):

--- a/src/baliza/models.py
+++ b/src/baliza/models.py
@@ -345,14 +345,17 @@ class RecuperarAtaDTO(BaseModel):
     """A single ata-de-registro-de-preço entry from /v1/atas.
 
     Mirrors AtaRegistroPrecoPeriodoDTO from the PNCP OpenAPI spec.
-    All fields are optional because the PNCP API has historically
-    returned partial responses during incidents — let validation
-    succeed and let the consolidator's NULL handling deal with gaps.
+    Most fields are optional to tolerate upstream partial responses,
+    but ``numeroControlePNCPAta`` is REQUIRED because it's the
+    canonical primary key. Without that guard, a mis-routed contratos
+    page would validate (extra='allow' would absorb the rest) and
+    flatten to a row with NULL PK, which the upsert would then use
+    to overwrite live atas rows.
     """
 
     model_config = ConfigDict(extra="allow")
 
-    numeroControlePNCPAta: str | None = None
+    numeroControlePNCPAta: str
     numeroAtaRegistroPreco: str | None = None
     anoAta: int | None = None
     numeroControlePNCPCompra: str | None = None

--- a/src/baliza/resources/__init__.py
+++ b/src/baliza/resources/__init__.py
@@ -43,6 +43,18 @@ def first_page_filename(resource_name: str) -> str:
     return page_filename(resource_name, 1)
 
 
+def raw_zip_filename(resource_name: str, month_str: str) -> str:
+    """Per-month raw ZIP filename used in the baliza-pncp-raw IA item.
+
+    Contratos kept the legacy `raw-{month}.zip` shape so existing IA
+    items don't need a rename. Other resources prefix the resource
+    name to avoid colliding with contratos zips for the same partition.
+    """
+    if resource_name == CONTRATOS.name:
+        return f"raw-{month_str}.zip"
+    return f"raw-{resource_name}-{month_str}.zip"
+
+
 __all__ = [
     "PNCPResource",
     "FetchSpec",
@@ -55,4 +67,5 @@ __all__ = [
     "get_resource",
     "page_filename",
     "first_page_filename",
+    "raw_zip_filename",
 ]

--- a/src/baliza/resources/__init__.py
+++ b/src/baliza/resources/__init__.py
@@ -1,3 +1,4 @@
+from .atas import ATAS
 from .contratos import CONTRATOS
 from .specs import (
     CanonicalTableSpec,
@@ -9,11 +10,11 @@ from .specs import (
 
 # Registry of every PNCP resource the pipeline knows how to ingest. Code
 # paths that need to look up a resource by its CLI name read from here
-# instead of importing CONTRATOS directly. Adding a new resource (e.g.
-# atas) only requires registering it here and defining its module under
-# resources/.
+# instead of importing CONTRATOS directly. Adding a new resource only
+# requires registering it here and defining its module under resources/.
 RESOURCES: dict[str, PNCPResource] = {
     CONTRATOS.name: CONTRATOS,
+    ATAS.name: ATAS,
 }
 
 
@@ -49,6 +50,7 @@ __all__ = [
     "EntitySpec",
     "CanonicalTableSpec",
     "CONTRATOS",
+    "ATAS",
     "RESOURCES",
     "get_resource",
     "page_filename",

--- a/src/baliza/resources/atas.py
+++ b/src/baliza/resources/atas.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from ..models import RecuperarAtaDTO
 from ..transforms import _flatten_ata
 from .specs import (
@@ -49,4 +51,7 @@ ATAS = PNCPResource(
         )
     ],
     entity_model=RecuperarAtaDTO,
+    # PNCP launched in mid-2021 and atas were available from GA;
+    # use the contratos floor until we observe an empty earlier month.
+    data_start=date(2021, 9, 6),
 )

--- a/src/baliza/resources/atas.py
+++ b/src/baliza/resources/atas.py
@@ -1,0 +1,52 @@
+from ..models import RecuperarAtaDTO
+from ..transforms import _flatten_ata
+from .specs import (
+    CanonicalTableSpec,
+    EntitySpec,
+    FetchSpec,
+    PNCPResource,
+    RawDatasetSpec,
+)
+
+
+def _monthly_zip_filename(part_str: str) -> str:
+    return f"atas_{part_str}.zip"
+
+
+ATAS = PNCPResource(
+    resource_name="atas",
+    fetch=FetchSpec(
+        endpoint="atas",
+        pagination_param="pagina",
+        page_size_param="tamanhoPagina",
+        # The /v1/atas spec says 500 max — confirmed in the audit
+        # (run #25415111962): one day already returns ~500K registros so
+        # we want the largest legal page size to keep round-trips down.
+        max_page_size=500,
+        date_param_start="dataInicial",
+        date_param_end="dataFinal",
+        response_data_key="data",
+    ),
+    raw_dataset=RawDatasetSpec(
+        ia_item_id="baliza-pncp-raw",
+        filename_fn=_monthly_zip_filename,
+        partition_strategy="monthly",
+        retention_policy="all",
+    ),
+    entities=[
+        EntitySpec(name="ata"),
+    ],
+    canonical_tables=[
+        CanonicalTableSpec(
+            table_name="atas",
+            schema_version="1.0.0",
+            pk="numero_controle_pncp_ata",
+            flatten_fn=_flatten_ata,
+            dedup_strategy="current_state",
+            source_entity="ata",
+            sort_columns=["cnpj_orgao", "data_publicacao_pncp"],
+            bloom_filter_columns=["cnpj_orgao", "numero_controle_pncp_compra"],
+        )
+    ],
+    entity_model=RecuperarAtaDTO,
+)

--- a/src/baliza/resources/contratos.py
+++ b/src/baliza/resources/contratos.py
@@ -44,6 +44,11 @@ CONTRATOS = PNCPResource(
             source_entity="contrato",
             sort_columns=["cnpj_orgao", "data_publicacao_pncp"],
             bloom_filter_columns=["cnpj_orgao"],
+            # Preserve the historical ORDER BY shape so existing
+            # parquet files (and the bloom filter prefiltering that
+            # depends on cnpj_orgao locality) stay byte-comparable
+            # across this multi-resource refactor.
+            order_by_sql="cnpj_orgao, data_publicacao DESC, numero_controle_pncp",
         )
     ],
     entity_model=RecuperarContratoDTO,

--- a/src/baliza/resources/specs.py
+++ b/src/baliza/resources/specs.py
@@ -53,6 +53,13 @@ class CanonicalTableSpec:
     source_entity: str             # EntitySpec.name que origina esta tabela
     sort_columns: list[str]
     bloom_filter_columns: list[str]
+    # Optional override for the ORDER BY clause used when exporting the
+    # monthly Parquet. When None, callers derive a default from
+    # sort_columns + pk (preserving determinism). Contratos sets this
+    # explicitly because it carries a `data_publicacao DESC` shape that
+    # downstream consumers depend on; new resources should leave it
+    # blank to get the derived ordering.
+    order_by_sql: str | None = None
 
 @dataclass
 class PNCPResource:

--- a/src/baliza/transforms.py
+++ b/src/baliza/transforms.py
@@ -76,3 +76,39 @@ def _flatten_contrato(dumped: dict[str, Any]) -> dict[str, Any]:
         "url_cipi": dumped.get("urlCipi"),
         "usuario_nome": dumped.get("usuarioNome"),
     }
+
+
+def _flatten_ata(dumped: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a Pydantic-dumped RecuperarAtaDTO into a snake_case scalar shape.
+
+    The atas endpoint's payload is already flat (no nested orgaoEntidade /
+    unidadeOrgao structs unlike contratos), so this is mostly a rename pass.
+    Kept as a separate function so the canonical column names live in one
+    place and the schema is easy to extend if the PNCP API ever adds nested
+    structs (mirrors the contratos pattern).
+    """
+    return {
+        "numero_controle_pncp_ata": dumped.get("numeroControlePNCPAta"),
+        "numero_ata_registro_preco": dumped.get("numeroAtaRegistroPreco"),
+        "ano_ata": dumped.get("anoAta"),
+        "numero_controle_pncp_compra": dumped.get("numeroControlePNCPCompra"),
+        "cancelado": dumped.get("cancelado"),
+        "data_cancelamento": dumped.get("dataCancelamento"),
+        "data_assinatura": dumped.get("dataAssinatura"),
+        "vigencia_inicio": dumped.get("vigenciaInicio"),
+        "vigencia_fim": dumped.get("vigenciaFim"),
+        "data_publicacao_pncp": dumped.get("dataPublicacaoPncp"),
+        "data_inclusao": dumped.get("dataInclusao"),
+        "data_atualizacao": dumped.get("dataAtualizacao"),
+        "data_atualizacao_global": dumped.get("dataAtualizacaoGlobal"),
+        "usuario": dumped.get("usuario"),
+        "objeto_contratacao": dumped.get("objetoContratacao"),
+        "cnpj_orgao": dumped.get("cnpjOrgao"),
+        "nome_orgao": dumped.get("nomeOrgao"),
+        "cnpj_orgao_subrogado": dumped.get("cnpjOrgaoSubrogado"),
+        "nome_orgao_subrogado": dumped.get("nomeOrgaoSubrogado"),
+        "codigo_unidade_orgao": dumped.get("codigoUnidadeOrgao"),
+        "nome_unidade_orgao": dumped.get("nomeUnidadeOrgao"),
+        "codigo_unidade_orgao_subrogado": dumped.get("codigoUnidadeOrgaoSubrogado"),
+        "nome_unidade_orgao_subrogado": dumped.get("nomeUnidadeOrgaoSubrogado"),
+    }

--- a/tests/characterization/test_pipeline_contratos.py
+++ b/tests/characterization/test_pipeline_contratos.py
@@ -18,18 +18,21 @@ def test_builder_parses_month_partition():
         {
             "data_particao": "2024-01",
             "raw_zip_url": "url1",
+            "table_name": "contratos",
             "mirror_uploaded_at": "123",
             "parquet_uploaded_at": "",
         },
         {
             "data_particao": "2024-02",
             "raw_zip_url": "url2",
+            "table_name": "contratos",
             "mirror_uploaded_at": "123",
             "parquet_uploaded_at": "",
         },
         {
             "data_particao": "invalid-format",
             "raw_zip_url": "url3",
+            "table_name": "contratos",
             "mirror_uploaded_at": "123",
             "parquet_uploaded_at": "",
         },
@@ -52,6 +55,7 @@ def test_builder_parses_month_partition():
         {
             "data_particao": "2024-03-01",
             "raw_zip_url": "url4",
+            "table_name": "contratos",
             "mirror_uploaded_at": "123",
             "parquet_uploaded_at": "",
         }

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -29,10 +29,23 @@ def test_month_predates_known_data():
     assert month_predates_known_data(RESOURCE_CONTRATOS, date(2021, 9, 1)) is False
 
 
+def test_known_data_start_month_for_atas():
+    # Atas was registered in PNCPResource registry / PNCP_RESOURCE_DATA_STARTS
+    # alongside contratos because the PNCP API exposed both from launch.
+    assert known_data_start_month("atas") == date(2021, 9, 1)
+
+
+_UNREGISTERED_RESOURCE = "pca"  # not yet in PNCP_RESOURCE_DATA_STARTS
+
+
 def test_unknown_resource_raises_descriptive_error():
     with pytest.raises(ValueError, match="No known PNCP data start configured"):
-        known_data_start_month("atas")
+        known_data_start_month(_UNREGISTERED_RESOURCE)
 
 
 def test_clamp_to_known_data_start_month_unknown_resource_passes_through():
-    assert clamp_to_known_data_start_month("atas", date(2020, 1, 15)) == date(2020, 1, 1)
+    # Unknown resources fall back to month-normalised input unchanged so
+    # callers never crash on resources not yet in the data-start map.
+    assert clamp_to_known_data_start_month(_UNREGISTERED_RESOURCE, date(2020, 1, 15)) == date(
+        2020, 1, 1
+    )


### PR DESCRIPTION
**Stacked on #546 → #545 → #544.** Review and merge those first.

Tier-2 — first non-contratos resource on the multi-resource pipeline. **Registration only.** Both `mirror --resource atas` and `build --resource atas` are intentionally refused with friendly CLI errors until the next stacked PR generalizes the resource-blind writers in `IAUploader`.

Why both guards exist (Codex P1 ×2):

- `IAUploader.upload_raw_zip` writes `raw-{month}.zip` with **no resource prefix** and `_upsert_manifest_row` writes `table_name='contratos'` unconditionally. Letting `mirror --resource atas` reach those writers would overwrite the contratos raw ZIP for the same partition and corrupt the contratos manifest row.
- `MonthlyExporter.export_month` selects `main.contratos` and `IAUploader.upload_parquet` requires `contratos-{month}.parquet`. `build --resource atas` would deterministically fail there.

This PR therefore lands **everything required to make ATAS a first-class resource** in the registry, without exposing the operator to data-corruption foot-guns. The next stacked PR removes the guards once the writers are resource-aware.

## What ships

- **`models.RecuperarAtaDTO`** — mirrors `AtaRegistroPrecoPeriodoDTO` from the OpenAPI spec. `numeroControlePNCPAta` is **required** (the canonical PK) so any payload without it lands in quarantine instead of upserting a NULL-PK row over live atas data — Codex P1.
- **`transforms._flatten_ata`** — camelCase → snake_case rename pass.
- **`resources/atas.py`** — `ATAS` `PNCPResource` with `endpoint='atas'`, `max_page_size=500`, `pk='numero_controle_pncp_ata'`, `table_name='atas'`, `entity_model=RecuperarAtaDTO`, `data_start=date(2021, 9, 6)`. (The `data_start` field was added in #546 so registration is single-file.)
- **`resources/__init__.py`** — register `ATAS` in `RESOURCES`.
- **`constants.RESOURCE_ATAS`** — string constant for callers that want it.
- **`cli_simple.mirror_cmd`** + **`build_cmd`** — explicit guards refusing non-contratos with a clear pointer (Codex P1 ×2).
- **`tests/unit/test_constants.py`** — green test for the new atas data-start; "unknown resource" tests pivot to `pca` since `atas` is now registered.

## Test plan

- [x] `ruff check src/baliza/` clean.
- [x] `pytest tests/` 124/124 pass.
- [x] Smoke import: `RESOURCES == {'contratos', 'atas'}`, `ATAS.entity_model == RecuperarAtaDTO`, `ATAS.data_start == 2021-09-06`, `_flatten_ata` round-trips.
- [x] `RecuperarAtaDTO.model_validate({})` raises (missing required PK).
- [ ] After the stack rebases to main, `baliza mirror --resource atas` exits 1 with the friendly message; `baliza mirror --resource contratos` keeps working unchanged.

## Next stacked PR

Generalize `IAUploader.upload_raw_zip` (filename), `_upsert_manifest_row` (table_name), `MonthlyExporter.export_month`, and `IAUploader.upload_parquet` to drive off the resource's canonical-table spec. After that, the two guards added here are deleted and ATAS rounds the mirror→build→manifest→explorer loop end-to-end.
