### PR TITLE
refactor(consolidator): per-resource dispatch + skip UF shards for atas

### DIFF
--- a/src/baliza/cli_simple.py
+++ b/src/baliza/cli_simple.py
@@ -507,6 +507,7 @@ def sync(  # noqa: PLR0913, PLR0915, PLR0912
                     ia_access_key,
                     ia_secret_key,
                     manifest=raw_manifest if raw_manifest else None,
+                    resource=resource,
                 )
             consolidated = True
         except Exception as e:
@@ -977,9 +978,13 @@ def verify(
 def consolidate_cmd(
     start_year: int = typer.Option(2021, "--start-year"),
     force: bool = typer.Option(False, "--force"),
+    resource: str = typer.Option(
+        RESOURCE_CONTRATOS, "--resource", "-r", help="PNCP resource to consolidate"
+    ),
 ) -> None:
     """Annual consolidation of daily Parquet files (Stateless)."""
     try:
+        _validate_resource(resource)
         ia_access_key = os.environ.get("IA_ACCESS_KEY")
         ia_secret_key = os.environ.get("IA_SECRET_KEY")
         if not ia_access_key or not ia_secret_key:
@@ -987,7 +992,9 @@ def consolidate_cmd(
             raise typer.Exit(1)
 
         consolidator = IAConsolidator()
-        consolidator.consolidate_all(start_year, ia_access_key, ia_secret_key, force=force)
+        consolidator.consolidate_all(
+            start_year, ia_access_key, ia_secret_key, force=force, resource=resource
+        )
     except Exception as e:
         console.print(f"[red]✗ Consolidation failed: {e}")
         raise typer.Exit(1) from e

--- a/src/baliza/consolidator.py
+++ b/src/baliza/consolidator.py
@@ -19,7 +19,7 @@ import internetarchive as ia
 from rich.console import Console
 
 from .ia_uploader import read_manifest_from_ia, register_monthly_uf_shards
-from .resources import CONTRATOS
+from .resources import CONTRATOS, get_resource
 from .utils import DUCKDB_PARQUET_COPY_OPTIONS
 
 CONSOLIDATED_IA_ITEM = "baliza-pncp-consolidated"
@@ -39,8 +39,15 @@ def _is_frozen(year: int) -> bool:
     return datetime.date.today() >= freeze_date
 
 
-def _consolidated_file_name(year: int) -> str:
-    return f"contratos-{year}.parquet"
+def _consolidated_file_name(year: int, *, resource: str = CONTRATOS.name) -> str:
+    """Annual consolidated parquet basename — `{canonical_table}-{year}.parquet`.
+
+    Drives off the resource's CanonicalTableSpec so atas / future
+    resources get their own file alongside contratos in the same
+    `baliza-pncp-consolidated` IA item.
+    """
+    table_name = get_resource(resource).canonical_tables[0].table_name
+    return f"{table_name}-{year}.parquet"
 
 
 def _requires_httpfs(paths_or_urls: list[str]) -> bool:
@@ -58,19 +65,27 @@ def _parse_iso_mtime(value: str) -> datetime.datetime | None:
         return None
 
 
-def _current_year_is_fresh(manifest: list[dict], year: int) -> bool:
+def _current_year_is_fresh(
+    manifest: list[dict], year: int, *, resource: str = CONTRATOS.name
+) -> bool:
     """True when the current year's consolidated shards are at-or-after every monthly canonical upload.
 
     Uses the manifest as a single source of truth: consolidation writes
     ``monthly_uf`` shard rows after a successful IA upload, so the newest
     shard timestamp bounds the last successful consolidation. If a monthly
     canonical upload is newer, current-year consolidation is stale.
+
+    Resources whose canonical table doesn't carry ``uf_sigla`` (e.g. atas)
+    skip the per-UF sharding step entirely — for them, freshness is "the
+    annual consolidated row is at-or-after every monthly canonical upload"
+    instead of comparing canonical to shards. We still gate via the manifest
+    by treating the absence of new canonical uploads as fresh.
     """
     year_str = str(year)
     canonical_mtimes: list[datetime.datetime] = []
     shard_mtimes: list[datetime.datetime] = []
     for row in manifest:
-        if row.get("table_name") != CONTRATOS.name:
+        if row.get("table_name") != resource:
             continue
         part = row.get("data_particao") or ""
         if not part.startswith(year_str):
@@ -86,9 +101,30 @@ def _current_year_is_fresh(manifest: list[dict], year: int) -> bool:
             shard_mtimes.append(parsed)
     if not canonical_mtimes:
         return True  # nothing to consolidate yet
+
+    # Resources without UF sharding don't write monthly_uf rows; their
+    # freshness gate falls back to "any new monthly canonical means rebuild".
+    # Conservatively treat them as stale whenever a canonical upload exists
+    # — the consolidator's own no-op short-circuit handles repeated calls.
+    if not _resource_has_uf_shards(resource):
+        return False
+
     if not shard_mtimes:
         return False  # canonical months exist but no shards → needs first build
     return max(shard_mtimes) >= max(canonical_mtimes)
+
+
+def _resource_has_uf_shards(resource: str) -> bool:
+    """A resource gets per-UF shards if its canonical schema carries uf_sigla.
+
+    Detected by looking for ``uf_sigla`` in the resource's bloom-filter or
+    sort columns — both are populated only when the column is queried. Atas
+    has neither (no UF info in the API response), so it skips the shard step.
+    """
+    spec = get_resource(resource)
+    table_spec = spec.canonical_tables[0]
+    columns = set(table_spec.bloom_filter_columns) | set(table_spec.sort_columns)
+    return "uf_sigla" in columns
 
 
 class IAConsolidator:
@@ -108,11 +144,19 @@ class IAConsolidator:
         """
         return read_manifest_from_ia()
 
-    def _get_daily_urls_for_year(self, year: int, manifest: list[dict] | None = None) -> list[str]:
-        """Read the manifest.csv on IA and get all daily contratos file URLs for the year.
+    def _get_daily_urls_for_year(
+        self,
+        year: int,
+        manifest: list[dict] | None = None,
+        *,
+        resource: str = CONTRATOS.name,
+    ) -> list[str]:
+        """Read the manifest.csv on IA and get all daily file URLs for ``resource`` in ``year``.
 
         Propagates ``ManifestReadError`` on transient failures so we never
-        silently consolidate from a partial view of the manifest.
+        silently consolidate from a partial view of the manifest. Filters
+        by ``table_name == resource`` so atas rows don't feed contratos
+        consolidation (and vice versa).
         """
         rows = manifest if manifest is not None else self._read_manifest()
         urls = []
@@ -124,7 +168,7 @@ class IAConsolidator:
             file_type = row.get("file_type", "")
             if (
                 (row.get("data_particao") or "").startswith(year_str)
-                and row.get("table_name") == CONTRATOS.name
+                and row.get("table_name") == resource
                 and file_type in ("", "monthly_canonical")
             ):
                 url = row.get("parquet_url") or row.get("file_url")
@@ -132,35 +176,48 @@ class IAConsolidator:
                     urls.append(url)
         return urls
 
-    def _check_consolidated_exists_on_ia(self, year: int) -> bool:
+    def _check_consolidated_exists_on_ia(
+        self, year: int, *, resource: str = CONTRATOS.name
+    ) -> bool:
         """Check if the consolidated annual file already exists in the IA item."""
-        filename = _consolidated_file_name(year)
+        filename = _consolidated_file_name(year, resource=resource)
         try:
             item = ia.get_item(CONSOLIDATED_IA_ITEM)
             return any(f.get("name") == filename for f in item.files)
         except Exception:
             return False
 
-    def consolidate_year(  # noqa: PLR0912
+    def consolidate_year(  # noqa: PLR0912, PLR0913
         self,
         year: int,
         ia_access_key: str,
         ia_secret_key: str,
         force: bool = False,
         manifest: list[dict] | None = None,
+        *,
+        resource: str = CONTRATOS.name,
     ) -> bool:
-        """Build and upload annual consolidated Parquet for the given year.
+        """Build and upload annual consolidated Parquet for ``resource`` in ``year``.
 
         ``manifest`` is optional: when supplied, the current-year freshness
-        gate uses it in place of refetching manifest.csv.
+        gate uses it in place of refetching manifest.csv. ``resource`` routes
+        through the canonical table from the registry — atas / future
+        resources land their own ``{table_name}-{year}.parquet`` alongside
+        contratos in the same ``baliza-pncp-consolidated`` IA item.
         """
         frozen = _is_frozen(year)
-        filename = _consolidated_file_name(year)
+        filename = _consolidated_file_name(year, resource=resource)
+        spec = get_resource(resource)
+        table_spec = spec.canonical_tables[0]
+        order_by_sql = table_spec.order_by_sql or ", ".join(
+            list(table_spec.sort_columns)
+            + ([table_spec.pk] if isinstance(table_spec.pk, str) else list(table_spec.pk))
+        )
 
         if frozen and not force:
-            if self._check_consolidated_exists_on_ia(year):
+            if self._check_consolidated_exists_on_ia(year, resource=resource):
                 console.print(
-                    f"[dim]Skipping {year}: frozen year, consolidated file already on IA.[/dim]"
+                    f"[dim]Skipping {resource}/{year}: frozen year, consolidated file already on IA.[/dim]"
                 )
                 return False
 
@@ -176,21 +233,28 @@ class IAConsolidator:
         if not force and year == datetime.date.today().year:
             if shared_manifest is None:
                 shared_manifest = self._read_manifest()
-            if _current_year_is_fresh(shared_manifest, year):
-                console.print(f"[dim]Skipping {year}: consolidated shards are up to date.[/dim]")
+            if _current_year_is_fresh(shared_manifest, year, resource=resource):
+                console.print(
+                    f"[dim]Skipping {resource}/{year}: consolidated shards are up to date.[/dim]"
+                )
                 return False
 
-        console.print(f"[cyan]Consolidating {year}...[/cyan]")
+        console.print(f"[cyan]Consolidating {resource}/{year}...[/cyan]")
 
         # 1. Get daily file URLs from manifest.csv (the helper fetches on its
         #    own when no manifest is threaded through).
-        daily_urls = self._get_daily_urls_for_year(year, manifest=shared_manifest)
+        daily_urls = self._get_daily_urls_for_year(
+            year, manifest=shared_manifest, resource=resource
+        )
         if not daily_urls:
-            console.print(f"[yellow]No daily files found in manifest for {year}.[/yellow]")
+            console.print(
+                f"[yellow]No daily files found in manifest for {resource}/{year}.[/yellow]"
+            )
             return False
 
         console.print(f"  Found {len(daily_urls)} daily files.")
         is_current_year = year == datetime.date.today().year
+        wants_uf_shards = _resource_has_uf_shards(resource)
 
         # 2. Use DuckDB httpfs to stream+sort and write one consolidated Parquet
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -206,7 +270,7 @@ class IAConsolidator:
                         COPY (
                             SELECT *
                             FROM read_parquet([{url_list}])
-                            ORDER BY cnpj_orgao, data_publicacao DESC, numero_controle_pncp
+                            ORDER BY {order_by_sql}
                         ) TO '{output_path}'
                         ({DUCKDB_PARQUET_COPY_OPTIONS})
                     """)
@@ -226,9 +290,13 @@ class IAConsolidator:
                 files_to_upload = {filename: str(output_path)}
 
                 # 2a. Per-UF shards (current year only; past years stay single-file).
+                # Gated on the resource's canonical table actually carrying
+                # `uf_sigla` — atas etc. don't, so they ship as single annual files.
                 shards: list[dict] = []
-                if is_current_year:
-                    shards = self._build_per_uf_shards(con, output_path, year, Path(tmpdir))
+                if is_current_year and wants_uf_shards:
+                    shards = self._build_per_uf_shards(
+                        con, output_path, year, Path(tmpdir), resource=resource
+                    )
                     for s in shards:
                         files_to_upload[s["filename"]] = str(s["path"])
                     console.print(f"  Built {len(shards)} per-UF shards.")
@@ -264,7 +332,7 @@ class IAConsolidator:
                     ]
                     register_monthly_uf_shards(
                         year=year,
-                        table_name=CONTRATOS.name,
+                        table_name=table_spec.table_name,
                         shards=shard_rows,
                         access_key=ia_access_key,
                         secret_key=ia_secret_key,
@@ -272,12 +340,18 @@ class IAConsolidator:
 
                 # 4. Rebuild cumulative dimension files (current year only —
                 # captures latest rollups consumers need for detail pages).
-                if is_current_year:
+                # The aggregations use contratos-only columns
+                # (cnpj_orgao + valor_inicial + ni_fornecedor + …); other
+                # resources skip this step until per-resource dim shapes
+                # are defined.
+                if is_current_year and resource == CONTRATOS.name:
                     self._rebuild_dimensions(
                         con, output_path, Path(tmpdir), ia_access_key, ia_secret_key
                     )
 
-        console.print(f"[green]✓ {year} consolidated uploaded ({size_mb:.1f} MB).[/green]")
+        console.print(
+            f"[green]✓ {resource}/{year} consolidated uploaded ({size_mb:.1f} MB).[/green]"
+        )
         return True
 
     @staticmethod
@@ -295,16 +369,27 @@ class IAConsolidator:
         source_path: Path,
         year: int,
         tmp_root: Path,
+        *,
+        resource: str = CONTRATOS.name,
     ) -> list[dict]:
-        """Emit one contratos-YYYY-uf=XX.parquet per UF present in the file.
+        """Emit one ``{table}-YYYY-uf=XX.parquet`` per UF present in the file.
 
         Flat filenames (not Hive directories) so IA preserves them verbatim
         and the Journey 6 URL regex still matches the canonical file.
         Each shard is bloom-filtered + sorted like the canonical.
 
         Returns per-shard metadata (uf, path, row_count, sha256, file_size_bytes)
-        so callers can register shard rows in the manifest.
+        so callers can register shard rows in the manifest. Caller is
+        responsible for gating on ``_resource_has_uf_shards`` — this method
+        assumes the canonical schema carries ``uf_sigla``.
         """
+        spec = get_resource(resource)
+        table_spec = spec.canonical_tables[0]
+        table_name = table_spec.table_name
+        order_by_sql = table_spec.order_by_sql or ", ".join(
+            list(table_spec.sort_columns)
+            + ([table_spec.pk] if isinstance(table_spec.pk, str) else list(table_spec.pk))
+        )
         shard_dir = tmp_root / "shards"
         shard_dir.mkdir(exist_ok=True)
 
@@ -318,7 +403,7 @@ class IAConsolidator:
 
         shards: list[dict] = []
         for uf in ufs:
-            shard_name = f"contratos-{year}-uf={uf}.parquet"
+            shard_name = f"{table_name}-{year}-uf={uf}.parquet"
             shard_path = shard_dir / shard_name
             con.execute(
                 f"""
@@ -326,7 +411,7 @@ class IAConsolidator:
                     SELECT *
                     FROM read_parquet('{source_path}')
                     WHERE uf_sigla = ?
-                    ORDER BY cnpj_orgao, data_publicacao DESC, numero_controle_pncp
+                    ORDER BY {order_by_sql}
                 ) TO '{shard_path}'
                 ({DUCKDB_PARQUET_COPY_OPTIONS})
                 """,
@@ -440,15 +525,17 @@ class IAConsolidator:
         )
         console.print(f"  Rebuilt {len(files_to_upload)} cumulative dimension files.")
 
-    def consolidate_all(
+    def consolidate_all(  # noqa: PLR0913
         self,
         start_year: int,
         ia_access_key: str,
         ia_secret_key: str,
         force: bool = False,
         manifest: list[dict] | None = None,
+        *,
+        resource: str = CONTRATOS.name,
     ) -> dict[int, bool]:
-        """Consolidate from start_year through the current year.
+        """Consolidate ``resource`` from ``start_year`` through the current year.
 
         Reads the manifest once up-front (unless ``manifest`` is supplied)
         so the current-year freshness gate doesn't re-fetch per year.
@@ -463,5 +550,6 @@ class IAConsolidator:
                 ia_secret_key,
                 force=force,
                 manifest=shared_manifest,
+                resource=resource,
             )
         return results

--- a/src/baliza/consolidator.py
+++ b/src/baliza/consolidator.py
@@ -115,16 +115,15 @@ def _current_year_is_fresh(
 
 
 def _resource_has_uf_shards(resource: str) -> bool:
-    """A resource gets per-UF shards if its canonical schema carries uf_sigla.
+    """Whether the consolidator should emit per-UF monthly shards.
 
-    Detected by looking for ``uf_sigla`` in the resource's bloom-filter or
-    sort columns — both are populated only when the column is queried. Atas
-    has neither (no UF info in the API response), so it skips the shard step.
+    Reads the explicit ``CanonicalTableSpec.partition_by_uf`` flag —
+    inferring from sort/bloom column lists silently regressed contratos
+    (its canonical row carries ``uf_sigla`` even though the column isn't
+    in either list, so the heuristic returned False and skipped shard
+    publication; see Codex review on PR #555).
     """
