### PR TITLE
feat(resources): introduce PNCP Resource Atlas with planned publicacoes/pca seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@
 
 ## Product vision and user journeys
 
+Baliza is evolving from a contratos-centered browser into a multi-resource
+PNCP archive: PCA → Publicações → Atas → Contratos → Itens. The
+architectural contract for each resource lives in
+[`web/features/pncp-resource-atlas.feature`](web/features/pncp-resource-atlas.feature),
+the strategic framing in [`VISION.md`](VISION.md), and the promotion
+roadmap in [`docs/plans/resource-atlas-roadmap.md`](docs/plans/resource-atlas-roadmap.md).
+
 Who Baliza serves and which problem it solves for each persona is documented in [`VISION.md`](VISION.md) — including the seven canonical user journeys (B2G supplier, public buyer, journalist, citizen, researcher, developer, auditor), the prioritization principle, and the explicit non-goals. The journeys are mirrored as an executable specification under [`web/features/journeys/`](web/features/journeys/); component-level behaviors live in [`web/features/`](web/features/). Red scenarios are intentional: each one is a backlog item. Run `npm run test:bdd:report` (from `web/`) for the current green/wip/planned breakdown.
 
 ## Installation

--- a/VISION.md
+++ b/VISION.md
@@ -211,6 +211,35 @@ Current state: not yet served. None of the alerting infrastructure exists.
 
 Feature file: [`web/features/journeys/07_auditor_watchdog.feature`](web/features/journeys/07_auditor_watchdog.feature)
 
+### The PNCP Resource Atlas
+
+Baliza is not a contracts search page; it is a temporal procurement
+intelligence system. To honour that framing the pipeline must mirror the
+several PNCP endpoints that, taken together, describe the full life cycle
+of a public purchase. The conceptual spine — from intent to fact — is:
+
+| Layer       | PNCP resource     | What it answers                              | Status         |
+|-------------|-------------------|----------------------------------------------|----------------|
+| Intended    | **PCA**           | What does this agency *plan* to buy?         | Planned        |
+| Open        | **Publicações**   | What is open for bidding *right now*?        | Planned        |
+| Reusable    | **Atas**          | Which framework agreements can I ride on?    | Registered     |
+| Final       | **Contratos**     | What was actually contracted, for how much?  | Registered     |
+| Comparable  | **Itens**         | Item-level prices across buyers and time     | Future         |
+
+Each row is a first-class Baliza resource: it owns a typed `FetchSpec`,
+a raw mirror filename strategy that cannot collide with peers, a
+canonical table with an explicit `schema_version` and primary key, and
+its own Pydantic validation model. The architectural contract is
+specified in [`web/features/pncp-resource-atlas.feature`](web/features/pncp-resource-atlas.feature)
+and is enforced by `tests/unit/test_resource_atlas.py`.
+
+Today `RESOURCES` (in `src/baliza/resources/__init__.py`) holds the two
+registered resources, `contratos` and `atas`. `PLANNED_RESOURCES` holds
+`publicacoes` and `pca` with documented TODO markers naming the exact
+facts that block promotion. Nothing about the active pipeline depends on
+the planned set, so registering a new resource is a single-line change
+and a closed-out TODO list — not a refactor.
+
 ### What Baliza is NOT (non-goals)
 
 - Not a replacement for PNCP. It is an analytical and archival layer on top

