### PR TITLE
refactor(build): make export_month + upload_parquet resource-aware (stacked on #548)

### DIFF
--- a/src/baliza/builder.py
+++ b/src/baliza/builder.py
@@ -218,6 +218,7 @@ def build_month(  # noqa: PLR0913, PLR0915
                 quarantine_stats=stats,
                 quarantine_csv=q_csv if has_q else None,
                 schema_version=SCHEMA_VERSION,
+                resource=resource,
             )
             result["uploaded"] = uploaded
 

--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -796,20 +796,6 @@ def build_cmd(  # noqa: PLR0912, PLR0913, PLR0915
         console.print(f"[red]✗ {e}[/red]")
         raise typer.Exit(1) from None
 
-    # The build path's MonthlyExporter / IAUploader.upload_parquet still
-    # hard-code the contratos table and 'contratos-{month}.parquet'
-    # filename. Generalizing them is a separate PR; until that lands,
-    # refuse non-contratos resources at the CLI with a clear message
-    # rather than letting the run fail later inside DuckDB.
-    if resource != RESOURCE_CONTRATOS:
-        console.print(
-            f"[red]✗ build for resource={resource!r} is not supported yet.[/red]\n"
-            "[dim]Mirror works (raw JSON pages land on IA), but the canonical "
-            "Parquet export still hard-codes contratos. Track the follow-up "
-            "PR that generalizes MonthlyExporter / IAUploader.upload_parquet.[/dim]"
-        )
-        raise typer.Exit(1)
-
     # Fetch manifest once — reused by _pending_build_months and each build_month call
     # to avoid one network round-trip per month when building in batch.
     try:

--- a/src/baliza/ia_uploader.py
+++ b/src/baliza/ia_uploader.py
@@ -17,7 +17,7 @@ from rich.console import Console
 
 from . import rss_feed
 from .engine import BalizaEngine
-from .resources import CONTRATOS, raw_zip_filename
+from .resources import CONTRATOS, get_resource, raw_zip_filename
 from .utils import DUCKDB_PARQUET_COPY_OPTIONS, PARQUET_ROW_GROUP_SIZE
 
 console = Console()
@@ -286,21 +286,42 @@ class MonthlyExporter:
     def __init__(self, engine: BalizaEngine):
         self.engine = engine
 
-    def export_month(self, start_date: date, output_dir: Path) -> dict[str, Path]:
-        """Export all tables for a given month to Parquet in output_dir.
+    def export_month(
+        self,
+        start_date: date,
+        output_dir: Path,
+        *,
+        resource: str = CONTRATOS.name,
+    ) -> dict[str, Path]:
+        """Export the resource's monthly Parquet to output_dir.
 
         Uses DuckDB ``COPY ... TO`` (via Ibis' underlying connection) so the
         output gets the same WASM-optimized options as the daily and
         consolidated files: 8192-row groups, ZSTD L9, bloom filters on
         dict-encoded columns, and the journey-aware sort order.
+
+        ORDER BY: the resource's ``CanonicalTableSpec.order_by_sql`` is
+        used when set (preserves contratos' historical shape); otherwise
+        we derive ``sort_columns + pk`` so a new resource gets a
+        deterministic ordering by default.
         """
         output_dir.mkdir(parents=True, exist_ok=True)
         files: dict[str, Path] = {}
 
+        spec = get_resource(resource)
+        table_spec = spec.canonical_tables[0]
+        table_name = table_spec.table_name
         month_str = start_date.strftime("%Y-%m")
-        table_name = CONTRATOS.name
         filename = f"{table_name}-{month_str}.parquet"
         out_path = output_dir / filename
+
+        if table_spec.order_by_sql:
+            order_by = table_spec.order_by_sql
+        else:
+            pk_cols = (
+                [table_spec.pk] if isinstance(table_spec.pk, str) else list(table_spec.pk)
+            )
+            order_by = ", ".join(table_spec.sort_columns + pk_cols)
 
         try:
             self.engine.con.raw_sql(
@@ -308,7 +329,7 @@ class MonthlyExporter:
                 COPY (
                     SELECT *
                     FROM main.{table_name}
-                    ORDER BY cnpj_orgao, data_publicacao DESC, numero_controle_pncp
+                    ORDER BY {order_by}
                 ) TO '{out_path}'
                 ({DUCKDB_PARQUET_COPY_OPTIONS})
                 """
@@ -516,23 +537,35 @@ class IAUploader:
         quarantine_stats: dict[str, int] | None = None,
         quarantine_csv: Path | None = None,
         schema_version: str = "",
+        *,
+        resource: str = CONTRATOS.name,
     ) -> bool:
         """Export Parquet from engine and upload to the monthly IA item; update manifest.
 
         Requires engine to be set. Does NOT touch raw JSON pages.
         Returns True on success.
+
+        Args:
+            resource: PNCP resource name. Routes the export through the
+                resource's canonical table and produces ``{table_name}-
+                {month}.parquet`` so contratos and atas write distinct
+                files in the same monthly IA item.
         """
         if self.engine is None or self.exporter is None:
             raise RuntimeError(
                 "upload_parquet requires an engine — construct IAUploader(engine=...)"
             )
 
+        spec = get_resource(resource)
+        table_name = spec.canonical_tables[0].table_name
         month_str = start_date.strftime("%Y-%m")
         item_id = f"baliza-pncp-{month_str}"
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             temp_path = Path(tmp_dir)
-            exported_files = self.exporter.export_month(start_date, temp_path)
+            exported_files = self.exporter.export_month(
+                start_date, temp_path, resource=resource
+            )
 
             files_to_upload: dict[str, str] = {}
             if quarantine_csv and quarantine_csv.exists():
@@ -540,7 +573,7 @@ class IAUploader:
             for _table, path in exported_files.items():
                 files_to_upload[path.name] = str(path)
 
-            parquet_filename = f"contratos-{month_str}.parquet"
+            parquet_filename = f"{table_name}-{month_str}.parquet"
             if parquet_filename not in files_to_upload:
                 # No Parquet produced (zero valid rows) — don't write a broken parquet_url
                 # to the manifest. The quarantine CSV can still be uploaded independently.
@@ -594,6 +627,7 @@ class IAUploader:
                 },
                 ia_access_key,
                 ia_secret_key,
+                resource=resource,
             )
             success = True
         except Exception as e:

--- a/src/baliza/resources/contratos.py
+++ b/src/baliza/resources/contratos.py
@@ -44,6 +44,11 @@ CONTRATOS = PNCPResource(
             source_entity="contrato",
             sort_columns=["cnpj_orgao", "data_publicacao_pncp"],
             bloom_filter_columns=["cnpj_orgao"],
+            # Preserve the historical ORDER BY shape so existing
+            # parquet files (and the bloom filter prefiltering that
+            # depends on cnpj_orgao locality) stay byte-comparable
+            # across this multi-resource refactor.
+            order_by_sql="cnpj_orgao, data_publicacao DESC, numero_controle_pncp",
         )
     ],
     entity_model=RecuperarContratoDTO,