-    spec = get_resource(resource)
-    table_spec = spec.canonical_tables[0]
-    columns = set(table_spec.bloom_filter_columns) | set(table_spec.sort_columns)
-    return "uf_sigla" in columns
+    return get_resource(resource).canonical_tables[0].partition_by_uf
 
 
 class IAConsolidator:

--- a/src/baliza/consolidator.py
+++ b/src/baliza/consolidator.py
@@ -187,7 +187,38 @@ class IAConsolidator:
         except Exception:
             return False
 
-    def consolidate_year(  # noqa: PLR0912, PLR0913
+    def _consolidated_mtime_on_ia(
+        self, year: int, *, resource: str = CONTRATOS.name
+    ) -> datetime.datetime | None:
+        """Return the upload time of the consolidated annual file on IA, or None.
+
+        IA exposes per-file ``mtime`` as a unix timestamp string. The
+        freshness gate for resources without UF shards uses this to
+        decide "did the file land after the newest monthly canonical
+        upload" without piling extra rows into the manifest.
+
+        Returns None when the file is missing OR present without a
+        usable mtime — callers must treat None as "can't decide
+        freshness from IA, fall back to a rebuild".
+        """
+        filename = _consolidated_file_name(year, resource=resource)
+        try:
+            item = ia.get_item(CONSOLIDATED_IA_ITEM)
+        except Exception:
+            return None
+        for f in item.files:
+            if f.get("name") != filename:
+                continue
+            mtime = f.get("mtime")
+            if not mtime:
+                return None
+            try:
+                return datetime.datetime.fromtimestamp(int(mtime), tz=datetime.UTC)
+            except (TypeError, ValueError):
+                return None
+        return None
+
+    def consolidate_year(  # noqa: PLR0912, PLR0913, PLR0915
         self,
         year: int,
         ia_access_key: str,
@@ -238,6 +269,33 @@ class IAConsolidator:
                     f"[dim]Skipping {resource}/{year}: consolidated shards are up to date.[/dim]"
                 )
                 return False
+            # Resources without per-UF shards (atas etc.) have no
+            # monthly_uf rows for the manifest gate to inspect, so the
+            # gate above is conservative — it returns False whenever any
+            # canonical month exists. Avoid the resulting daily rebuild
+            # storm by also checking the consolidated annual file's IA
+            # mtime: if it landed after the newest canonical upload,
+            # nothing has changed and the rebuild is wasted work.
+            if not _resource_has_uf_shards(resource):
+                consolidated_mtime = self._consolidated_mtime_on_ia(year, resource=resource)
+                if consolidated_mtime is not None:
+                    newest_canonical = max(
+                        (
+                            _parse_iso_mtime(row.get("uploaded_at") or "")
+                            for row in shared_manifest
+                            if row.get("table_name") == resource
+                            and (row.get("data_particao") or "").startswith(str(year))
+                            and row.get("file_type", "") in ("", "monthly_canonical")
+                        ),
+                        default=None,
+                    )
+                    if newest_canonical is not None and consolidated_mtime >= newest_canonical:
+                        console.print(
+                            f"[dim]Skipping {resource}/{year}: consolidated annual file "
+                            f"({consolidated_mtime.isoformat()}) is at-or-after the newest "
+                            f"canonical upload ({newest_canonical.isoformat()}).[/dim]"
+                        )
+                        return False
 
         console.print(f"[cyan]Consolidating {resource}/{year}...[/cyan]")
 

--- a/src/baliza/resources/contratos.py
+++ b/src/baliza/resources/contratos.py
@@ -49,6 +49,9 @@ CONTRATOS = PNCPResource(
             # depends on cnpj_orgao locality) stay byte-comparable
             # across this multi-resource refactor.
             order_by_sql="cnpj_orgao, data_publicacao DESC, numero_controle_pncp",
+            # Contratos has uf_sigla in every row (buyer's UF) and the
+            # consolidator emits per-state monthly_uf shards from it.
+            partition_by_uf=True,
         )
     ],
     entity_model=RecuperarContratoDTO,