--- a/docs/plans/resource-atlas-roadmap.md
+++ b/docs/plans/resource-atlas-roadmap.md
@@ -1,0 +1,112 @@
+# Resource Atlas Roadmap
+
+This roadmap tracks promotion of PNCP resources from
+`PLANNED_RESOURCES` to `RESOURCES` in `src/baliza/resources/__init__.py`.
+The architectural contract every phase must satisfy is captured in
+[`web/features/pncp-resource-atlas.feature`](../../web/features/pncp-resource-atlas.feature)
+and the strategic framing lives in [`VISION.md`](../../VISION.md).
+
+The phases are ordered by leverage on the seven user journeys: open
+opportunities (publicações) help the B2G supplier and the public buyer
+*today*; PCA unlocks intent-vs-fact comparisons; item-level data unlocks
+price intelligence; cross-resource analytics is the payoff.
+
+## Phase 1 — Publicações as canonical archive resource
+
+Goal: register `publicacoes` in `RESOURCES` so that
+`baliza sync --resource publicacoes` mirrors and ingests open
+opportunities monthly.
+
+Blocking work, all tracked as TODO markers in
+`src/baliza/resources/publicacoes.py`:
+
+- Decide modalidade fan-out (`codigoModalidadeContratacao` is required
+  by `/v1/contratacoes/publicacao`). Recommended: extend `FetchSpec`
+  with an optional `required_params: dict[str, list[int|str]]` and have
+  the extractor iterate the cartesian product per page request. Avoids
+  registering one synthetic resource per modalidade.
+- Implement `_flatten_publicacao` in `transforms.py` against
+  `RecuperarCompraPublicacaoDTO`; mirror the snake_case shape of
+  `_flatten_contrato` so the explorer and detail views can reuse the
+  same column conventions.
+- Confirm `numeroControlePNCP` is unique inside a single fetched window
+  before committing to `current_state` dedup. Otherwise switch to
+  `append_only` and add a `data_atualizacao_global DESC` ordering.
+- Confirm `data_start` for the endpoint and set it on the resource;
+  until then backfills walk months unnecessarily.
+
+Exit criteria: characterization test under
+`tests/characterization/` covering at least one mirrored month and the
+flatten round-trip; `RESOURCES["publicacoes"]` exists; no contratos
+regression.
+
+## Phase 2 — PCA as canonical archive resource
+
+Goal: register `pca` in `RESOURCES` and expose a `pca_itens` canonical
+table.
+
+Blocking work, all tracked as TODO markers in
+`src/baliza/resources/pca.py`:
+
+- Confirm which `/v1/pca/...` endpoint is the canonical snapshot
+  source (atualizacao vs usuario vs an item-level alternative).
+- Teach the mirror/uploader to handle `partition_strategy="annual"`.
+  Today `mirror_month` and `_pending_mirror_months` are month-only.
+  Minimum-viable change: add a `partition_period(spec)` helper that
+  returns a `(start, end, label)` tuple and replace the month math in
+  the two pending-loops with it.
+- Implement an item-level flatten that emits one row per
+  `PlanoContratacaoItemDTO` enriched with the parent plan's fields.
+- Verify the composite PK `(id_pca_pncp, numero_item)`.
+
+Exit criteria: same as Phase 1, plus the annual-partition primitive is
+exercised by at least one passing year of PCA data.
+
+## Phase 3 — Item-level canonical data
+
+Goal: introduce `itens_contratos` (and later `itens_atas`,
+`itens_publicacoes`) as derived canonical tables, enabling per-item
+price comparability.
+
+This phase is the first one that benefits from the
+`derived_tables` slot already declared in `pncp_resources.PNCPResource`
+but not yet used. The cleanest path is to hang derived tables off the
+existing `CONTRATOS` and `ATAS` resources rather than minting a
+top-level "itens" resource — items are not a PNCP endpoint of their own,
+they are the long-form projection of contracts and atas payloads.
+
+Blocking work:
+
+- Confirm whether per-item rows are exposed in the public PNCP
+  endpoints, or only via the per-contract detail endpoint. If the
+  latter, this phase requires a per-key fan-out fetcher (one extra
+  request per contract), with rate-limit budgeting.
+- Define the canonical price-intelligence schema (CATMAT/CATSER code,
+  unit, unit price, quantity, agency, supplier, date).
+
+## Phase 4 — Cross-resource joins and analytics
+
+Goal: surface PCA → publicações → atas → contratos → itens journeys
+inside the explorer and as named DuckDB views. Examples:
+
+- "Did this agency contract what its PCA promised?"  
+  (PCA `objeto` ↔ contratos `objeto_contrato` joined on
+  `cnpj_orgao` and time window.)
+- "Open opportunities for an object that has historical price evidence."
+  (publicações × itens.)
+- "Atas vigentes whose underlying compra is now contratada."
+  (atas × contratos via `numero_controle_pncp_compra`.)
+
+Blocking work:
+
+- Define the join keys formally as a small DAG in `transforms.py` so
+  the frontend can list available cross-resource queries without
+  hard-coding SQL.
+- Add an explorer "Atlas" sidebar that lists tables grouped by their
+  resource layer (intent → open → reusable → final → comparable).
+
+## Out of scope for this roadmap
+
+- Real-time tender tracking (still a non-goal in `VISION.md`).
+- Per-user webhooks / email alerts (still requires a server).
+- A separate canonical resource per modalidade.

--- a/src/baliza/resources/__init__.py
+++ b/src/baliza/resources/__init__.py
@@ -1,5 +1,7 @@
 from .atas import ATAS
 from .contratos import CONTRATOS
