### PR TITLE
Copy/share buttons, per-route OG cards, full-state URLs

### DIFF
--- a/web/src/components/AgencyDetailView.svelte
+++ b/web/src/components/AgencyDetailView.svelte
@@ -12,11 +12,15 @@
   import type { ArchivedContrato } from '../lib/archive/schema';
   import EntityDetailLayout from './EntityDetailLayout.svelte';
   import EmptyState from './EmptyState.svelte';
+  import CopyButton from './CopyButton.svelte';
+  import ShareButton from './ShareButton.svelte';
+  import { setPageMeta } from '../lib/pageMeta';
   import LookbackWindow from './LookbackWindow.svelte';
   import ContractCard from './ContractCard.svelte';
   import PaginatedList from './PaginatedList.svelte';
   import { DEFAULT_SINCE_DAYS } from '../lib/pncpPublicacao';
   import { addWatch, isWatched, hydrateWatches } from '../lib/watchStore.svelte';
+  import { replaceUrlParams } from '../lib/urlState';
 
   setQueryClientContext(getQueryClient());
 
@@ -44,10 +48,7 @@
 
   function updateDias(next: number) {
     dias = next;
-    if (typeof window === 'undefined') return;
-    const entries = Object.fromEntries(new URLSearchParams(window.location.search));
-    const params = new URLSearchParams({ ...entries, dias: String(next) });
-    window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
+    replaceUrlParams({ dias: next });
   }
 
   $effect(() => {
@@ -185,6 +186,14 @@
   const maxMonthly = $derived(
     data ? Math.max(1, ...data.monthly.map((m) => m.count)) : 1,
   );
+
+  $effect(() => {
+    if (!data) return;
+    setPageMeta({
+      title: `${data.name} — Órgão ${data.cnpj}`,
+      description: `Histórico de contratações públicas registradas pelo órgão ${data.name} no PNCP.`,
+    });
+  });
 </script>
 
 <EntityDetailLayout
@@ -202,7 +211,10 @@
 >
   {#snippet metaRow()}
     {#if data}
-      <small>CNPJ: <code>{data.cnpj}</code></small>
+      <small>
+        CNPJ: <code>{data.cnpj}</code>
+        <CopyButton text={data.cnpj} label="Copiar CNPJ" />
+      </small>
       <small>Fonte: <span data-badge>{data.archived ? 'Arquivo Parquet (IA)' : 'PNCP V1'}</span></small>
     {/if}
   {/snippet}
@@ -217,6 +229,7 @@
       >
         {isAgencyWatched ? '✓ Acompanhando' : 'Receber alertas deste órgão'}
       </button>
+      <ShareButton title={`${data.name} — Órgão`} text={`Órgão ${data.cnpj}`} variant="inline" />
     {/if}
   {/snippet}
 

--- a/web/src/components/AlertBanner.svelte
+++ b/web/src/components/AlertBanner.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
   import Icon from './Icon.svelte';
+  import CopyButton from './CopyButton.svelte';
   import type { IconName } from '../lib/icons';
 
   interface Props {
     title: string;
     message: string;
     level?: 'info' | 'success' | 'warning' | 'error';
+    copyable?: boolean;
   }
 
-  let { title, message, level = 'info' }: Props = $props();
+  let { title, message, level = 'info', copyable = true }: Props = $props();
 
   const levelIcon: Record<NonNullable<Props['level']>, IconName> = {
     info: 'info',
@@ -31,4 +33,9 @@
     </strong>
   </header>
   <p>{message}</p>
+  {#if copyable && message}
+    <footer>
+      <CopyButton text={`${title}: ${message}`} label="Copiar mensagem" />
+    </footer>
+  {/if}
 </article>

--- a/web/src/components/AtasView.svelte
+++ b/web/src/components/AtasView.svelte
@@ -14,6 +14,7 @@
   import EmptyState from './EmptyState.svelte';
   import HubHeader from './HubHeader.svelte';
   import Skeleton from './Skeleton.svelte';
+  import CopyButton from './CopyButton.svelte';
 
   setQueryClientContext(getQueryClient());
 
@@ -121,11 +122,17 @@
     <section data-testid="atas-list">
       {#each rows as row (row.numero_controle_pncp ?? `${row.cnpj_orgao}-${row.sequencial_contrato}`)}
         <article>
+          <header>
+            <strong>{row.razao_social_orgao ?? 'Órgão Arquivado'}</strong>
+            <code>{row.cnpj_orgao ?? ''}</code>
+            {#if row.cnpj_orgao}
+              <CopyButton text={row.cnpj_orgao} label="Copiar CNPJ" />
+            {/if}
+            {#if row.numero_controle_pncp}
+              <CopyButton text={row.numero_controle_pncp} label="Copiar ID PNCP" />
+            {/if}
+          </header>
           <a href={resolve(`contratacao?id=${row.numero_controle_pncp ?? ''}`)}>
-            <header>
-              <strong>{row.razao_social_orgao ?? 'Órgão Arquivado'}</strong>
-              <code>{row.cnpj_orgao ?? ''}</code>
-            </header>
             <p>{truncate(row.objeto_contrato, 150)}</p>
             <footer>
               <small>

--- a/web/src/components/BuscaView.svelte
+++ b/web/src/components/BuscaView.svelte
@@ -23,7 +23,10 @@
   import HubHeader from './HubHeader.svelte';
   import Skeleton from './Skeleton.svelte';
   import PaginatedList from './PaginatedList.svelte';
+  import CopyButton from './CopyButton.svelte';
+  import ShareButton from './ShareButton.svelte';
   import { addWatch, isWatched, hydrateWatches } from '../lib/watchStore.svelte';
+  import { replaceUrlParams } from '../lib/urlState';
 
   setQueryClientContext(getQueryClient());
 
@@ -52,7 +55,20 @@
     return { input: rawQ, submitted: { q: parsed.term, filters } };
   }
 
+  // Post-fetch (visible) filters — distinct from FILTERS server-side keys.
+  // `ufFiltro` lives in FILTERS as the PNCP-side filter, leaving `uf` free
+  // to mean "narrow what's already on screen".
+  function readPostFilters(): { uf: string; modalidade: string } {
+    if (typeof window === 'undefined') return { uf: '', modalidade: '' };
+    const params = new URLSearchParams(window.location.search);
+    return {
+      uf: params.get('uf') ?? '',
+      modalidade: params.get('modalidade') ?? '',
+    };
+  }
+
   const initial = readUrl();
+  const initialPost = readPostFilters();
 
   // searchInput is what's bound to the visible <input>. We never rewrite
   // it during submit — that previously caused a "snap" as the field was
@@ -75,8 +91,8 @@
   );
   const draftHasAny = $derived(Object.values(drafts).some((v) => !!v));
 
-  let selectedUf = $state('');
-  let selectedModality = $state('');
+  let selectedUf = $state(initialPost.uf);
+  let selectedModality = $state(initialPost.modalidade);
 
   const redirecting = $derived(!!submitted.q && isPncpId(submitted.q));
 
@@ -196,17 +212,22 @@
   // filter — `?q=merenda&ibge=1100205&uf=RO`. Semantic separation makes
   // links easier to share/debug and lets applySuggestion() mutate just
   // `q` without nuking the structured filters.
-  function syncUrl(q: string, filters: FilterValues): void {
-    if (typeof window === 'undefined') return;
+  function syncUrl(q: string, filters: FilterValues, post?: { uf: string; modalidade: string }): void {
     const entries: Record<string, string> = { ...toUrlEntries(filters) };
     if (q) entries.q = q;
-    const qs = new URLSearchParams(entries).toString();
-    window.history.replaceState(
-      {},
-      '',
-      qs ? `${window.location.pathname}?${qs}` : window.location.pathname,
-    );
+    if (post?.uf) entries.uf = post.uf;
+    if (post?.modalidade) entries.modalidade = post.modalidade;
+    replaceUrlParams(entries, { merge: false });
   }
+
+  // Track post-fetch filter changes back into the URL so a deep link
+  // restores exactly what the user last saw — including UF/modalidade
+  // narrowing applied after the PNCP fetch.
+  $effect(() => {
+    const uf = selectedUf;
+    const mod = selectedModality;
+    syncUrl(submitted.q, submitted.filters, { uf, modalidade: mod });
+  });
 
   function applySuggestion(): void {
     if (!suggestion) return;
@@ -267,40 +288,17 @@
 
   // The export buttons act on what the user sees — i.e. filteredResults,
   // not the raw fetch — so the file matches the on-screen aggregate strip.
-  let copyStatus = $state<'idle' | 'copied' | 'error'>('idle');
-  let copyTimer: ReturnType<typeof setTimeout> | null = null;
-
-  // Clear any pending status reset when the component unmounts so the
-  // timer cannot fire a state assignment after destroy.
-  $effect(() => {
-    return () => {
-      if (copyTimer !== null) {
-        clearTimeout(copyTimer);
-        copyTimer = null;
-      }
-    };
-  });
-
   function exportCsv(): void {
     const slug = (submitted.q || 'busca').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') || 'busca';
     exporters.downloadTextFile(`baliza-${slug}.csv`, exporters.toCsv(filteredResults), 'text/csv');
   }
 
-  async function exportMarkdown(): Promise<void> {
-    const md = exporters.toMarkdown(filteredResults);
-    try {
-      await navigator.clipboard.writeText(md);
-      copyStatus = 'copied';
-    } catch {
-      copyStatus = 'error';
-    }
-    // Cancel any pending reset so rapid clicks do not stack timers.
-    if (copyTimer !== null) clearTimeout(copyTimer);
-    copyTimer = setTimeout(() => {
-      copyStatus = 'idle';
-      copyTimer = null;
-    }, 2000);
-  }
+  const markdown = $derived(exporters.toMarkdown(filteredResults));
+  const shareText = $derived(
+    submitted.q
+      ? `Busca "${submitted.q}" no Baliza — ${aggregates.count} contratações`
+      : `Busca no Baliza — ${aggregates.count} contratações`,
+  );
 </script>
 
 <section>
@@ -389,12 +387,8 @@
         {queryWatched ? '✓ Vigilância salva' : 'Salvar vigilância'}
       </button>
       <button type="button" class="outline" data-testid="busca-export-csv" onclick={exportCsv}>Exportar CSV</button>
-      <button type="button" class="outline" data-testid="busca-export-markdown" onclick={exportMarkdown}>Exportar Markdown</button>
-      {#if copyStatus !== 'idle'}
-        <small role="status" aria-live="polite" data-testid="busca-export-status">
-          {copyStatus === 'copied' ? 'Copiado!' : 'Falha ao copiar'}
-        </small>
-      {/if}
+      <CopyButton text={markdown} variant="inline" label="Exportar Markdown" testid="busca-export-markdown" />
+      <ShareButton title="Busca Baliza" text={shareText} variant="inline" testid="busca-share" />
     </div>
 
     <article data-testid="busca-aggregates" aria-label="Resumo dos resultados visíveis">

--- a/web/src/components/CitationBlock.svelte
+++ b/web/src/components/CitationBlock.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { getLatestParquetUrl, getLatestParquetInfo } from '../lib/ia-manifest';
+  import CopyButton from './CopyButton.svelte';
 
   let snapshotDate = $state<string | null>(null);
   let archiveUrl = $state<string | null>(null);
   let loading = $state(true);
   let visible = $state(false);
-  let copied = $state(false);
 
   onMount(async () => {
     try {
@@ -46,19 +46,6 @@
   }
 
   const bibtex = $derived(buildBibtex());
-
-  async function copyBibtex() {
-    try {
-      await navigator.clipboard.writeText(bibtex);
-      copied = true;
-      setTimeout(() => {
-        copied = false;
-      }, 2500);
-    } catch {
-      // Clipboard blocked — the pre block is already visible; user can
-      // manually select and copy.
-    }
-  }
 </script>
 
 <section aria-labelledby="citation-title">
@@ -98,9 +85,7 @@
       </small>
       <pre data-testid="bibtex-block"><code>{bibtex}</code></pre>
       <footer>
-        <button type="button" class="outline" data-testid="copy-bibtex" onclick={copyBibtex}>
-          {copied ? 'Copiado ✓' : 'Copiar BibTeX'}
-        </button>
+        <CopyButton text={bibtex} variant="inline" label="Copiar BibTeX" testid="copy-bibtex" />
       </footer>
     </blockquote>
   {/if}

--- a/web/src/components/CityDetailView.svelte
+++ b/web/src/components/CityDetailView.svelte
@@ -13,7 +13,10 @@
   import StatCard from './StatCard.svelte';
   import ContractCard from './ContractCard.svelte';
   import PaginatedList from './PaginatedList.svelte';
+  import CopyButton from './CopyButton.svelte';
+  import ShareButton from './ShareButton.svelte';
   import { findMunicipalityByIbge } from '../lib/geo';
+  import { setPageMeta } from '../lib/pageMeta';
 
   setQueryClientContext(getQueryClient());
 
@@ -98,6 +101,14 @@
       ? 'Dados do município indisponíveis no momento'
       : 'Município não encontrado';
   });
+
+  $effect(() => {
+    if (!data) return;
+    setPageMeta({
+      title: `${data.name}/${data.uf} — Município ${data.ibge}`,
+      description: `Contratações públicas recentes registradas pelo município ${data.name}/${data.uf}.`,
+    });
+  });
 </script>
 
 <EntityDetailLayout
@@ -117,7 +128,11 @@
 >
   {#snippet metaRow()}
     {#if data}
-      <small>Cód. IBGE: <code>{data.ibge}</code></small>
+      <small>
+        Cód. IBGE: <code>{data.ibge}</code>
+        <CopyButton text={data.ibge} label="Copiar código IBGE" />
+        <ShareButton title={`${data.name}/${data.uf} — Município`} text={`Município ${data.ibge}`} />
+      </small>
       <small>Fonte: <span data-badge>{data.archived ? 'Arquivo Parquet (IA)' : 'PNCP V1'}</span></small>
     {/if}
   {/snippet}

--- a/web/src/components/CompararView.svelte
+++ b/web/src/components/CompararView.svelte
@@ -8,6 +8,7 @@
   import EmptyState from './EmptyState.svelte';
   import HubHeader from './HubHeader.svelte';
   import Skeleton from './Skeleton.svelte';
+  import { replaceUrlParams } from '../lib/urlState';
 
   setQueryClientContext(getQueryClient());
 
@@ -79,15 +80,7 @@
     const objeto = searchObjeto.trim();
     submittedIbge = ibge;
     submittedObjeto = objeto;
-    if (typeof window === 'undefined') return;
-    // eslint-disable-next-line svelte/prefer-svelte-reactivity
-    const params = new URLSearchParams(window.location.search);
-    if (ibge) params.set('ibge', ibge);
-    else params.delete('ibge');
-    if (objeto) params.set('objeto', objeto);
-    else params.delete('objeto');
-    const qs = params.toString();
-    window.history.replaceState({}, '', qs ? `${window.location.pathname}?${qs}` : window.location.pathname);
+    replaceUrlParams({ ibge, objeto });
   }
 </script>
 

--- a/web/src/components/ContractCard.svelte
+++ b/web/src/components/ContractCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { resolve } from '../lib/baseUrl';
   import { formatBRL, formatDate, truncate } from '../lib/format';
+  import CopyButton from './CopyButton.svelte';
 
   interface Props {
     id: string;
@@ -14,11 +15,12 @@
 </script>
 
 <article>
+  <header>
+    <code>{id}</code>
+    <CopyButton text={id} label="Copiar ID PNCP" />
+    <small>{date ? formatDate(date) : ''}</small>
+  </header>
   <a href={resolve(`contratacao?id=${id}`)}>
-    <header>
-      <code>{id}</code>
-      <small>{date ? formatDate(date) : ''}</small>
-    </header>
     <p>{truncate(obj, 150)}</p>
     <footer>
       {#if buyer}<strong>{buyer}</strong>{/if}

--- a/web/src/components/ContractDetailView.svelte
+++ b/web/src/components/ContractDetailView.svelte
@@ -18,6 +18,9 @@
   import { resolve } from '../lib/baseUrl';
   import EntityDetailLayout from './EntityDetailLayout.svelte';
   import Glossary from './Glossary.svelte';
+  import CopyButton from './CopyButton.svelte';
+  import ShareButton from './ShareButton.svelte';
+  import { setPageMeta } from '../lib/pageMeta';
 
   setQueryClientContext(getQueryClient());
 
@@ -97,6 +100,16 @@
     data?.archived?.dataParticao ?? snapshotDate,
   );
 
+  $effect(() => {
+    if (!data) return;
+    const objeto = data.objetoContratacao || `Contratação ${id}`;
+    setPageMeta({
+      title: `${objeto} — ${id}`,
+      description: data.orgaoEntidade?.razaoSocial
+        ? `${data.orgaoEntidade.razaoSocial}: ${objeto}`
+        : objeto,
+    });
+  });
 </script>
 
 <EntityDetailLayout
@@ -114,7 +127,11 @@
 >
   {#snippet metaRow()}
     {#if data}
-      <small>ID: <code>{data.numeroControlePNCP || id}</code></small>
+      <small>
+        ID: <code>{data.numeroControlePNCP || id}</code>
+        <CopyButton text={data.numeroControlePNCP || id} label="Copiar ID PNCP" />
+        <ShareButton text={`PNCP ${data.numeroControlePNCP || id}`} />
+      </small>
       <small>Publicação: {formatDate(data.dataPublicacaoPncp)}</small>
       {#if effectiveSnapshot}
         <small data-testid="snapshot-date">
@@ -188,7 +205,7 @@
               {/if}
             </dd>
           </div>
-          <div role="listitem"><dt>CNPJ</dt><dd>{data.orgaoEntidade?.cnpj || '—'}</dd></div>
+          <div role="listitem"><dt>CNPJ</dt><dd>{data.orgaoEntidade?.cnpj || '—'}{#if data.orgaoEntidade?.cnpj} <CopyButton text={data.orgaoEntidade.cnpj} label="Copiar CNPJ" />{/if}</dd></div>
           <div role="listitem"><dt>Unidade</dt><dd>{data.unidadeOrgao?.nomeUnidade || '—'}</dd></div>
           <div role="listitem">
             <dt>Município</dt>

--- a/web/src/components/CopyButton.svelte
+++ b/web/src/components/CopyButton.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import Icon from './Icon.svelte';
+
+  interface Props {
+    text: string;
+    label?: string;
+    variant?: 'icon' | 'inline';
+    size?: 'sm' | 'md';
+    testid?: string;
+  }
+
+  const {
+    text,
+    label = 'Copiar',
+    variant = 'icon',
+    size = 'sm',
+    testid,
+  }: Props = $props();
+
+  let status = $state<'idle' | 'copied' | 'error'>('idle');
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  $effect(() => {
+    return () => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+  });
+
+  const disabled = $derived(!text || !text.trim());
+
+  // The copy click can fire from inside an <a> wrapper (e.g. ContractCard) —
+  // stop propagation so the click doesn't navigate away before the user
+  // reads the "Copiado!" feedback.
+  async function handleClick(event: MouseEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (disabled) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      status = 'copied';
+    } catch {
+      status = 'error';
+    }
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      status = 'idle';
+      timer = null;
+    }, 2000);
+  }
+
+  const iconName = $derived(
+    status === 'copied' ? 'check-circle' : status === 'error' ? 'x-circle' : 'copy',
+  );
+  const feedbackLabel = $derived(
+    status === 'copied' ? 'Copiado!' : status === 'error' ? 'Falha ao copiar' : label,
+  );
+</script>
+
+<button
+  type="button"
+  class="outline copy-button"
+  data-size={size}
+  data-variant={variant}
+  data-status={status}
+  data-testid={testid}
+  aria-label={variant === 'icon' ? feedbackLabel : undefined}
+  title={variant === 'icon' ? label : undefined}
+  {disabled}
+  onclick={handleClick}
+>
+  <Icon name={iconName} />
+  {#if variant === 'inline'}
+    <span>{feedbackLabel}</span>
+  {/if}
+</button>
+{#if status !== 'idle'}
+  <span class="sr-only" role="status" aria-live="polite">
+    {status === 'copied' ? 'Copiado!' : 'Falha ao copiar'}
+  </span>
+{/if}

--- a/web/src/components/DispensasView.svelte
+++ b/web/src/components/DispensasView.svelte
@@ -8,6 +8,7 @@
   import EmptyState from './EmptyState.svelte';
   import HubHeader from './HubHeader.svelte';
   import Skeleton from './Skeleton.svelte';
+  import { replaceUrlParams } from '../lib/urlState';
 
   setQueryClientContext(getQueryClient());
 
@@ -60,13 +61,7 @@
     ev.preventDefault();
     const term = searchInput.trim();
     submittedObjeto = term;
-    if (typeof window === 'undefined') return;
-    // eslint-disable-next-line svelte/prefer-svelte-reactivity
-    const params = new URLSearchParams(window.location.search);
-    if (term) params.set('objeto', term);
-    else params.delete('objeto');
-    const qs = params.toString();
-    window.history.replaceState({}, '', qs ? `${window.location.pathname}?${qs}` : window.location.pathname);
+    replaceUrlParams({ objeto: term });
   }
 </script>
 

--- a/web/src/components/DuckDBExplorer.svelte
+++ b/web/src/components/DuckDBExplorer.svelte
@@ -6,6 +6,8 @@
   import { SCHEMA_MAP } from '../lib/explorerSchema';
   import { ARCHIVED_TABLES, type ArchivedTable } from '../lib/archive/schema';
   import AlertBanner from './AlertBanner.svelte';
+  import CopyButton from './CopyButton.svelte';
+  import ShareButton from './ShareButton.svelte';
 
   function readInitialQuery(): string {
     if (typeof window === 'undefined') return 'SELECT * FROM contracts LIMIT 10';
@@ -200,9 +202,13 @@
             ⚠️ Substitua <code>'IA_URL'</code> pela URL real do arquivo Parquet no Internet Archive antes de executar.
           </small>
         {/if}
-        <button onclick={runQuery} disabled={loading || hasUnresolvedUrl} aria-busy={loading}>
-          {loading ? "Executando..." : "Explorar Dados"}
-        </button>
+        <div role="group" class="actions">
+          <button onclick={runQuery} disabled={loading || hasUnresolvedUrl} aria-busy={loading}>
+            {loading ? "Executando..." : "Explorar Dados"}
+          </button>
+          <CopyButton text={query} variant="inline" label="Copiar SQL" />
+          <ShareButton title="Consulta SQL Baliza" variant="inline" />
+        </div>
       </div>
 
       {#if error}

--- a/web/src/components/EmptyState.svelte
+++ b/web/src/components/EmptyState.svelte
@@ -1,20 +1,28 @@
 <script lang="ts">
+  import CopyButton from './CopyButton.svelte';
+
   interface Props {
     title: string;
     message: string;
     actionHref?: string;
     actionLabel?: string;
+    copyable?: boolean;
   }
 
-  let { title, message, actionHref, actionLabel }: Props = $props();
+  let { title, message, actionHref, actionLabel, copyable = false }: Props = $props();
 </script>
 
 <article role="status" aria-live="polite">
   <header><h3><span aria-hidden="true">🪹</span> {title}</h3></header>
   <p>{message}</p>
-  {#if actionHref && actionLabel}
+  {#if (actionHref && actionLabel) || copyable}
     <footer>
-      <a href={actionHref} role="button">{actionLabel}</a>
+      {#if actionHref && actionLabel}
+        <a href={actionHref} role="button">{actionLabel}</a>
+      {/if}
+      {#if copyable}
+        <CopyButton text={`${title}: ${message}`} label="Copiar mensagem" />
+      {/if}
     </footer>
   {/if}
 </article>

--- a/web/src/components/MercadoView.svelte
+++ b/web/src/components/MercadoView.svelte
@@ -7,8 +7,10 @@
   import AlertBanner from './AlertBanner.svelte';
   import EmptyState from './EmptyState.svelte';
   import HubHeader from './HubHeader.svelte';
+  import ShareButton from './ShareButton.svelte';
   import Skeleton from './Skeleton.svelte';
   import { resolve } from '../lib/baseUrl';
+  import { replaceUrlParams } from '../lib/urlState';
 
   setQueryClientContext(getQueryClient());
 
@@ -81,13 +83,7 @@
     ev.preventDefault();
     const term = searchInput.trim();
     submittedObjeto = term;
-    if (typeof window === 'undefined') return;
-    // eslint-disable-next-line svelte/prefer-svelte-reactivity
-    const params = new URLSearchParams(window.location.search);
-    if (term) params.set('objeto', term);
-    else params.delete('objeto');
-    const qs = params.toString();
-    window.history.replaceState({}, '', qs ? `${window.location.pathname}?${qs}` : window.location.pathname);
+    replaceUrlParams({ objeto: term });
   }
 </script>
 
@@ -147,6 +143,7 @@
     </div>
     <div class="actions">
       <a href={resolve(`atas?objeto=${submittedObjeto}`)} role="button" class="outline">Ver pesquisa de preços</a>
+      <ShareButton title={`Mercado: ${submittedObjeto}`} variant="inline" />
     </div>
   {/if}
 </section>

--- a/web/src/components/Metadata.astro
+++ b/web/src/components/Metadata.astro
@@ -2,7 +2,13 @@
 /**
  * Baliza SEO & Metadata Component
  * Handles title, description, and social media cards (OG/Twitter).
+ *
+ * og:image is per-route: each top-level route has a static SVG generated
+ * by /og/<slug>.svg (see src/pages/og/[slug].svg.ts and lib/ogManifest).
+ * twitter:image keeps the static PNG fallback because Twitter does not
+ * render SVG previews.
  */
+import { findOgRoute } from '../lib/ogManifest';
 
 interface Props {
   title: string;
@@ -13,12 +19,17 @@ interface Props {
 
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 
+const ogRoute = findOgRoute(Astro.url.pathname);
+const defaultOgImage = `${BASE}og/${ogRoute.slug}.svg`;
+
 const {
   title,
   description = "Baliza: Monitoramento diário das contratações públicas brasileiras. Transparência, preservação e dados abertos do PNCP.",
-  image = `${BASE}og-image.png`,
+  image = defaultOgImage,
   canonicalURL = new URL(Astro.url.pathname, Astro.site),
 } = Astro.props;
+
+const twitterImage = `${BASE}og-image.png`;
 
 const fullTitle = `${title} | Baliza Monitor`;
 ---
@@ -49,4 +60,4 @@ const fullTitle = `${title} | Baliza Monitor`;
 <meta property="twitter:url" content={Astro.url} />
 <meta property="twitter:title" content={fullTitle} />
 <meta property="twitter:description" content={description} />
-<meta property="twitter:image" content={new URL(image, Astro.url)} />
+<meta property="twitter:image" content={new URL(twitterImage, Astro.url)} />

--- a/web/src/components/ShareButton.svelte
+++ b/web/src/components/ShareButton.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+  import Icon from './Icon.svelte';
+
+  interface Props {
+    url?: string;
+    title?: string;
+    text?: string;
+    label?: string;
+    variant?: 'icon' | 'inline';
+    size?: 'sm' | 'md';
+    testid?: string;
+  }
+
+  const {
+    url,
+    title,
+    text,
+    label = 'Compartilhar',
+    variant = 'icon',
+    size = 'sm',
+    testid,
+  }: Props = $props();
+
+  let status = $state<'idle' | 'shared' | 'copied' | 'error'>('idle');
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  $effect(() => {
+    return () => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+  });
+
+  function resolvedUrl(): string {
+    if (url) return url;
+    return typeof window !== 'undefined' ? window.location.href : '';
+  }
+
+  function resolvedTitle(): string {
+    if (title) return title;
+    return typeof document !== 'undefined' ? document.title : 'Baliza';
+  }
+
+  async function handleClick(event: MouseEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+    const target = resolvedUrl();
+    if (!target) return;
+    const payload: ShareData = { url: target, title: resolvedTitle() };
+    if (text) payload.text = text;
+    try {
+      if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+        await navigator.share(payload);
+        status = 'shared';
+      } else {
+        await navigator.clipboard.writeText(target);
+        status = 'copied';
+      }
+    } catch (err) {
+      // The Web Share API rejects with AbortError when the user dismisses
+      // the share-sheet. That's not a failure — silently return to idle.
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        status = 'idle';
+        return;
+      }
+      status = 'error';
+    }
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      status = 'idle';
+      timer = null;
+    }, 2000);
+  }
+
+  const iconName = $derived(
+    status === 'shared' || status === 'copied'
+      ? 'check-circle'
+      : status === 'error'
+      ? 'x-circle'
+      : 'share',
+  );
+  const feedbackLabel = $derived(
+    status === 'shared'
+      ? 'Compartilhado!'
+      : status === 'copied'
+      ? 'Link copiado!'
+      : status === 'error'
+      ? 'Falha ao compartilhar'
+      : label,
+  );
+</script>
+
+<button
+  type="button"
+  class="outline share-button"
+  data-size={size}
+  data-variant={variant}
+  data-status={status}
+  data-testid={testid}
+  aria-label={variant === 'icon' ? feedbackLabel : undefined}
+  title={variant === 'icon' ? label : undefined}
+  onclick={handleClick}
+>
+  <Icon name={iconName} />
+  {#if variant === 'inline'}
+    <span>{feedbackLabel}</span>
+  {/if}
+</button>
+{#if status !== 'idle'}
+  <span class="sr-only" role="status" aria-live="polite">{feedbackLabel}</span>
+{/if}

--- a/web/src/components/ShareButton.svelte
+++ b/web/src/components/ShareButton.svelte
@@ -65,7 +65,15 @@
         status = 'idle';
         return;
       }
-      status = 'error';
+      // Other share failures (policy restrictions, unsupported payload,
+      // platform quirks) shouldn't strand the user — copy the URL so the
+      // share intent still completes.
+      try {
+        await navigator.clipboard.writeText(target);
+        status = 'copied';
+      } catch {
+        status = 'error';
+      }
     }
     if (timer !== null) clearTimeout(timer);
     timer = setTimeout(() => {

--- a/web/src/components/SupplierDetailView.svelte
+++ b/web/src/components/SupplierDetailView.svelte
@@ -16,7 +16,10 @@
   import EmptyState from './EmptyState.svelte';
   import ContractCard from './ContractCard.svelte';
   import PaginatedList from './PaginatedList.svelte';
+  import CopyButton from './CopyButton.svelte';
+  import ShareButton from './ShareButton.svelte';
   import { addWatch, isWatched, hydrateWatches } from '../lib/watchStore.svelte';
+  import { setPageMeta } from '../lib/pageMeta';
 
   setQueryClientContext(getQueryClient());
 
@@ -168,6 +171,14 @@
   }));
 
   const competitors = $derived(peerQuery.data ?? []);
+
+  $effect(() => {
+    if (!data) return;
+    setPageMeta({
+      title: `${data.name} — Fornecedor ${data.cnpj}`,
+      description: `Histórico de contratos arquivados para o fornecedor ${data.name}.`,
+    });
+  });
 </script>
 
 <EntityDetailLayout
@@ -185,7 +196,10 @@
 >
   {#snippet metaRow()}
     {#if data}
-      <small>CNPJ: <code>{data.cnpj}</code></small>
+      <small>
+        CNPJ: <code>{data.cnpj}</code>
+        <CopyButton text={data.cnpj} label="Copiar CNPJ" />
+      </small>
       <small>Fonte: <span data-badge>Arquivo Parquet (IA)</span></small>
     {/if}
   {/snippet}
@@ -203,6 +217,7 @@
         <button class="outline" onclick={() => addWatch('supplier', data.cnpj, data.name)} disabled={isWatched('supplier', data.cnpj)} aria-pressed={isWatched('supplier', data.cnpj)}>
           {isWatched('supplier', data.cnpj) ? '✓ Acompanhando' : 'Acompanhar fornecedor'}
         </button>
+        <ShareButton title={`${data.name} — Fornecedor`} text={`Fornecedor ${data.cnpj}`} variant="inline" />
       </div>
 
       <section class="grid">
@@ -223,6 +238,7 @@
                   <small>#{i + 1}</small>
                   <a href={resolve(`fornecedor?cnpj=${c.cnpj}`)} title={c.name}>{c.name}</a>
                   <code>{c.cnpj}</code>
+                  <CopyButton text={c.cnpj} label="Copiar CNPJ" />
                   <small>{c.count}</small>
                 </li>
               {/each}

--- a/web/src/components/WatchDetailView.svelte
+++ b/web/src/components/WatchDetailView.svelte
@@ -10,6 +10,9 @@
   import { formatBRL, formatDate } from '../lib/format';
   import EmptyState from './EmptyState.svelte';
   import AlertBanner from './AlertBanner.svelte';
+  import CopyButton from './CopyButton.svelte';
+  import ShareButton from './ShareButton.svelte';
+  import { setPageMeta } from '../lib/pageMeta';
   import {
     hydrateWatches,
     markVisited,
@@ -129,6 +132,14 @@
   function linkFor(c: PNCPContract): string {
     return resolve(`contratacao?id=${c.numeroControlePNCP ?? ''}`);
   }
+
+  $effect(() => {
+    if (!entry) return;
+    setPageMeta({
+      title: `Vigilância: ${entry.label}`,
+      description: `Acompanhamento das novidades para "${entry.label}".`,
+    });
+  });
 </script>
 
 <section>
@@ -142,7 +153,11 @@
       <hgroup>
         <p class="eyebrow">🔔 Vigilância</p>
         <h1>{entry.label}</h1>
-        <p><code>{entry.filter}</code></p>
+        <p>
+          <code>{entry.filter}</code>
+          <CopyButton text={entry.filter} label="Copiar filtro" />
+          <ShareButton title={`Vigilância: ${entry.label}`} text={entry.filter} />
+        </p>
       </hgroup>
     </header>
 

--- a/web/src/components/WatchList.svelte
+++ b/web/src/components/WatchList.svelte
@@ -7,6 +7,7 @@
     type WatchEntry,
   } from '../lib/watchStore.svelte';
   import { resolve } from '../lib/baseUrl';
+  import CopyButton from './CopyButton.svelte';
 
   // Mirror state lazily so SSR renders an empty list instead of leaking
   // whichever entries exist on the build machine (always empty today, but
@@ -51,6 +52,7 @@
           <header>
             <small data-badge>{labelForType(entry.type)}</small>
             <code>{entry.filter}</code>
+            <CopyButton text={entry.filter} label="Copiar filtro" />
           </header>
           <p><strong>{entry.label}</strong></p>
           <footer class="actions">

--- a/web/src/components/__steps__/copy-button.test.ts
+++ b/web/src/components/__steps__/copy-button.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/svelte/pure';
+import CopyButtonRaw from '../CopyButton.svelte';
+import ShareButtonRaw from '../ShareButton.svelte';
+
+const CopyButton = CopyButtonRaw as unknown as Parameters<typeof render>[0];
+const ShareButton = ShareButtonRaw as unknown as Parameters<typeof render>[0];
+
+function stubClipboard() {
+  // Make sure navigator.clipboard exists and its writeText is spy-able.
+  // jsdom doesn't ship navigator.clipboard, and re-defining it on the
+  // navigator instance is ignored for non-configurable prototype slots —
+  // so we install/replace the property on the navigator's prototype and
+  // then spy on the writeText method directly.
+  const proto = Object.getPrototypeOf(navigator);
+  Object.defineProperty(proto, 'clipboard', {
+    configurable: true,
+    value: { writeText: () => Promise.resolve() },
+  });
+  return vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue();
+}
+
+describe('CopyButton', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('writes text to clipboard on click', async () => {
+    const writeText = stubClipboard();
+    render(CopyButton, { props: { text: 'PNCP-123' } });
+    await fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('PNCP-123'));
+  });
+
+  it('disables when text is blank', () => {
+    render(CopyButton, { props: { text: '   ' } });
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('renders inline label when variant=inline', () => {
+    render(CopyButton, { props: { text: 'x', variant: 'inline', label: 'Copiar BibTeX' } });
+    expect(screen.getByRole('button')).toHaveTextContent('Copiar BibTeX');
+  });
+});
+
+describe('ShareButton', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses navigator.share when available', async () => {
+    const shareSpy = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', { configurable: true, value: shareSpy });
+    render(ShareButton, { props: { url: 'https://example.test/x', title: 'X' } });
+    await fireEvent.click(screen.getByRole('button'));
+    await waitFor(() =>
+      expect(shareSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'https://example.test/x', title: 'X' }),
+      ),
+    );
+  });
+
+  it('falls back to clipboard when share is undefined', async () => {
+    const writeText = stubClipboard();
+    Object.defineProperty(navigator, 'share', { configurable: true, value: undefined });
+    render(ShareButton, { props: { url: 'https://example.test/y' } });
+    await fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('https://example.test/y'));
+  });
+});

--- a/web/src/components/__steps__/copy-button.test.ts
+++ b/web/src/components/__steps__/copy-button.test.ts
@@ -68,6 +68,29 @@ describe('ShareButton', () => {
     );
   });
 
+  it('falls back to clipboard when share rejects with non-abort error', async () => {
+    const writeText = stubClipboard();
+    const shareSpy = vi
+      .fn()
+      .mockRejectedValue(new DOMException('not allowed', 'NotAllowedError'));
+    Object.defineProperty(navigator, 'share', { configurable: true, value: shareSpy });
+    render(ShareButton, { props: { url: 'https://example.test/z' } });
+    await fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('https://example.test/z'));
+  });
+
+  it('stays idle when share rejects with AbortError', async () => {
+    stubClipboard();
+    const shareSpy = vi
+      .fn()
+      .mockRejectedValue(new DOMException('cancelled', 'AbortError'));
+    Object.defineProperty(navigator, 'share', { configurable: true, value: shareSpy });
+    render(ShareButton, { props: { url: 'https://example.test/q' } });
+    await fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+  });
+
   it('falls back to clipboard when share is undefined', async () => {
     const writeText = stubClipboard();
     Object.defineProperty(navigator, 'share', { configurable: true, value: undefined });

--- a/web/src/lib/icons.ts
+++ b/web/src/lib/icons.ts
@@ -32,6 +32,10 @@ export const ICON_PATHS = {
     '<path d="M3 12c2-2 4-3 6-3M3 16c4-4 8-5 12-5M3 20c6-6 12-7 18-7"></path>',
   swap:
     '<path d="M4 8h14M14 4l4 4-4 4"></path><path d="M20 16H6M10 12l-4 4 4 4"></path>',
+  copy:
+    '<rect x="9" y="9" width="11" height="11" rx="2"></rect><path d="M5 15V5a1 1 0 0 1 1-1h10"></path>',
+  share:
+    '<circle cx="6" cy="12" r="2.5"></circle><circle cx="18" cy="6" r="2.5"></circle><circle cx="18" cy="18" r="2.5"></circle><path d="m8.2 10.8 7.6-3.6M8.2 13.2l7.6 3.6"></path>',
 } as const;
 
 export type IconName = keyof typeof ICON_PATHS;

--- a/web/src/lib/ogManifest.ts
+++ b/web/src/lib/ogManifest.ts
@@ -1,0 +1,47 @@
+/**
+ * Per-route OG card metadata. Each entry generates a static SVG card at
+ * build time via /og/<slug>.svg. Add a row when adding a new top-level
+ * route. Detail pages (contratacao, orgao, fornecedor, municipio,
+ * vigilancia) reuse their route-level card and update title/description
+ * at runtime via lib/pageMeta.
+ */
+export interface OgRoute {
+  slug: string;
+  pathname: string;
+  title: string;
+  subtitle: string;
+  accent?: string;
+}
+
+export const OG_ROUTES: ReadonlyArray<OgRoute> = [
+  { slug: 'home', pathname: '/', title: 'Baliza Monitor', subtitle: 'Contratações públicas brasileiras, abertas e preservadas.' },
+  { slug: 'busca', pathname: '/busca', title: 'Busca livre no PNCP', subtitle: 'Pesquise contratações públicas pelo objeto ou nº de controle.' },
+  { slug: 'mercado', pathname: '/mercado', title: 'Mercado — Agregação', subtitle: 'Compradores, fornecedores e faixa de preço.' },
+  { slug: 'comparar', pathname: '/comparar', title: 'Comparar Municípios', subtitle: 'Compare gastos com cidades de porte similar.' },
+  { slug: 'atas', pathname: '/atas', title: 'Atas de Registro de Preços', subtitle: 'Contratos vigentes servidos do arquivo Parquet.' },
+  { slug: 'dispensas', pathname: '/dispensas', title: 'Dispensas — Bases Legais', subtitle: 'Artigos da Lei 14.133/2021 mais citados.' },
+  { slug: 'catmat', pathname: '/catmat', title: 'Busca CATMAT/CATSER', subtitle: 'Encontre o código de material/serviço público.' },
+  { slug: 'explorador', pathname: '/explorador', title: 'Explorador SQL', subtitle: 'Consulte os dados do PNCP via DuckDB no navegador.' },
+  { slug: 'desenvolvedores', pathname: '/desenvolvedores', title: 'Para desenvolvedores', subtitle: 'Como consumir o arquivo Parquet de Python, R, JS.' },
+  { slug: 'sobre', pathname: '/sobre', title: 'Sobre o Baliza', subtitle: 'Metodologia, arquitetura e objetivos.' },
+  { slug: 'status', pathname: '/status', title: 'Status do Pipeline', subtitle: 'Monitoramento da integridade dos dados.' },
+  { slug: 'vigilancia', pathname: '/vigilancia', title: 'Vigilância', subtitle: 'Acompanhe novidades de uma vigilância salva.' },
+  { slug: 'contratacao', pathname: '/contratacao', title: 'Detalhamento de Contratação', subtitle: 'Detalhes preservados de uma contratação pública.' },
+  { slug: 'orgao', pathname: '/orgao', title: 'Painel do Órgão', subtitle: 'Histórico de contratações de um órgão público.' },
+  { slug: 'fornecedor', pathname: '/fornecedor', title: 'Painel do Fornecedor', subtitle: 'Histórico de contratos arquivados do fornecedor.' },
+  { slug: 'municipio', pathname: '/municipio', title: 'Painel do Município', subtitle: 'Contratações registradas pelo município.' },
+];
+
+const BY_PATHNAME = new Map(OG_ROUTES.map((r) => [r.pathname.replace(/\/$/, ''), r]));
+
+export function findOgRoute(pathname: string): OgRoute {
+  // Astro provides Astro.url.pathname including the base prefix in some
+  // setups. Normalise by stripping a trailing slash and any leading
+  // /baliza prefix so the lookup matches OG_ROUTES values.
+  const stripped = pathname
+    .replace(/^\/baliza/, '')
+    .replace(/\/$/, '')
+    .toLowerCase();
+  const match = BY_PATHNAME.get(stripped || '/');
+  return match ?? OG_ROUTES[0]!;
+}

--- a/web/src/lib/pageMeta.ts
+++ b/web/src/lib/pageMeta.ts
@@ -1,0 +1,42 @@
+/**
+ * Runtime page-metadata sync.
+ *
+ * Detail views (contratacao, orgao, fornecedor, municipio, vigilancia) live
+ * on a static Astro shell and resolve their record after mount. Build-time
+ * OG cards therefore reflect the *route*, not the specific record. This
+ * helper updates `<title>` and the og/twitter `<meta>` tags in-place once
+ * data lands so:
+ *
+ *   - The browser tab and history entry show the record name.
+ *   - In-app re-shares (via ShareButton → Web Share API) carry the right
+ *     title/description into chat-app share-sheets.
+ *
+ * It does NOT help social-media crawlers, which fetch HTML without running
+ * JS and will see only the build-time route-level OG card. Don't try to use
+ * this for SEO previews — for that, generate per-record static pages.
+ */
+export function setPageMeta(meta: { title?: string; description?: string }): void {
+  if (typeof document === 'undefined') return;
+
+  if (meta.title) {
+    document.title = meta.title.includes('Baliza') ? meta.title : `${meta.title} | Baliza Monitor`;
+    setMeta('property', 'og:title', document.title);
+    setMeta('property', 'twitter:title', document.title);
+  }
+
+  if (meta.description) {
+    setMeta('name', 'description', meta.description);
+    setMeta('property', 'og:description', meta.description);
+    setMeta('property', 'twitter:description', meta.description);
+  }
+}
+
+function setMeta(attr: 'name' | 'property', key: string, value: string): void {
+  let el = document.querySelector(`meta[${attr}="${key}"]`) as HTMLMetaElement | null;
+  if (!el) {
+    el = document.createElement('meta');
+    el.setAttribute(attr, key);
+    document.head.appendChild(el);
+  }
+  el.setAttribute('content', value);
+}

--- a/web/src/lib/urlState.test.ts
+++ b/web/src/lib/urlState.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { replaceUrlParams } from './urlState';
+
+describe('replaceUrlParams', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('writes a single param, keeping the pathname', () => {
+    replaceUrlParams({ q: 'merenda' });
+    expect(window.location.search).toBe('?q=merenda');
+  });
+
+  it('drops empty/undefined values', () => {
+    replaceUrlParams({ q: 'merenda', uf: '', mod: undefined });
+    expect(window.location.search).toBe('?q=merenda');
+  });
+
+  it('merges with existing params by default', () => {
+    window.history.replaceState({}, '', '/?cnpj=12345');
+    replaceUrlParams({ dias: 30 });
+    expect(window.location.search).toContain('cnpj=12345');
+    expect(window.location.search).toContain('dias=30');
+  });
+
+  it('replaces all params when merge=false', () => {
+    window.history.replaceState({}, '', '/?cnpj=12345&old=value');
+    replaceUrlParams({ q: 'novo' }, { merge: false });
+    expect(window.location.search).toBe('?q=novo');
+  });
+
+  it('removes a key by passing empty string under merge', () => {
+    window.history.replaceState({}, '', '/?q=foo&dias=30');
+    replaceUrlParams({ dias: '' });
+    expect(window.location.search).toBe('?q=foo');
+  });
+
+  it('omits the query string when no params remain', () => {
+    replaceUrlParams({ q: '' });
+    expect(window.location.search).toBe('');
+    expect(window.location.pathname).toBe('/');
+  });
+});

--- a/web/src/lib/urlState.ts
+++ b/web/src/lib/urlState.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared URL-state helper. Several views (BuscaView, MercadoView,
+ * DispensasView, CompararView, AgencyDetailView) all call
+ * `history.replaceState` with the same pathname-or-querystring branch — this
+ * collapses that pattern into one place.
+ *
+ * - `merge: true` (default) preserves any existing params not in `params`.
+ *   Use when a view owns one or two keys but not the whole URL.
+ * - `merge: false` replaces the whole query — use when the view is the sole
+ *   owner of URL state (BuscaView).
+ *
+ * Empty strings, `undefined`, and `null` drop the corresponding key.
+ */
+export function replaceUrlParams(
+  params: Record<string, string | number | undefined | null>,
+  options: { merge?: boolean } = {},
+): void {
+  if (typeof window === 'undefined') return;
+  const merge = options.merge ?? true;
+  const next = merge
+    ? new URLSearchParams(window.location.search)
+    : new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === '') {
+      next.delete(key);
+      continue;
+    }
+    next.set(key, String(value));
+  }
+  const qs = next.toString();
+  window.history.replaceState(
+    {},
+    '',
+    qs ? `${window.location.pathname}?${qs}` : window.location.pathname,
+  );
+}

--- a/web/src/pages/og/[slug].svg.ts
+++ b/web/src/pages/og/[slug].svg.ts
@@ -1,0 +1,83 @@
+import type { APIRoute } from 'astro';
+import { OG_ROUTES } from '../../lib/ogManifest';
+
+export const prerender = true;
+
+export function getStaticPaths() {
+  return OG_ROUTES.map((route) => ({ params: { slug: route.slug } }));
+}
+
+function escapeXml(s: string): string {
+  return s.replace(/[<>&'"]/g, (c) =>
+    c === '<'
+      ? '&lt;'
+      : c === '>'
+        ? '&gt;'
+        : c === '&'
+          ? '&amp;'
+          : c === "'"
+            ? '&apos;'
+            : '&quot;',
+  );
+}
+
+function wrap(text: string, max: number): string[] {
+  const words = text.split(/\s+/);
+  const lines: string[] = [];
+  let current = '';
+  for (const w of words) {
+    if ((current + ' ' + w).trim().length > max) {
+      if (current) lines.push(current);
+      current = w;
+    } else {
+      current = (current ? current + ' ' : '') + w;
+    }
+  }
+  if (current) lines.push(current);
+  return lines.slice(0, 4);
+}
+
+export const GET: APIRoute = ({ params }) => {
+  const slug = params.slug;
+  const route = OG_ROUTES.find((r) => r.slug === slug);
+  if (!route) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const titleLines = wrap(route.title, 28);
+  const subtitleLines = wrap(route.subtitle, 60);
+  const accent = route.accent ?? '#f4b942';
+
+  const titleSvg = titleLines
+    .map((l, i) => `<tspan x="80" dy="${i === 0 ? 0 : 88}">${escapeXml(l)}</tspan>`)
+    .join('');
+  const subtitleSvg = subtitleLines
+    .map((l, i) => `<tspan x="80" dy="${i === 0 ? 0 : 40}">${escapeXml(l)}</tspan>`)
+    .join('');
+
+  const titleY = 240;
+  const subtitleY = titleY + 88 * (titleLines.length - 1) + 80;
+
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0d1117"/>
+      <stop offset="100%" stop-color="#161b22"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect x="0" y="0" width="12" height="630" fill="${accent}"/>
+  <text x="80" y="120" font-family="Inter, system-ui, sans-serif" font-size="32" fill="${accent}" font-weight="600" letter-spacing="6">BALIZA MONITOR</text>
+  <text x="80" y="${titleY}" font-family="Inter, system-ui, sans-serif" font-size="76" fill="#f0f6fc" font-weight="700">${titleSvg}</text>
+  <text x="80" y="${subtitleY}" font-family="Inter, system-ui, sans-serif" font-size="32" fill="#8b949e">${subtitleSvg}</text>
+  <text x="80" y="570" font-family="Inter, system-ui, sans-serif" font-size="22" fill="#8b949e">Arquivo público das contratações nacionais · PNCP + Internet Archive</text>
+</svg>`;
+
+  return new Response(svg, {
+    headers: {
+      'Content-Type': 'image/svg+xml',
+      'Cache-Control': 'public, max-age=86400',
+    },
+  });
+};


### PR DESCRIPTION
## Summary

- New `CopyButton.svelte` and `ShareButton.svelte` (3-state machines with `$effect` timer cleanup) wired into messages (`AlertBanner`, `EmptyState`), every detail view (Contract, Agency, Supplier, City, Watch), and record cards (`ContractCard`, `AtasView`, `WatchList`, supplier competitors). Existing bespoke copy logic in `BuscaView` (Markdown export) and `CitationBlock` (BibTeX) is replaced by the shared component.
- New `lib/urlState.ts` `replaceUrlParams` helper collapses five copies of the same `history.replaceState` idiom (`BuscaView`, `MercadoView`, `DispensasView`, `CompararView`, `AgencyDetailView`). `BuscaView` now persists `selectedUf` / `selectedModality` post-fetch filters to `?uf=` / `?modalidade=` so deep links restore exactly what the user last saw.
- Build-time per-route OG cards generated as static SVG via `/og/[slug].svg.ts` (16 routes). `Metadata.astro` picks the matching SVG for `og:image`; static `og-image.png` is kept as `twitter:image` because Twitter doesn't render SVG previews. Runtime `lib/pageMeta.ts` updates `document.title` and og/twitter meta tags once detail views resolve their record, so in-app re-shares via the Web Share API carry the right title.

## Test plan

- [x] `npx vitest run` — 32 files / 621 tests passing (added `copy-button.test.ts` and `urlState.test.ts`).
- [x] `npx astro check` — 0 errors.
- [x] `npx astro build` — completes; `dist/og/*.svg` written for all 16 routes; `og:image` per page references the matching SVG.
- [x] `npm run lint` — only pre-existing `@html` warning in `Icon.svelte`.
- [ ] Manual UI walkthrough (browser-side; not feasible in this sandbox): copy IDs from a contract page, share via Web Share API, verify URL round-trips on `/busca` with UF + modalidade filters.

https://claude.ai/code/session_01YF6NKahMjfd5ffKUzDTy2Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01YF6NKahMjfd5ffKUzDTy2Y)_