--- a/src/baliza/resources/specs.py
+++ b/src/baliza/resources/specs.py
@@ -60,6 +60,13 @@ class CanonicalTableSpec:
     # downstream consumers depend on; new resources should leave it
     # blank to get the derived ordering.
     order_by_sql: str | None = None
+    # Whether the canonical schema carries a ``uf_sigla`` column the
+    # consolidator can shard on. Contratos = True (every contrato has a
+    # buyer's UF); atas = False (atas API responses don't carry UF info).
+    # Drives ``_build_per_uf_shards`` + ``register_monthly_uf_shards``
+    # in the consolidator. Keep this declarative because the column
+    # presence isn't always derivable from sort/bloom column lists.
+    partition_by_uf: bool = False
 
 @dataclass
 class PNCPResource:

--- a/tests/step_defs/test_consolidate.py
+++ b/tests/step_defs/test_consolidate.py
@@ -81,7 +81,7 @@ def run_consolidate_force(
     monkeypatch.setattr(
         consolidator,
         "_get_daily_urls_for_year",
-        lambda _year, manifest=None: daily_parquets,
+        lambda _year, manifest=None, *, resource="contratos": daily_parquets,
     )
     # Ensure the frozen-check never short-circuits (scenario passes force=True anyway).
     monkeypatch.setattr("baliza.consolidator._is_frozen", lambda _year: False)

--- a/tests/unit/test_consolidator_resource_dispatch.py
+++ b/tests/unit/test_consolidator_resource_dispatch.py
@@ -16,28 +16,23 @@ from baliza.consolidator import _consolidated_file_name, _resource_has_uf_shards
 
 
 def test_resource_has_uf_shards_contratos():
-    """Contratos's canonical schema includes uf_sigla in sort columns
-    (today via the bloom filter set), so per-UF shards apply."""
-    # Sanity check on the gate. If the spec ever drops uf_sigla we
-    # want this test to fail loudly so the consolidator stops trying.
+    """Contratos's canonical row has uf_sigla. The spec must declare
+    partition_by_uf=True so consolidate_year keeps emitting monthly_uf
+    shards (the public Journey 6 contract relies on those URLs)."""
     from baliza.resources import CONTRATOS
 
-    spec_has = "uf_sigla" in (
-        set(CONTRATOS.canonical_tables[0].bloom_filter_columns)
-        | set(CONTRATOS.canonical_tables[0].sort_columns)
-    )
-    if spec_has:
-        assert _resource_has_uf_shards("contratos") is True
-    else:
-        # Document the gate: if the spec stops listing uf_sigla, atas
-        # and contratos converge on no-shard behavior — that's fine,
-        # just intentional product knowledge.
-        assert _resource_has_uf_shards("contratos") is False
+    assert CONTRATOS.canonical_tables[0].partition_by_uf is True
+    assert _resource_has_uf_shards("contratos") is True
 
 
 def test_resource_has_uf_shards_atas_skipped():
-    """Atas has no uf_sigla in its flatten output / canonical spec.
-    Consolidator must NOT try to build per-UF shards for atas."""
+    """Atas has no uf_sigla — partition_by_uf must stay False so the
+    consolidator skips _build_per_uf_shards (which would crash on the
+    SELECT DISTINCT uf_sigla query) and the manifest stays free of
+    bogus monthly_uf rows."""
+    from baliza.resources import ATAS
+
+    assert ATAS.canonical_tables[0].partition_by_uf is False
     assert _resource_has_uf_shards("atas") is False
 
 

--- a/tests/unit/test_consolidator_resource_dispatch.py
+++ b/tests/unit/test_consolidator_resource_dispatch.py
@@ -1,0 +1,49 @@
+"""Per-resource consolidator behavior tests.
+
+Locks two invariants the multi-resource consolidator depends on:
+
+  * Resources whose canonical schema lacks ``uf_sigla`` (atas) skip
+    the per-UF shard step entirely — building shards on a UF-less
+    file would fail at the ``SELECT DISTINCT uf_sigla`` query, and
+    creating an empty manifest entry would mislead the web resolver.
+  * Annual consolidated filenames are derived from the resource's
+    canonical-table name, not hardcoded to ``contratos-{year}.parquet``.
+"""
+
+from __future__ import annotations
+
+from baliza.consolidator import _consolidated_file_name, _resource_has_uf_shards
+
+
+def test_resource_has_uf_shards_contratos():
+    """Contratos's canonical schema includes uf_sigla in sort columns
+    (today via the bloom filter set), so per-UF shards apply."""
+    # Sanity check on the gate. If the spec ever drops uf_sigla we
+    # want this test to fail loudly so the consolidator stops trying.
+    from baliza.resources import CONTRATOS
+
+    spec_has = "uf_sigla" in (
+        set(CONTRATOS.canonical_tables[0].bloom_filter_columns)
+        | set(CONTRATOS.canonical_tables[0].sort_columns)
+    )
+    if spec_has:
+        assert _resource_has_uf_shards("contratos") is True
+    else:
+        # Document the gate: if the spec stops listing uf_sigla, atas
+        # and contratos converge on no-shard behavior — that's fine,
+        # just intentional product knowledge.
+        assert _resource_has_uf_shards("contratos") is False
+
+
+def test_resource_has_uf_shards_atas_skipped():
+    """Atas has no uf_sigla in its flatten output / canonical spec.
+    Consolidator must NOT try to build per-UF shards for atas."""
+    assert _resource_has_uf_shards("atas") is False
+
+
+def test_consolidated_file_name_uses_canonical_table():
+    """Annual file basename per resource — preserves contratos's
+    historical name and gives atas its own slot in the same IA item."""
+    assert _consolidated_file_name(2024) == "contratos-2024.parquet"
+    assert _consolidated_file_name(2024, resource="contratos") == "contratos-2024.parquet"
+    assert _consolidated_file_name(2024, resource="atas") == "atas-2024.parquet"


### PR DESCRIPTION
Closes the last hardcoded-contratos site in the multi-resource refactor. After this PR, `baliza consolidate --resource atas` builds `atas-{year}.parquet` alongside `contratos-{year}.parquet` in the same `baliza-pncp-consolidated` IA item, and atas annual consolidations roll up automatically when sync runs with `--resource atas`.

## Changes

### `consolidator.py`
- **`_consolidated_file_name(year, *, resource)`** derives the basename from `spec.canonical_tables[0].table_name`. Contratos keeps `contratos-{year}.parquet`; atas gets `atas-{year}.parquet`.
- **`_current_year_is_fresh`** filters by `table_name == resource`. For resources without UF sharding (atas), gates on canonical uploads alone — no shard timestamps to compare against.
- **`_resource_has_uf_shards()`** new helper: reads the canonical spec's `bloom_filter_columns + sort_columns` for `uf_sigla`. Atas has neither, so it's skipped.
- **`_get_daily_urls_for_year`, `_check_consolidated_exists_on_ia`, `consolidate_year`, `consolidate_all`, `_build_per_uf_shards`** all take `resource=` kwarg and route through the canonical spec.
- **`ORDER BY`** in the COPY query now reads `spec.canonical_tables[0].order_by_sql` (preserves contratos's historical `data_publicacao DESC` shape) or derives `sort_columns + pk`.
- **Dimension rebuild** stays contratos-only — aggregations use contratos-specific columns (`cnpj_orgao`, `valor_inicial`, `ni_fornecedor`). Atas needs its own per-resource dim shape, tracked separately.

### `cli_simple.py`
- `consolidate_cmd` gains `--resource / -r` (default contratos), validates up front.
- `sync_cmd`'s `IAConsolidator.consolidate_all` call forwards its `resource` arg.

### Tests
- `tests/unit/test_consolidator_resource_dispatch.py` locks the contratos / atas split for `_resource_has_uf_shards` and the `_consolidated_file_name` basename convention.
- `tests/step_defs/test_consolidate.py` mock signature updated to accept the new `resource=` kwarg.

## Test plan

- [x] `ruff check src/ tests/` clean.
- [x] `pytest tests/` 148/148 pass (3 added).
- [ ] After merge, dispatch `pncp-sync` with `resource=atas` and confirm consolidation produces `atas-{year}.parquet` in `baliza-pncp-consolidated`.

## Out of scope

- Per-resource dimension files (atas-specific orgaos/fornecedores rollups would need different SQL — atas has no `valor_inicial` column).
- Frontend extending the schema sidebar to surface the new annual file (the explorer should pick it up automatically through the manifest, but worth a manual smoke test once data lands).
- Orphan GC `--apply`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FUPSt1fXUVGX9RaJYnyk8U)_