### PR TITLE
ShareButton: scope AbortError to share call, add stopImmediatePropagation

### DIFF
--- a/src/baliza/extractor.py
+++ b/src/baliza/extractor.py
@@ -4,9 +4,10 @@ import json
 import subprocess
 import threading
 import time
+from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
 
 import httpx
 import structlog
@@ -364,7 +365,6 @@ class PNCPExtractor:
             raise RuntimeError(
                 f"resource {resource!r} has no entity_model; cannot validate"
             )
-        entity_model = spec.entity_model
 
         month_str = start_date.strftime("%Y-%m")
         raw_dir = Path("data/raw") / month_str

--- a/web/src/components/CopyButton.svelte
+++ b/web/src/components/CopyButton.svelte
@@ -36,7 +36,6 @@
   // reads the "Copiado!" feedback.
   async function handleClick(event: MouseEvent) {
     event.preventDefault();
-    event.stopPropagation();
     event.stopImmediatePropagation();
     if (disabled) return;
     try {

--- a/web/src/components/CopyButton.svelte
+++ b/web/src/components/CopyButton.svelte
@@ -37,6 +37,7 @@
   async function handleClick(event: MouseEvent) {
     event.preventDefault();
     event.stopPropagation();
+    event.stopImmediatePropagation();
     if (disabled) return;
     try {
       await navigator.clipboard.writeText(text);

--- a/web/src/components/ShareButton.svelte
+++ b/web/src/components/ShareButton.svelte
@@ -46,35 +46,44 @@
   async function handleClick(event: MouseEvent) {
     event.preventDefault();
     event.stopPropagation();
+    event.stopImmediatePropagation();
     const target = resolvedUrl();
     if (!target) return;
     const payload: ShareData = { url: target, title: resolvedTitle() };
     if (text) payload.text = text;
-    try {
-      if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+
+    // Try native share first when available. AbortError from
+    // navigator.share specifically means the user dismissed the
+    // share-sheet — silently return to idle without falling through to
+    // clipboard. Other share failures (policy, unsupported payload,
+    // platform quirks) fall through so the share intent still completes
+    // via clipboard.
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      try {
         await navigator.share(payload);
         status = 'shared';
-      } else {
-        await navigator.clipboard.writeText(target);
-        status = 'copied';
-      }
-    } catch (err) {
-      // The Web Share API rejects with AbortError when the user dismisses
-      // the share-sheet. That's not a failure — silently return to idle.
-      if (err instanceof DOMException && err.name === 'AbortError') {
-        status = 'idle';
+        scheduleReset();
         return;
-      }
-      // Other share failures (policy restrictions, unsupported payload,
-      // platform quirks) shouldn't strand the user — copy the URL so the
-      // share intent still completes.
-      try {
-        await navigator.clipboard.writeText(target);
-        status = 'copied';
-      } catch {
-        status = 'error';
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          status = 'idle';
+          return;
+        }
+        // fall through to clipboard
       }
     }
+
+    try {
+      await navigator.clipboard.writeText(target);
+      status = 'copied';
+    } catch {
+      status = 'error';
+    }
+    scheduleReset();
+    return;
+  }
+
+  function scheduleReset() {
     if (timer !== null) clearTimeout(timer);
     timer = setTimeout(() => {
       status = 'idle';

--- a/web/src/components/ShareButton.svelte
+++ b/web/src/components/ShareButton.svelte
@@ -45,7 +45,6 @@
 
   async function handleClick(event: MouseEvent) {
     event.preventDefault();
-    event.stopPropagation();
     event.stopImmediatePropagation();
     const target = resolvedUrl();
     if (!target) return;

--- a/web/src/lib/parquetFallback.ts
+++ b/web/src/lib/parquetFallback.ts
@@ -1,3 +1,5 @@
+import type { AsyncDuckDBConnection } from '@duckdb/duckdb-wasm';
+import type * as arrow from 'apache-arrow';
 import { getDuckDB } from './duckdb';
 import { getLatestParquetInfo, getParquetShardsForFilter } from './ia-manifest';
 import {
@@ -43,10 +45,10 @@ function isArchivedTable(name: string): name is ArchivedTable {
  * Executes a DuckDB query with a timeout and automatic cancellation.
  */
 async function withDuckDBTimeout(
-  conn: any,
+  conn: AsyncDuckDBConnection,
   sql: string,
   timeoutMs: number,
-): Promise<any | '__timeout__'> {
+): Promise<arrow.Table | '__timeout__'> {
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
   const queryPromise = conn.query(sql);
   queryPromise.catch(() => null); // Swallow late rejections
@@ -464,6 +466,7 @@ export async function queryCityAggregates(
 export async function queryPublishingCnpjRaizes(
   opts: { timeoutMs?: number } = {},
 ): Promise<ArchiveResult<string>> {
+  const { timeoutMs = DEFAULT_QUERY_TIMEOUT_MS } = opts;
   const info = await getLatestParquetInfo(CITY_AGGREGATES_TABLE);
   if (!info) {
     logFallbackFailed(CITY_AGGREGATES_TABLE, 'cnpj_orgao', 'no_manifest');


### PR DESCRIPTION
## Summary

Follow-up to #550 addressing two `kilo-code-bot` review comments that arrived after merge.

- **Scope `AbortError` handling to the share call only.** Previously the catch wrapped both `navigator.share` and the clipboard fallback, so any `AbortError` from clipboard would also be silently swallowed. Restructured so `navigator.share`'s `AbortError` (user dismissing the share-sheet) returns to idle, other share rejections fall through to the clipboard fallback, and clipboard errors get their own `try`/`catch`.
- **Add `event.stopImmediatePropagation()`** to both `CopyButton` and `ShareButton` click handlers so sibling listeners on the same node can't fire while the async clipboard write is still pending.

## Test plan

- [x] `npx vitest run src/components/__steps__/copy-button.test.ts` — all 7 tests pass (existing AbortError-stays-idle and non-AbortError-falls-back tests still cover both branches).

https://claude.ai/code/session_01YF6NKahMjfd5ffKUzDTy2Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01YF6NKahMjfd5ffKUzDTy2Y)_