### PR TITLE
docs: adopt Pico CSS v2 rules and update project identity

### DIFF
--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -38,6 +38,25 @@ Astro generates static shells. Svelte is reserved for interactive data islands.
 **10. Truthful metrics over vanity.**
 Show successful syncs, quarantine counts, timestamps, and source links without hiding failure modes.
 
+## Pico CSS Primitives Mapping
+
+Baliza's design language is executed through Pico primitives plus a thin `global.css` extension layer.
+
+- Cards and panels: use `<article>`.
+- Page and section headers: use `<header><hgroup><h2>...</h2><p>...</p></hgroup></header>`.
+- Navigation: use `<nav>`, lists, and semantic links.
+- Disclosure and filters: use `<details>` and `<summary>` when appropriate.
+- Loading states: use `aria-busy="true"`; use `.is-skeleton` only for skeleton placeholders already defined in `global.css`.
+- Error and alert messages: use `<article role="alert" data-invalid="true">`.
+- Neutral async/status messages: use `[role="status"]`.
+- Buttons: use `<button>`, `<button class="outline">`, `<button class="secondary">`, or `<a role="button">` when the element is truly navigational.
+- Actions layout: use the global `.actions` utility.
+- Badges and compact metadata: use `[data-badge]`.
+- Icons or icon-leading labels: use `[data-icon]`.
+- Horizontal tables: wrap `<table>` in `.table-scroll`.
+
+*Note: Baliza does not create a parallel component styling system. Pico is the primitive layer; `global.css` is the civic design-system layer; Svelte/Astro components provide behavior and composition, not local visual law.*
+
 ## Practical Defaults
 
 - Use `Fraunces` for display hierarchy, `Manrope` for UI text, and `JetBrains Mono` for metrics and identifiers.

--- a/web/FRONTEND.md
+++ b/web/FRONTEND.md
@@ -1,6 +1,6 @@
 # Baliza Frontend Architecture Guide
 
-This document describes the tech stack, idioms, and patterns for the Baliza web dashboard, adapted from the CausaGanha standard.
+This document describes the tech stack, idioms, and patterns for the Baliza web dashboard.
 All frontend code lives under `web/`.
 
 ---
@@ -11,7 +11,7 @@ All frontend code lives under `web/`.
 |---|---|
 | Meta-framework | Astro 5 |
 | Component framework | Svelte 5 |
-| Styling | Vanilla CSS with design tokens (No Tailwind) |
+| Styling | Pico CSS v2 + Semantic HTML + Global CSS Variables (No Tailwind) |
 | Local state | Svelte 5 runes (`$state`, `$derived`) |
 | Async state | TanStack Query (`@tanstack/svelte-query@^6`) |
 | Build | Vite |
@@ -65,13 +65,30 @@ type ManifestRow = z.infer<typeof ManifestRowSchema>;
 
 ---
 
-## Vanilla CSS & Design Tokens
+## Styling & Pico CSS Rules
 
-Like CausaGanha, **Tailwind is strictly forbidden in new components.**
-All components must use scoped `<style>` blocks referencing global CSS variables (`var(--color-primary)`, `var(--space-md)`) defined in `web/src/index.css`.
+- Baliza uses Pico CSS v2 as the baseline styling framework.
+- Zero Tailwind. Tailwind syntax, utility-class composition, and Tailwind-style local styling are not allowed.
+- Component-local `<style>` blocks inside `.svelte` or `.astro` files are prohibited.
+- Visual structure must first be solved with semantic HTML supported by Pico: `<article>`, `<header>`, `<hgroup>`, `<nav>`, `<details>`, `<summary>`, `<section>`, forms, tables, and native buttons.
+- Pico's own small class vocabulary is allowed when semantically appropriate, for example `container`, `grid`, `outline`, `secondary`, `contrast`, and `overflow-auto`.
+- Baliza-specific visual variations must be centralized in `web/src/styles/global.css`.
+- When a variation is necessary, prefer explicit semantic/state attributes such as `data-badge`, `data-icon`, `data-invalid`, `aria-busy`, `role="alert"`, or `role="status"` rather than inventing local component classes.
+- New CSS must be rare, global, documented, and expressed as design-system vocabulary, not one-off component styling.
 
-- **Do not** write inline `style="..."` with hardcoded values.
-- **Do not** duplicate hex codes.
+### Do / Don't
+
+Do:
+- `<article>`
+- `<button class="outline">`
+- `<article role="alert" data-invalid="true">`
+- `<div class="table-scroll"><table>...</table></div>`
+
+Don't:
+- Tailwind classes
+- component-scoped `<style>`
+- one-off classes such as `.custom-card`, `.blue-box`, `.page-title-special`
+- visual layout solved by arbitrary `<div>` nesting when semantic tags would work
 
 ---
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2910,7 +2910,7 @@
       "version": "8.59.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
       "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9790,6 +9790,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
This pull request updates the `web/FRONTEND.md` and `web/DESIGN.md` documentation files to officially formalize Baliza's adoption of Pico CSS v2.

Key changes:
- Replaced the "Vanilla CSS & Design Tokens" section in `FRONTEND.md` with "Styling & Pico CSS Rules", clarifying that Tailwind and component-scoped `<style>` tags are strictly forbidden, and Pico semantic HTML must be used instead.
- Added a "Do / Don't" section to `FRONTEND.md` for styling enforcement.
- Updated `DESIGN.md` to include a "Pico CSS Primitives Mapping", giving concrete instructions on how to use `<article>`, `<hgroup>`, etc., to express the design language without a parallel component styling system.
- Completely scrubbed all references to the previous legacy project name.

---
*PR created automatically by Jules for task [3043131114412932244](https://jules.google.com/task/3043131114412932244) started by @franklinbaldo*