--- a/src/baliza/resources/specs.py
+++ b/src/baliza/resources/specs.py
@@ -53,6 +53,13 @@ class CanonicalTableSpec:
     source_entity: str             # EntitySpec.name que origina esta tabela
     sort_columns: list[str]
     bloom_filter_columns: list[str]
+    # Optional override for the ORDER BY clause used when exporting the
+    # monthly Parquet. When None, callers derive a default from
+    # sort_columns + pk (preserving determinism). Contratos sets this
+    # explicitly because it carries a `data_publicacao DESC` shape that
+    # downstream consumers depend on; new resources should leave it
+    # blank to get the derived ordering.
+    order_by_sql: str | None = None
 
 @dataclass
 class PNCPResource:


### PR DESCRIPTION
**Stacked on #548 → #547 → #546 → #545 → #544.** Review and merge those first.

Closes the multi-resource refactor for the **build** path. After this PR, `baliza build --resource atas` rounds the loop end-to-end (alongside the mirror path that #548 unlocked):

```
baliza mirror --resource atas
baliza build  --resource atas
```

The full atas backfill produces `atas-{month}.parquet` files inside the existing `baliza-pncp-{month}` IA items, with separate manifest rows under `table_name='atas'`.

## Changes

### `resources/specs.py`
New `CanonicalTableSpec.order_by_sql` override. Lets a resource keep a hand-tuned `ORDER BY` (contratos uses `data_publicacao DESC` which affects bloom-filter prefiltering of `cnpj_orgao` runs); resources that leave it `None` get a deterministic `', '.join(sort_columns + pk)` default.

### `resources/contratos.py`
Sets `order_by_sql` to the existing literal `cnpj_orgao, data_publicacao DESC, numero_controle_pncp` so the published parquet bytes don't shift across this refactor.

### `ia_uploader.export_month`
Takes `resource=` kwarg. Looks up the canonical table from the registry, derives `table_name` and the ORDER BY clause, writes `{table_name}-{month}.parquet`.

### `ia_uploader.upload_parquet`
Takes `resource=` kwarg. Calls `export_month(..., resource=resource)`, derives the upload filename from `{table_name}-{month}.parquet`, forwards `resource` into `_upsert_manifest_row` so the manifest row gets the right `table_name`.

### `builder.build_month`
Threads its `resource` arg into `upload_parquet`.

### `cli_simple.build_cmd`
Drops the guard refusing non-contratos. `baliza build --resource atas` is now fully supported.

## Test plan

- [x] `ruff check src/baliza/` clean.
- [x] `pytest tests/` 124/124 pass.
- [x] Smoke: contratos retains `cnpj_orgao, data_publicacao DESC, numero_controle_pncp` ORDER BY; atas derives `cnpj_orgao, data_publicacao_pncp, numero_controle_pncp_ata`.
- [ ] After the stack rebases to main: `baliza build --resource atas --batch-size 1 --dry-run` runs without the guard error.
- [ ] After atas mirror has uploaded a real raw zip, `baliza build --resource atas --batch-size 1` produces `atas-{month}.parquet` and a `table_name='atas'` row in the manifest.

## Out of scope

- The `sync` cron command is still contratos-only (uses `RESOURCE_CONTRATOS` literal in its body). Adding atas to the cron is a follow-up — once we want the production cadence to mirror+build atas every 30 minutes, the loop in `sync_cmd` needs to fan out per resource.
- Consolidator's UF-shard step still filters on `contratos`. Atas will get a canonical parquet but no UF shards until the consolidator dispatches per resource.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FUPSt1fXUVGX9RaJYnyk8U)_