### PR TITLE
fix(web): home structural follow-up to #538

### DIFF
--- a/web/src/components/AlertBanner.svelte
+++ b/web/src/components/AlertBanner.svelte
@@ -21,7 +21,13 @@
   data-invalid={level === 'error' || level === 'warning' ? 'true' : undefined}
   data-level={level}
 >
-  <header><strong><span aria-hidden="true">{levelEmoji[level]}</span> {title}</strong></header>
+  <header><strong>
+    {#if level === 'success'}
+      <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="m8 12 3 3 5-6"/></svg>
+    {:else}
+      <span aria-hidden="true">{levelEmoji[level]}</span>
+    {/if}
+    {title}</strong></header>
   <p>{message}</p>
 </article>
 

--- a/web/src/components/CityHero.svelte
+++ b/web/src/components/CityHero.svelte
@@ -86,19 +86,30 @@
     </div>
   </form>
 
-  <div role="group" class="actions">
+  <div role="group">
     <a href={dashboardHref} role="button">Ver painel de {cityState.nome}</a>
 
     {#if geoStatus !== 'ready'}
-      <button type="button" class="outline" onclick={handleFindLocal} disabled={geoStatus === 'locating'} aria-busy={geoStatus === 'locating'}>
-        {geoStatus === 'locating' ? 'Localizando...' : '📍 Usar minha localização'}
+      <button type="button" class="outline contrast" onclick={handleFindLocal} disabled={geoStatus === 'locating'} aria-busy={geoStatus === 'locating'}>
+        {#if geoStatus !== 'locating'}
+          <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2a7 7 0 0 0-7 7c0 5 7 13 7 13s7-8 7-13a7 7 0 0 0-7-7Z"/><circle cx="12" cy="9" r="2.5"/></svg>
+        {/if}
+        {geoStatus === 'locating' ? 'Localizando…' : 'Usar minha localização'}
       </button>
     {/if}
-
-    <button type="button" class="outline secondary" aria-expanded={pickerOpen} aria-controls="city-hero-picker" onclick={() => (pickerOpen = !pickerOpen)}>
-      {pickerOpen ? 'Fechar seletor' : 'Buscar outra cidade'}
-    </button>
   </div>
+
+  <p>
+    <a
+      href="#city-hero-picker"
+      class="contrast"
+      aria-expanded={pickerOpen}
+      aria-controls="city-hero-picker"
+      onclick={(e) => { e.preventDefault(); pickerOpen = !pickerOpen; }}
+    >
+      {pickerOpen ? 'Fechar seletor' : 'Buscar outra cidade'}
+    </a>
+  </p>
 
   {#if geoStatus === 'denied'}
     <small role="alert" aria-live="polite">Acesso à localização negado. Use o seletor manual.</small>

--- a/web/src/components/CityPicker.svelte
+++ b/web/src/components/CityPicker.svelte
@@ -147,7 +147,8 @@
       autocomplete="off"
     />
     <button type="button" class="outline" onclick={useMyLocation} disabled={geoStatus === 'locating'} aria-busy={geoStatus === 'locating'} aria-label="Usar minha localização atual">
-      {geoStatus === 'locating' ? 'Buscando…' : '📍 minha localização'}
+      {#if geoStatus !== 'locating'}<svg data-icon aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2a7 7 0 0 0-7 7c0 5 7 13 7 13s7-8 7-13a7 7 0 0 0-7-7Z"/><circle cx="12" cy="9" r="2.5"/></svg>{/if}
+      {geoStatus === 'locating' ? 'Buscando…' : 'minha localização'}
     </button>
   </div>
 

--- a/web/src/components/CityWowStrip.svelte
+++ b/web/src/components/CityWowStrip.svelte
@@ -71,8 +71,8 @@
   <section aria-label={`Pulso de ${cityState.nome}`}>
     <div class="grid">
       {#if loading}
-        {#each [1, 2, 3, 4] as _, col (col)}
-          <Skeleton />
+        {#each ['Calculando contratações…', 'Somando R$ executados…', 'Procurando maior comprador…', 'Lendo Internet Archive…'] as msg (msg)}
+          <Skeleton messages={[msg]} />
         {/each}
       {:else if data}
         <article>

--- a/web/src/components/Dashboard.svelte
+++ b/web/src/components/Dashboard.svelte
@@ -7,12 +7,17 @@
   import { resolve } from '../lib/baseUrl';
   import { onMount } from 'svelte';
 
-  let stats = $state<SyncStats | null>(null);
+  const { initialStats }: { initialStats?: SyncStats } = $props();
+  const seed = initialStats;
+
+  let stats = $state<SyncStats | null>(seed ?? null);
   let error = $state<string | null>(null);
-  let loading = $state(true);
+  // When the page passes pre-rendered stats, the first paint shows real
+  // numbers; the background refresh below replaces them once it lands.
+  let loading = $state(!seed);
 
   async function loadStats() {
-    loading = true;
+    if (!stats) loading = true;
     error = null;
     try {
       const res = await fetch(resolve('data/sync_stats.json'));
@@ -20,7 +25,7 @@
       const raw = await res.json();
       stats = SyncStatsSchema.parse(raw);
     } catch (e) {
-      error = (e as Error).message;
+      if (!stats) error = (e as Error).message;
     } finally {
       loading = false;
     }

--- a/web/src/components/DispensasView.svelte
+++ b/web/src/components/DispensasView.svelte
@@ -71,7 +71,7 @@
 </script>
 
 <section>
-  <HubHeader kicker="⚖️ Dispensas" title="Dispensas — Bases Legais">
+  <HubHeader kicker="Dispensas" title="Dispensas — Bases Legais">
     {#snippet lede()}
       <p>Quais artigos da lei são mais citados em dispensas similares. Fonte: API PNCP, modalidade 8 (Dispensa).</p>
     {/snippet}

--- a/web/src/components/LocalBids.svelte
+++ b/web/src/components/LocalBids.svelte
@@ -79,7 +79,7 @@
 <article>
   <header>
     <hgroup>
-      <small>📍</small>
+      <small><svg data-icon aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2a7 7 0 0 0-7 7c0 5 7 13 7 13s7-8 7-13a7 7 0 0 0-7-7Z"/><circle cx="12" cy="9" r="2.5"/></svg></small>
       <h3>Radar Local</h3>
       <p>Encontre oportunidades perto de você usando geolocalização.</p>
     </hgroup>

--- a/web/src/components/MonitorGrid.astro
+++ b/web/src/components/MonitorGrid.astro
@@ -30,7 +30,7 @@ const ITEMS = [
     title: 'Novas contratações por órgão',
     question: 'Qual secretaria publicou mais no mês corrente?',
     href: DEFAULT_CITY_HREF,
-    icon: '🏛️',
+    icon: 'building-library',
   },
   {
     title: 'Atas de registro de preços',
@@ -42,7 +42,7 @@ const ITEMS = [
     title: 'Dispensas e inexigibilidades',
     question: 'Houve pico de contratação sem concorrência?',
     href: 'explorador',
-    icon: '⚖️',
+    icon: 'scale',
   },
   {
     title: 'Variações atípicas no valor',
@@ -67,7 +67,15 @@ const ITEMS = [
     {ITEMS.map((item) => (
       <article>
         <a href={resolve(item.href)}>
-          <figure aria-hidden="true" style="font-size: 2.5rem; margin: 0">{item.icon}</figure>
+          <figure aria-hidden="true" style="font-size: 2.5rem; margin: 0">
+            {item.icon === 'building-library' ? (
+              <svg data-icon viewBox="0 0 24 24"><path d="M3 21h18M5 21V10m14 11V10M3 10l9-6 9 6M8 21v-7m4 7v-7m4 7v-7"/></svg>
+            ) : item.icon === 'scale' ? (
+              <svg data-icon viewBox="0 0 24 24"><path d="M12 3v18M5 7h14M5 7l-3 7a4 4 0 0 0 6 0L5 7Zm14 0-3 7a4 4 0 0 0 6 0L19 7Z"/></svg>
+            ) : (
+              <span>{item.icon}</span>
+            )}
+          </figure>
           <strong>{item.title}</strong>
           <p><small>{item.question}</small></p>
         </a>

--- a/web/src/components/Navigation.astro
+++ b/web/src/components/Navigation.astro
@@ -38,8 +38,8 @@ const isCityActive = cleanPath === cityPrefix;
     </li>
     <li><a href={BASE + 'sobre'} aria-current={isActive(BASE + 'sobre') ? 'page' : undefined}>Sobre</a></li>
     <li>
-      <a href={BASE + 'busca'} role="button" class="outline" aria-label="Buscar">
-        <span aria-hidden="true">🔍</span>
+      <a href={BASE + 'busca'} class="contrast" aria-label="Buscar">
+        <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
         <span class="sr-only">Buscar</span>
       </a>
     </li>

--- a/web/src/components/Skeleton.svelte
+++ b/web/src/components/Skeleton.svelte
@@ -2,15 +2,23 @@
   // Loading placeholder built on Pico's aria-busy=true plus the
   // .is-skeleton hook in global.css. Centralized so every loading
   // state has the same shape and a11y treatment.
+  // `messages` is additive: when provided, each entry renders as a
+  // labelled placeholder line instead of empty filler. Lets skeleton
+  // tiles tell the user what is loading instead of going blank.
   let {
     label = 'Carregando',
     rows = 2,
+    messages,
   }: {
     label?: string;
     rows?: number;
+    messages?: string[];
   } = $props();
+
+  const NBSP = ' ';
+  const lines = $derived(messages ?? Array.from({ length: rows }, () => NBSP));
 </script>
 
 <article aria-busy="true" class="is-skeleton" aria-label={label}>
-  {#each { length: rows } as _, i (i)}<p>&nbsp;</p>{/each}
+  {#each lines as line, i (i)}<p>{line}</p>{/each}
 </article>

--- a/web/src/components/StatCard.svelte
+++ b/web/src/components/StatCard.svelte
@@ -23,7 +23,7 @@
   };
   const toneEmoji: Record<Tone, string> = {
     default: '🔢',
-    success: '✅',
+    success: '',
     warning: '⚠️',
     danger:  '❌',
   };
@@ -35,7 +35,11 @@
   <article>
     <a {href} role="button" class="contrast outline" style="--pico-primary:{accent}">
       <header>
-        <span aria-hidden="true">{emoji}</span>
+        {#if tone === 'success'}
+          <svg data-icon aria-hidden="true" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="m8 12 3 3 5-6"/></svg>
+        {:else}
+          <span aria-hidden="true">{emoji}</span>
+        {/if}
         <h3>{title}</h3>
       </header>
       <p><strong>{value}</strong></p>

--- a/web/src/components/TrustStrip.astro
+++ b/web/src/components/TrustStrip.astro
@@ -4,19 +4,19 @@ const resolve = (href: string) => `${BASE}${href.replace(/^\//, '')}`;
 
 const PILLARS = [
   {
-    kicker: '📦 Arquivo',
+    kicker: 'Arquivo',
     title: 'Snapshots diários no Internet Archive',
     body: 'Cada dia de contratações vira um Parquet aberto fora do alcance de qualquer servidor único. Mesmo que o PNCP saia do ar, o dia de ontem segue consultável.',
     cta: { label: 'Metodologia', href: 'sobre' },
   },
   {
-    kicker: '🔗 Citação',
+    kicker: 'Citação',
     title: 'Links estáveis e hashes verificáveis',
     body: 'Todo contrato tem permalink Baliza com hash do snapshot. O link que você compartilha hoje reproduz a mesma evidência amanhã.',
     cta: { label: 'Desenvolvedores', href: 'desenvolvedores' },
   },
   {
-    kicker: '🦆 Análise',
+    kicker: 'Análise',
     title: 'SQL aberto direto no navegador',
     body: 'Consultas completas rodam no seu navegador via DuckDB WASM. Nada passa por um backend nosso — sua análise é privada e reprodutível.',
     cta: { label: 'Explorador SQL', href: 'explorador' },
@@ -26,7 +26,7 @@ const PILLARS = [
 
 <section aria-labelledby="trust-title">
   <hgroup>
-    <small>✨ Por que Baliza é diferente</small>
+    <small>Por que Baliza é diferente</small>
     <h2 id="trust-title">Arquivo permanente, citação estável, análise sem servidor</h2>
   </hgroup>
 

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -64,13 +64,16 @@ const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
     </main>
 
     <footer class="container">
-      <p>🇧🇷 Baliza: Arquivo público das contratações nacionais.</p>
       <nav aria-label="Rodapé">
         <ul>
-          <li><a href="https://github.com/franklinbaldo" target="_blank" rel="noopener">👨‍💻 Codificado por Franklin Baldo</a></li>
-          <li><small>📚 Fonte: PNCP & Internet Archive</small></li>
-          <li><a href={BASE + 'explorador'}>🔬 Explorador SQL (Beta)</a></li>
-          <li><a href={BASE + 'status'}>📡 Status</a></li>
+          <li><strong>Baliza</strong></li>
+          <li><small>Arquivo público das contratações nacionais.</small></li>
+          <li><small>Fonte: PNCP &amp; Internet Archive</small></li>
+        </ul>
+        <ul>
+          <li><a href="https://github.com/franklinbaldo" target="_blank" rel="noopener">Codificado por Franklin Baldo</a></li>
+          <li><a href={BASE + 'explorador'}>Explorador SQL</a></li>
+          <li><a href={BASE + 'status'}>Status</a></li>
         </ul>
       </nav>
     </footer>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -9,6 +9,7 @@ import OrnamentBand from '../components/OrnamentBand.astro';
 import Dashboard from '../components/Dashboard.svelte';
 import WatchList from '../components/WatchList.svelte';
 import { IA_MANIFEST_URL } from '../lib/ia-manifest';
+import syncStats from '../../public/data/sync_stats.json';
 
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 const resolve = (href: string) => `${BASE}${href.replace(/^\//, '')}`;
@@ -77,10 +78,10 @@ const TOOLS: Array<{
   <!-- 5. Sinal do arquivo: preservation signal backed by sync_stats.json. -->
   <HomeSection
     id="signal-title"
-    kicker="📦 Sinal do arquivo"
+    kicker="Sinal do arquivo"
     title="O que Baliza já preservou"
   >
-    <Dashboard client:visible />
+    <Dashboard client:visible initialStats={syncStats} />
   </HomeSection>
 
   <!-- 6. Watchlist: the "Acompanhar" buttons on detail views save to

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -249,6 +249,22 @@ hr[data-ornament="volpi"] {
   );
 }
 
+/* WHY: inline SVG icons replace emoji glyphs so icon size, color, and
+   baseline are predictable across platforms (emoji renderers vary; the
+   ones that drift the most — 🏛️, ⚖️, 📦 — are the ones we use the
+   most). currentColor + stroke lets buttons/links inherit Pico tones. */
+[data-icon] {
+  width: 1.25em;
+  height: 1.25em;
+  vertical-align: -0.15em;
+  display: inline-block;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 /* WHY: a couple of components render a wide DuckDB result table
    that must scroll horizontally without breaking the page grid;
    Pico's <figure> wrapping handles this when the table is the


### PR DESCRIPTION
## Summary

Structural follow-ups to the design review notes on PR #538. Stays inside Pico CSS — no new component styles, no Tailwind, no `<style scoped>`.

- **Skeletons → meaningful first paint**
  - `Dashboard` accepts an optional `initialStats` prop. `index.astro` imports `web/public/data/sync_stats.json` at build and passes it through, so "Sinal do arquivo" renders real numbers on first paint instead of three blank tiles.
  - `Skeleton` gains an additive `messages?: string[]` prop. `CityWowStrip` uses it to label each loading tile ("Calculando contratações…", "Somando R$ executados…", "Procurando maior comprador…", "Lendo Internet Archive…") instead of leaving four empty boxes.
- **Navigation** — search demotes from `role="button" class="outline"` (red trim) to `class="contrast"` icon link.
- **CityHero** — three actions reorganized: a real `role="group"` joins "Ver painel de {cidade}" and "Usar minha localização" into one segmented control; "Buscar outra cidade" moves below as a `class="contrast"` link, removing the third button competing with the primary CTA.
- **Footer** — collapses to a single `<nav>` with two `<ul>`s (brand/credits on the left, links on the right), which Pico styles as a split row for free.
- **Emoji icons → inline SVG** — new `[data-icon]` utility in `global.css`. Replaces 🏛️ ⚖️ 📍 ✅ 📦 with currentColor heroicons-style SVGs in MonitorGrid, DispensasView, StatCard, AlertBanner, CityHero, CityPicker, LocalBids, TrustStrip, Navigation, and the index page kicker. Decorative 🇧🇷 🔬 📡 ✨ are removed (text only) so footer/trust strip baselines stay clean.

## Test plan

- [x] `npm run build` (with `BALIZA_MANIFEST_FIXTURE=fixtures/manifest.csv`) — passes; `astro check` clean; bundle within budget (330.3 KB / 356.4 KB).
- [x] `npm run test` — 610 passed, 7 skipped.
- [ ] Manual: dev preview at 1440 + 390, verify Dashboard shows real numbers, CityWowStrip skeletons show their labels, footer renders as split row, all SVG icons inherit color from their context.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FUPSt1fXUVGX9RaJYnyk8U)_