+from .pca import PCA
+from .publicacoes import PUBLICACOES
 from .specs import (
     CanonicalTableSpec,
     EntitySpec,
@@ -15,6 +17,22 @@ from .specs import (
 RESOURCES: dict[str, PNCPResource] = {
     CONTRATOS.name: CONTRATOS,
     ATAS.name: ATAS,
+}
+
+# Resources that have been declared in code with their fetch/canonical
+# shape but are intentionally NOT yet part of ``RESOURCES`` because they
+# still carry TODO markers (modalidade fan-out for publicações; annual
+# partitioning + flatten for PCA). They live here so:
+#
+#   * tests can assert their shape today (filename safety, name regex,
+#     non-collision with the active registry);
+#   * the frontend resource catalog can list them as "planejado" without
+#     the backend pipeline trying to ingest them;
+#   * promoting one to ``RESOURCES`` is a single-line move plus the
+#     missing TODOs being closed in their respective modules.
+PLANNED_RESOURCES: dict[str, PNCPResource] = {
+    PUBLICACOES.name: PUBLICACOES,
+    PCA.name: PCA,
 }
 
 
@@ -63,7 +81,10 @@ __all__ = [
     "CanonicalTableSpec",
     "CONTRATOS",
     "ATAS",
+    "PUBLICACOES",
+    "PCA",
     "RESOURCES",
+    "PLANNED_RESOURCES",
     "get_resource",
     "page_filename",
     "first_page_filename",

--- a/src/baliza/resources/pca.py
+++ b/src/baliza/resources/pca.py
@@ -1,0 +1,82 @@
+"""Plano Anual de Contratações (PNCP /v1/pca/...).
+
+Status: PLANNED, not yet wired into the active ``RESOURCES`` registry.
+
+PCA is the upstream-most layer of the Baliza resource atlas: it
+expresses *intended* future procurement, before any opportunity is
+opened. Cross-joining PCA with publicações and contratos is what lets
+Baliza answer "did this agency actually buy what it said it would?".
+
+Known gaps before this can be promoted to ``RESOURCES``:
+
+* TODO(pncp-pca-endpoint): the API exposes a family of endpoints under
+  ``/v1/pca/`` (atualizacao, usuario, etc.). The exact endpoint Baliza
+  should mirror as the canonical "PCA snapshot" is not decided yet.
+* TODO(pncp-pca-partitioning): PCA is naturally partitioned by
+  ``anoPca`` (annual), not monthly. Promoting PCA requires either
+  extending ``RawDatasetSpec.partition_strategy`` plumbing in the
+  mirror/uploader (currently month-only) or generating one synthetic
+  monthly partition per year.
+* TODO(pncp-pca-flatten): PCA payloads are nested (item-level rows
+  under each plan). The canonical model is item-level, so the flatten
+  function emits one row per ``PlanoContratacaoItemDTO`` enriched with
+  the parent ``PlanoContratacaoComItensDoUsuarioDTO`` fields.
+* TODO(pncp-pca-pk): item-level PK is composite — provisional choice
+  ``(id_pca_pncp, numero_item)`` pending verification.
+"""
+
+from __future__ import annotations
+
+from ..models import PlanoContratacaoComItensDoUsuarioDTO
+from .specs import (
+    CanonicalTableSpec,
+    EntitySpec,
+    FetchSpec,
+    PNCPResource,
+    RawDatasetSpec,
+)
+
+
+def _annual_zip_filename(part_str: str) -> str:
+    # part_str is YYYY for annual partitions. The mirror plumbing today
+    # passes YYYY-MM; promoting PCA must teach it to pass YYYY.
+    return f"pca_{part_str}.zip"
+
+
+PCA = PNCPResource(
+    resource_name="pca",
+    fetch=FetchSpec(
+        # TODO(pncp-pca-endpoint): provisional; verify before wiring.
+        endpoint="pca/atualizacao",
+        pagination_param="pagina",
+        page_size_param="tamanhoPagina",
+        max_page_size=500,
+        # PCA uses dataInicio/dataFim, not dataInicial/dataFinal.
+        date_param_start="dataInicio",
+        date_param_end="dataFim",
+        response_data_key="data",
+    ),
+    raw_dataset=RawDatasetSpec(
+        ia_item_id="baliza-pncp-raw",
+        filename_fn=_annual_zip_filename,
+        partition_strategy="annual",
+        retention_policy="all",
+    ),
+    entities=[
+        EntitySpec(name="pca_plan"),
+        EntitySpec(name="pca_item"),
+    ],
+    canonical_tables=[
+        CanonicalTableSpec(
+            table_name="pca_itens",
+            schema_version="0.1.0",
+            pk=["id_pca_pncp", "numero_item"],
+            flatten_fn=None,  # TODO(pncp-pca-flatten): see module docstring.
+            dedup_strategy="current_state",
+            source_entity="pca_item",
+            sort_columns=["orgao_entidade_cnpj", "ano_pca"],
+            bloom_filter_columns=["orgao_entidade_cnpj"],
+        )
+    ],
+    entity_model=PlanoContratacaoComItensDoUsuarioDTO,
+)

--- a/src/baliza/resources/publicacoes.py
+++ b/src/baliza/resources/publicacoes.py
@@ -1,0 +1,101 @@
+"""Publicações de contratações (PNCP /v1/contratacoes/publicacao).
+
+Status: PLANNED, not yet wired into the active ``RESOURCES`` registry.
+
+This module defines the resource shape we intend to register once the
+remaining facts below are verified against the official PNCP API and
+covered by tests. Keeping the spec here (instead of in a design doc)
+means promotion to a registered resource is a single-line change in
+``resources/__init__.py`` and forces every gap to be a code-visible TODO
+rather than prose.
+
+Why publicações is the next strategic resource:
+
+* It captures *current opportunity* — what is open right now — which is
+  the missing temporal layer between PCA (intended demand) and contratos
+  (finalized facts). The B2G-supplier and public-buyer journeys both
+  depend on it.
+
+Known gaps before this can be promoted to ``RESOURCES``:
+
+* TODO(pncp-publicacao-modalidade): the ``/v1/contratacoes/publicacao``
+  endpoint requires the ``codigoModalidadeContratacao`` query parameter
+  (see ``debug_api.py``). Our current ``FetchSpec`` has no fan-out
+  primitive; promoting publicações requires either (a) extending
+  FetchSpec with an iterable ``required_params`` field and teaching the
+  extractor to fan out, or (b) registering one resource per modalidade.
+  Decision deferred.
+* TODO(pncp-publicacao-flatten): no ``_flatten_publicacao`` exists in
+  ``transforms.py``. The Pydantic model ``RecuperarCompraPublicacaoDTO``
+  is already generated from the OpenAPI spec and can be the basis for a
+  flatten function once the canonical column list is agreed.
+* TODO(pncp-publicacao-pk): the natural primary key is
+  ``numeroControlePNCP``, but we should verify that it is unique within
+  a single fetched window before committing to ``current_state`` dedup.
+* TODO(pncp-publicacao-data-start): confirm the earliest date PNCP
+  exposes ``contratacoes/publicacao`` records for. Until then we leave
+  ``data_start`` unset so backfills do not silently clamp to a wrong
+  floor.
+"""
+
+from __future__ import annotations
+
+from ..models import RecuperarCompraPublicacaoDTO
+from .specs import (
+    CanonicalTableSpec,
+    EntitySpec,
+    FetchSpec,
+    PNCPResource,
+    RawDatasetSpec,
+)
+
+
+def _monthly_zip_filename(part_str: str) -> str:
+    return f"publicacoes_{part_str}.zip"
+
+
+PUBLICACOES = PNCPResource(
+    resource_name="publicacoes",
+    fetch=FetchSpec(
+        # Verified against debug_api.py: PNCP exposes this as
+        # /v1/contratacoes/publicacao. The base URL in extractor.py
+        # already includes /v1, so the endpoint is the suffix.
+        endpoint="contratacoes/publicacao",
+        pagination_param="pagina",
+        page_size_param="tamanhoPagina",
+        # TODO(pncp-publicacao-page-size): confirm the documented max.
+        # Using 50 as a conservative default mirroring the contratos
+        # original until verified — do NOT raise without testing.
+        max_page_size=50,
+        date_param_start="dataInicial",
+        date_param_end="dataFinal",
+        response_data_key="data",
+    ),
+    raw_dataset=RawDatasetSpec(
+        ia_item_id="baliza-pncp-raw",
+        filename_fn=_monthly_zip_filename,
+        partition_strategy="monthly",
+        retention_policy="all",
+    ),
+    entities=[
+        EntitySpec(name="publicacao"),
+    ],
+    canonical_tables=[
+        CanonicalTableSpec(
+            table_name="publicacoes",
+            schema_version="0.1.0",
+            # TODO(pncp-publicacao-pk): see module docstring.
+            pk="numero_controle_pncp",
+            # TODO(pncp-publicacao-flatten): see module docstring.
+            flatten_fn=None,
+            dedup_strategy="current_state",
+            source_entity="publicacao",
+            sort_columns=["cnpj_orgao", "data_publicacao_pncp"],
+            bloom_filter_columns=["cnpj_orgao"],
+        )
+    ],
+    entity_model=RecuperarCompraPublicacaoDTO,
+    # data_start intentionally omitted until verified against the API.
+    # clamp_to_known_data_start_month tolerates this and returns the
+    # caller-provided start unchanged.
+)

--- a/tests/unit/test_resource_atlas.py
+++ b/tests/unit/test_resource_atlas.py
@@ -1,0 +1,131 @@
+"""Tests for the PNCP Resource Atlas: registered + planned resources.
+
+These tests pin down the architectural contract documented in
+``web/features/pncp-resource-atlas.feature``. They protect:
+
+* the registered resources keep their established names, schema versions
+  and raw filename shapes (regression for contratos / atas);
+* the planned resources (publicações, PCA) are declared with the same
+  spec shape as registered ones, so promotion is mechanical;
+* raw ZIP filenames cannot collide across resources for the same
+  monthly partition.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from baliza.resources import (
+    ATAS,
+    CONTRATOS,
+    PCA,
+    PLANNED_RESOURCES,
+    PUBLICACOES,
+    RESOURCES,
+    PNCPResource,
+    first_page_filename,
+    get_resource,
+    page_filename,
+    raw_zip_filename,
+)
+
+
+def test_registered_resources_are_contratos_and_atas():
+    assert set(RESOURCES) == {"contratos", "atas"}
+
+
+def test_planned_resources_are_publicacoes_and_pca():
+    assert set(PLANNED_RESOURCES) == {"publicacoes", "pca"}
+
+
+def test_planned_resources_do_not_overlap_with_registered():
+    assert set(RESOURCES).isdisjoint(set(PLANNED_RESOURCES))
+
+
+@pytest.mark.parametrize(
+    "resource",
+    [CONTRATOS, ATAS, PUBLICACOES, PCA],
+    ids=lambda r: r.name,
+)
+def test_resource_shape_is_complete(resource: PNCPResource) -> None:
+    # Endpoint / pagination / date-range params are present.
+    assert resource.fetch.endpoint
+    assert resource.fetch.pagination_param
+    assert resource.fetch.page_size_param
+    assert resource.fetch.date_param_start
+    assert resource.fetch.date_param_end
+    assert resource.fetch.response_data_key
+
+    # Raw dataset.
+    assert resource.raw_dataset.ia_item_id
+    assert callable(resource.raw_dataset.filename_fn)
+    assert resource.raw_dataset.partition_strategy in {"monthly", "annual", "weekly"}
+
+    # At least one canonical table with PK + schema_version.
+    assert resource.canonical_tables
+    for ct in resource.canonical_tables:
+        assert ct.table_name
+        assert ct.schema_version
+        assert ct.pk
+
+    # Pydantic entity model (validation seam).
+    assert resource.entity_model is not None
+
+
+def test_contratos_keeps_legacy_raw_zip_shape():
+    # Regression: existing IA items must not need renaming.
+    assert raw_zip_filename(CONTRATOS.name, "2024-01") == "raw-2024-01.zip"
+
+
+def test_non_contratos_resources_have_prefixed_raw_zip():
+    assert raw_zip_filename(ATAS.name, "2024-01") == "raw-atas-2024-01.zip"
+    assert (
+        raw_zip_filename(PUBLICACOES.name, "2024-01")
+        == "raw-publicacoes-2024-01.zip"
+    )
+    assert raw_zip_filename(PCA.name, "2024") == "raw-pca-2024.zip"
+
+
+def test_raw_zip_filenames_do_not_collide_across_resources():
+    month = "2024-01"
+    names = {
+        raw_zip_filename(r.name, month)
+        for r in (CONTRATOS, ATAS, PUBLICACOES, PCA)
+    }
+    assert len(names) == 4
+
+
+def test_per_page_filenames_are_resource_scoped():
+    assert page_filename("publicacoes", 3) == "publicacoes_p3.json"
+    assert first_page_filename("pca") == "pca_p1.json"
+    # Contratos and a planned resource never produce the same page filename.
+    assert page_filename("contratos", 1) != page_filename("publicacoes", 1)
+
+
+def test_get_resource_only_returns_registered_resources():
+    assert get_resource("contratos") is CONTRATOS
+    assert get_resource("atas") is ATAS
+    # Planned resources are intentionally not addressable through the
+    # active registry until their TODOs are closed — protects the
+    # extractor and mirror from being invoked on an unfinished spec.
+    with pytest.raises(ValueError, match="unknown resource"):
+        get_resource("publicacoes")
+    with pytest.raises(ValueError, match="unknown resource"):
+        get_resource("pca")
+
+
+def test_publicacoes_endpoint_is_contratacoes_publicacao():
+    # Verified against debug_api.py probes.
+    assert PUBLICACOES.fetch.endpoint == "contratacoes/publicacao"
+
+
+def test_pca_uses_inicio_fim_date_params():
+    # PCA uses dataInicio/dataFim, contratos uses dataInicial/dataFinal.
+    assert PCA.fetch.date_param_start == "dataInicio"
+    assert PCA.fetch.date_param_end == "dataFim"
+
+
+def test_pca_canonical_table_uses_composite_pk():
+    ct = PCA.canonical_tables[0]
+    assert isinstance(ct.pk, list)
+    assert ct.pk == ["id_pca_pncp", "numero_item"]

--- a/web/features/pncp-resource-atlas.feature
+++ b/web/features/pncp-resource-atlas.feature
@@ -1,0 +1,90 @@
+@journey5 @journey6 @planned
+Feature: PNCP Resource Atlas
+  Baliza is evolving from a contratos-centered browser into a temporal
+  procurement intelligence system that mirrors several first-class PNCP
+  resources. This feature documents the architectural contract that every
+  PNCP resource — registered today or planned — must satisfy so that the
+  pipeline, the archive layer and the frontend can discover them
+  generically.
+
+  The conceptual spine is:
+
+    PCA          -> intended demand / future procurement
+    Publicações  -> current opportunity / what is open now
+    Atas         -> reusable purchasing instruments
+    Contratos    -> finalized legal/economic facts
+    Itens        -> item-level comparability and price intelligence
+
+  The "Atlas" is the union of every registered resource plus every planned
+  resource that has been declared in code with documented gaps. Promotion
+  from planned to registered is what these scenarios protect.
+
+  Background:
+    Given the PNCP resource registry exposed by `src/baliza/resources/`
+
+  Scenario: A registered PNCP resource declares a complete contract
+    Given a resource registered in `RESOURCES`
+    Then it declares an endpoint path under PNCP `/v1`
+    And it declares a pagination parameter and page size parameter
+    And it declares a date-range start parameter and end parameter
+    And it declares a raw filename strategy that does not collide with other resources
+    And it declares at least one canonical table with a schema_version and a primary key
+    And it declares the first date on which PNCP exposed source data, or explicitly leaves it open
+
+  Scenario: Contratos is the reference resource
+    When I look up "contratos" in the registry
+    Then the canonical table name is "contratos"
+    And the schema_version is "2.0.0"
+    And the primary key is "numero_controle_pncp"
+    And the raw monthly ZIP filename keeps the legacy `raw-{YYYY-MM}.zip` shape
+      so existing Internet Archive items do not need to be renamed
+
+  Scenario: Atas is a registered resource alongside contratos
+    When I look up "atas" in the registry
+    Then the canonical table name is "atas"
+    And the primary key is "numero_controle_pncp_ata"
+    And the raw monthly ZIP filename is `raw-atas-{YYYY-MM}.zip`
+      so it cannot collide with the contratos ZIP for the same partition
+
+  Scenario: Publicações is declared as a first-class planned resource
+    When I look up "publicacoes" in the planned resource atlas
+    Then it declares the PNCP endpoint `/v1/contratacoes/publicacao`
+    And it links to the existing Pydantic model `RecuperarCompraPublicacaoDTO`
+    And it documents that the endpoint requires fan-out by `codigoModalidadeContratacao`
+    And it carries TODO markers naming the missing facts that block ingestion
+      (modalidade fan-out strategy, canonical column list, primary key choice)
+
+  Scenario: PCA is declared as a documented future resource
+    When I look up "pca" in the planned resource atlas
+    Then it declares the PNCP endpoint family under `/v1/pca`
+    And it links to the existing Pydantic model `PlanoContratacaoComItensDoUsuarioDTO`
+    And it documents that PCA partitioning is annual, not monthly
+    And it carries TODO markers for the canonical flatten function and PK
+
+  Scenario: Frontend discovers archive resources from manifest metadata
+    Given the IA manifest exposes a `table_name` column per row
+    When the frontend lists archive tables
+    Then every distinct `table_name` value is recognized as an `ArchivedTable`
+    And every `ArchivedTable` has a human-readable label and short description
+    And the label set covers at minimum: contratos, atas
+
+  Scenario: A resource that is registered but has no partitions yet
+    Given a resource registered in `RESOURCES`
+    And the IA manifest has no rows whose `table_name` equals that resource
+    When the frontend asks for that resource's latest partition
+    Then it returns an empty result without raising
+    And the explorer renders an empty-state explaining "ainda sem partições publicadas"
+
+  Scenario: Adding a new resource is a single-file change
+    Given a developer wants to register a new PNCP resource
+    When they create `src/baliza/resources/<name>.py` and add an entry to `RESOURCES`
+    Then no other backend module needs to be edited for the resource to be
+      addressable from the CLI via `--resource <name>`
+    And the only additional editing required to surface the resource in the
+      frontend is to add a label/description in `web/src/lib/resourceCatalog.ts`
+
+  Scenario: Resource names are filesystem- and SQL-safe
+    Given any resource name accepted by `PNCPResource.__post_init__`
+    Then the name matches `^[a-zA-Z0-9_]+$`
+    And the name can be safely interpolated into raw paths, ZIP filenames,
+      URL params and DuckDB identifiers without further escaping

--- a/web/src/lib/resourceCatalog.test.ts
+++ b/web/src/lib/resourceCatalog.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RESOURCE_CATALOG,
+  REGISTERED_RESOURCE_NAMES,
+  getResourceEntry,
+} from './resourceCatalog';
+
+describe('resourceCatalog', () => {
+  it('covers the conceptual spine PCA → Publicações → Atas → Contratos → Itens', () => {
+    expect(RESOURCE_CATALOG.map((r) => r.name)).toEqual([
+      'pca',
+      'publicacoes',
+      'atas',
+      'contratos',
+      'itens',
+    ]);
+  });
+
+  it('marks contratos and atas as registered today', () => {
+    expect(REGISTERED_RESOURCE_NAMES.has('contratos')).toBe(true);
+    expect(REGISTERED_RESOURCE_NAMES.has('atas')).toBe(true);
+  });
+
+  it('marks publicacoes, pca and itens as planned (not yet queryable)', () => {
+    for (const name of ['publicacoes', 'pca', 'itens']) {
+      expect(REGISTERED_RESOURCE_NAMES.has(name)).toBe(false);
+      expect(getResourceEntry(name)?.status).toBe('planned');
+    }
+  });
+
+  it('exposes a label and a description for every entry', () => {
+    for (const r of RESOURCE_CATALOG) {
+      expect(r.label.length).toBeGreaterThan(0);
+      expect(r.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns undefined for an unknown resource name', () => {
+    expect(getResourceEntry('not-a-resource')).toBeUndefined();
+  });
+});

--- a/web/src/lib/resourceCatalog.ts
+++ b/web/src/lib/resourceCatalog.ts
@@ -1,0 +1,91 @@
+// PNCP Resource Atlas — frontend-side catalog.
+//
+// This is the web layer's mirror of the backend resource registry in
+// `src/baliza/resources/__init__.py`. It exists so the UI can render
+// the conceptual spine PCA → Publicações → Atas → Contratos → Itens
+// generically, without hard-coding `contratos` everywhere a resource
+// label is needed.
+//
+// "registered" entries here MUST correspond to a resource in the backend
+// `RESOURCES` dict (i.e. one that produces parquet files on Internet
+// Archive). "planned" entries correspond to `PLANNED_RESOURCES` and are
+// shown to the user as upcoming, never as queryable.
+//
+// Adding a new resource is a single edit here, on the frontend side.
+// The architectural contract is documented in
+// `web/features/pncp-resource-atlas.feature`.
+
+export type ResourceLayer =
+  | 'intent'
+  | 'open'
+  | 'reusable'
+  | 'final'
+  | 'comparable';
+
+export type ResourceStatus = 'registered' | 'planned';
+
+export interface ResourceCatalogEntry {
+  /** Backend resource_name; matches `PNCPResource.resource_name`. */
+  name: string;
+  /** Display label, Portuguese. */
+  label: string;
+  /** One-sentence description in plain language. */
+  description: string;
+  /** Conceptual layer in the resource atlas. */
+  layer: ResourceLayer;
+  /** Whether the backend pipeline already mirrors this resource. */
+  status: ResourceStatus;
+}
+
+export const RESOURCE_CATALOG: readonly ResourceCatalogEntry[] = [
+  {
+    name: 'pca',
+    label: 'PCA',
+    description:
+      'Plano Anual de Contratações: o que cada órgão pretende comprar.',
+    layer: 'intent',
+    status: 'planned',
+  },
+  {
+    name: 'publicacoes',
+    label: 'Publicações',
+    description:
+      'Contratações abertas no momento — oportunidades em curso no PNCP.',
+    layer: 'open',
+    status: 'planned',
+  },
+  {
+    name: 'atas',
+    label: 'Atas de Registro de Preços',
+    description:
+      'Atas vigentes que outros órgãos podem usar como referência ou carona.',
+    layer: 'reusable',
+    status: 'registered',
+  },
+  {
+    name: 'contratos',
+    label: 'Contratos',
+    description:
+      'Contratos celebrados — fato jurídico e econômico finalizado.',
+    layer: 'final',
+    status: 'registered',
+  },
+  {
+    name: 'itens',
+    label: 'Itens',
+    description:
+      'Linhas de item por contrato/ata, base para inteligência de preços.',
+    layer: 'comparable',
+    status: 'planned',
+  },
+] as const;
+
+export const REGISTERED_RESOURCE_NAMES: ReadonlySet<string> = new Set(
+  RESOURCE_CATALOG.filter((r) => r.status === 'registered').map((r) => r.name),
+);
+
+export function getResourceEntry(
+  name: string,
+): ResourceCatalogEntry | undefined {
+  return RESOURCE_CATALOG.find((r) => r.name === name);
+}


### PR DESCRIPTION
## Summary

Document and begin implementing the **PNCP Resource Atlas**: Baliza's
evolution from a contratos-centered browser into a multi-resource PNCP
archive whose conceptual spine is

`PCA → Publicações → Atas → Contratos → Itens`.

The active pipeline is unchanged. `RESOURCES` still contains only
`contratos` and `atas`. New resources are declared in a sibling
`PLANNED_RESOURCES` registry with verified fetch metadata, linked
Pydantic models (already generated from the PNCP OpenAPI spec) and
explicit code-visible TODOs naming the facts that block promotion.

## What's in this PR

**Backend**
- `src/baliza/resources/publicacoes.py` — declares `PUBLICACOES`
  pointing at `/v1/contratacoes/publicacao` (verified via
  `debug_api.py`) and `RecuperarCompraPublicacaoDTO`. TODOs cover the
  `codigoModalidadeContratacao` fan-out, flatten function, PK
  verification, and `data_start`.
- `src/baliza/resources/pca.py` — declares `PCA` with
  `PlanoContratacaoComItensDoUsuarioDTO`, `dataInicio`/`dataFim` date
  params and `partition_strategy="annual"`. TODOs cover endpoint choice,
  annual partitioning plumbing in mirror/uploader, the item-level
  flatten and the composite PK.
- `src/baliza/resources/__init__.py` — exposes both as
  `PLANNED_RESOURCES`. `get_resource()` still rejects them so the
  extractor and mirror cannot accidentally try to ingest an unfinished
  spec.
- `tests/unit/test_resource_atlas.py` — pins down the registered set,
  the planned set, raw filename non-collision (incl. contratos's legacy
  `raw-{YYYY-MM}.zip` shape), and that planned resources are not
  addressable through `get_resource`.

**Docs / specs**
- `web/features/pncp-resource-atlas.feature` — Gherkin contract for any
  resource: endpoint, pagination, dates, raw filename strategy,
  canonical table + schema_version + PK; scenarios for publicações and
  PCA being declared as planned, frontend discovery from the manifest,
  empty-partition graceful behavior, and single-file-change extension.
- `VISION.md` — new "PNCP Resource Atlas" section with the spine table.
- `docs/plans/resource-atlas-roadmap.md` — Phase 1 (publicações) →
  Phase 2 (PCA) → Phase 3 (item-level) → Phase 4 (cross-resource
  joins).
- `README.md` — links to the atlas feature, vision section and roadmap.

**Frontend**
- `web/src/lib/resourceCatalog.ts` + test — typed catalog of resources
  with layer (`intent | open | reusable | final | comparable`), label,
  description and `registered | planned` status. No new component, no
  Tailwind, no scoped `<style>`.

## What is intentionally deferred

- No code attempts to ingest publicações or PCA. The TODOs in those
  modules are the gating list.
- The mirror/uploader still assumes monthly partitions; PCA's annual
  strategy is documented but not yet plumbed.
- No item-level resource module yet; Phase 3 of the roadmap.
- The frontend catalog is not yet wired into a UI surface; this PR only
  introduces the data so a follow-up can render it without further
  schema work.

## Test plan

- [x] `uv run pytest --ignore=tests/integration` — 116 passed
  (integration suite needs `vcr`, not installed in this sandbox)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `npm run lint` (web) — clean (one pre-existing warning in
  `Icon.svelte`, unrelated)
- [x] `npm run check:full` (web) — 0 errors, 0 warnings (13
  pre-existing hints in unrelated files)
- [x] `npm test` (web) — 628 passed / 7 skipped (33 files)

## Risks / assumptions

- The publicações endpoint path was validated against `debug_api.py`,
  not against a live API call from CI. Ingestion is not enabled, so the
  worst case if the path drifted is a TODO needing update before
  promotion — no runtime impact today.
- `PUBLICACOES.fetch.max_page_size = 50` is conservative pending
  verification.
- `PCA.fetch.endpoint = "pca/atualizacao"` is provisional and flagged
  as such in a TODO; the canonical PCA endpoint choice is part of
  Phase 2.

## Next recommended step

Begin Phase 1 of the roadmap: extend `FetchSpec` with an optional
`required_params` fan-out primitive, implement `_flatten_publicacao`
against `RecuperarCompraPublicacaoDTO`, and move `PUBLICACOES` from
`PLANNED_RESOURCES` to `RESOURCES` once a characterization test for one
mirrored month passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017xuTaTcrzwkYSZo1WAibB2)_