### PR TITLE
feat(engine): upsert_rows accepts composite PKs (Drift-A)

### DIFF
--- a/docs/plans/pncp-resource-pipeline.md
+++ b/docs/plans/pncp-resource-pipeline.md
@@ -128,17 +128,15 @@ não listava atas mesmo com o pipeline ingerindo.
 - Pinado em `web/features/pncp-resource-atlas.feature` (cenário
   `@drift-0`) e em `tests/unit/test_build_frontend_config.py`.
 
-### Drift-A — `BalizaEngine.upsert_rows` aceita PK composta
+### Drift-A — `BalizaEngine.upsert_rows` aceita PK composta ✓
 
-**Estado atual:** `engine.py:67` — `pk: str = "numeroControlePNCP"`.
-**Bloqueia:** qualquer recurso com PK composta. PCA já mora aqui:
-`pk=[id_pca_pncp, numero_item]`. Atas escapou porque
-`numero_controle_pncp_ata` é único.
-
-**Plano:** assinatura passa a `pk: str | list[str]`; usar
-`anti_join` / `NOT EXISTS` em vez de coluna sintética (preserva
-caminho rápido para PK string). Teste: PK simples (não regride),
-PK composta (dedup correto). Default kwarg garante compatibilidade.
+**Estado (resolvido):** `engine.py:upsert_rows` agora aceita
+`pk: str | list[str]`. PK string mantém o caminho rápido com
+`isin`; PK lista usa `anti_join` em todas as colunas da chave.
+Pinado em
+`tests/characterization/test_pipeline_contratos.py::test_engine_upsert_composite_pk`
+(prova explicitamente que dedup composto não derruba linhas que
+colidiriam num anti-join de coluna única).
 
 ### Drift-B — `ArtifactSpec` formalizado
 

--- a/src/baliza/engine.py
+++ b/src/baliza/engine.py
@@ -82,6 +82,13 @@ class BalizaEngine:
         if not data:
             return 0
 
+        # Validate the PK shape up front — including on first insert
+        # — so a misconfigured caller surfaces immediately rather than
+        # silently writing the first batch and only failing on the
+        # second call when the dedup branch fires.
+        if isinstance(pk, list) and not pk:
+            raise ValueError("pk list must contain at least one column")
+
         # Create a memtable from the new data
         t_new = ibis.memtable(data)
 
@@ -118,10 +125,9 @@ class BalizaEngine:
             if isinstance(pk, str):
                 t_kept = t_existing.filter(~t_existing[pk].isin(t_new[pk]))
             else:
-                if not pk:
-                    raise ValueError("pk list must contain at least one column")
-                predicates = [t_existing[c] == t_new[c] for c in pk]
-                t_kept = t_existing.anti_join(t_new, predicates)
+                # Ibis treats a list of column names as equi-join keys,
+                # which is exactly the composite-PK semantics we want.
+                t_kept = t_existing.anti_join(t_new, pk)
             # 4. Union with new batch
             t_combined = ibis.union(t_kept, t_new)
             # 5. Overwrite table

--- a/src/baliza/engine.py
+++ b/src/baliza/engine.py
@@ -69,9 +69,16 @@ class BalizaEngine:
         data: list[dict[str, Any]],
         table_name: str,
         schema: str = "main",
-        pk: str = "numeroControlePNCP",
+        pk: str | list[str] = "numeroControlePNCP",
     ) -> int:
-        """Upsert rows using pure Ibis logic (Union + Overwrite)."""
+        """Upsert rows using pure Ibis logic (Union + Overwrite).
+
+        ``pk`` accepts a single column name (fast path: ``isin``) or a
+        list of column names (anti-join on every column). Composite PKs
+        are required for resources like PCA where uniqueness lives on
+        ``(id_pca_pncp, numero_item)``; the simple-PK fast path is kept
+        so contratos / atas don't pay the join overhead.
+        """
         if not data:
             return 0
 
@@ -104,9 +111,19 @@ class BalizaEngine:
                 # Fallback if Ibis cast fails (e.g. new columns added in code)
                 pass
 
-            # 3. Filter out rows that are in the new batch (based on PK)
+            # 3. Drop rows from existing whose PK collides with the new
+            #    batch. Two paths:
+            #    - simple string pk: cheap ``isin`` against a single column.
+            #    - composite (list) pk: anti-join on every PK column.
+            if isinstance(pk, str):
+                t_kept = t_existing.filter(~t_existing[pk].isin(t_new[pk]))
+            else:
+                if not pk:
+                    raise ValueError("pk list must contain at least one column")
+                predicates = [t_existing[c] == t_new[c] for c in pk]
+                t_kept = t_existing.anti_join(t_new, predicates)
             # 4. Union with new batch
-            t_combined = ibis.union(t_existing.filter(~t_existing[pk].isin(t_new[pk])), t_new)
+            t_combined = ibis.union(t_kept, t_new)
             # 5. Overwrite table
             self.con.create_table(table_name, t_combined, database=schema, overwrite=True)
         else:

--- a/tests/characterization/test_pipeline_contratos.py
+++ b/tests/characterization/test_pipeline_contratos.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from ibis.common.exceptions import IbisTypeError
 
 from baliza.builder import _pending_build_months
 from baliza.engine import BalizaEngine
@@ -68,7 +67,9 @@ def test_builder_parses_month_partition():
     assert len(pending_with_day) == 2
 
 
-# 2. engine.py upsert_rows deduplicates by a single hardcoded PK string parameter by default and only supports simple ISIN
+# 2. engine.py upsert_rows deduplicates by PK. Drift-A made ``pk``
+#    accept ``str | list[str]``: simple PKs keep the cheap ``isin`` path,
+#    composite PKs go through an anti-join. Both shapes are pinned here.
 def test_engine_upsert_single_pk():
     engine = BalizaEngine()
     data1 = [{"numeroControlePNCP": "A1", "valor": 10}, {"numeroControlePNCP": "A2", "valor": 20}]
@@ -88,12 +89,42 @@ def test_engine_upsert_single_pk():
     res2 = engine.con.table("test_table").execute()
     assert len(res2) == 3
 
-    # Verify that the current interface of upsert_rows only accepts a string for pk
-    # (or rather, we characterize how it fails if given a list)
-    with pytest.raises(IbisTypeError):
-        # Ibis raises IbisTypeError (column not found) when pk is a list
-        # — current engine only supports single-column pk
-        engine.upsert_rows([{"k1": "v1", "k2": "v2"}], "test_table", pk=["k1", "k2"])
+
+def test_engine_upsert_composite_pk():
+    """PCA uses ``(id_pca_pncp, numero_item)`` — verify the composite
+    path dedups on the full key and not on either column alone."""
+    engine = BalizaEngine()
+    data1 = [
+        {"id_pca": "P1", "item": 1, "valor": 10},
+        {"id_pca": "P1", "item": 2, "valor": 20},
+        {"id_pca": "P2", "item": 1, "valor": 30},
+    ]
+    engine.upsert_rows(data1, "pca_table", pk=["id_pca", "item"])
+    assert len(engine.con.table("pca_table").execute()) == 3
+
+    # Update P1/item=1 (collides), insert P2/item=2 (new). Critically,
+    # P1/item=2 must survive — a single-column anti-join on id_pca alone
+    # would have dropped it.
+    data2 = [
+        {"id_pca": "P1", "item": 1, "valor": 99},
+        {"id_pca": "P2", "item": 2, "valor": 40},
+    ]
+    engine.upsert_rows(data2, "pca_table", pk=["id_pca", "item"])
+    res = engine.con.table("pca_table").execute()
+    assert len(res) == 4
+
+    rows = {(r["id_pca"], r["item"]): r["valor"] for _, r in res.iterrows()}
+    assert rows[("P1", 1)] == 99   # updated
+    assert rows[("P1", 2)] == 20   # untouched — would die under single-PK
+    assert rows[("P2", 1)] == 30
+    assert rows[("P2", 2)] == 40
+
+
+def test_engine_upsert_empty_composite_pk_rejected():
+    engine = BalizaEngine()
+    engine.upsert_rows([{"k": 1}], "tbl", pk="k")
+    with pytest.raises(ValueError, match="pk list"):
+        engine.upsert_rows([{"k": 2}], "tbl", pk=[])
 
 
 # 3. ia_uploader.py hardcodes the written fields


### PR DESCRIPTION
## Summary

Closes Drift-A from `docs/plans/pncp-resource-pipeline.md`. `BalizaEngine.upsert_rows` previously hardcoded a string PK (`pk: str = "numeroControlePNCP"`), which silently broke for any resource whose uniqueness lives across multiple columns (PCA's `(id_pca_pncp, numero_item)` is the immediate use case; atas only escaped because `numero_controle_pncp_ata` happens to be unique).

Now `pk` accepts `str | list[str]`:
- string PK keeps the cheap `isin` fast path (no overhead for contratos / atas);
- list PK uses `anti_join` across every PK column.

Pinned by `tests/characterization/test_pipeline_contratos.py::test_engine_upsert_composite_pk`, which proves the composite path doesn't drop rows that share one component but not the rest (the bug a single-column anti-join would have).

## Stacking

Branched off `claude/unify-resource-registries-2aKZj` (PR #560 — Drift-0). Once #560 merges to main, this PR's base auto-retargets. The diff vs the Drift-0 branch is engine-only.

## References

- Plan: [`docs/plans/pncp-resource-pipeline.md`](docs/plans/pncp-resource-pipeline.md) §3 Drift-A.

## Test plan

- [x] `uv run ruff check src/ tests/ scripts/`
- [x] `uv run pytest tests/ --ignore=tests/integration/test_pncp_cassettes.py` → 158 passed (+2 for composite/empty-list cases)

https://claude.ai/code/session_014zdc1izkTSMnA7f1PcbFsC

---
_Generated by [Claude Code](https://claude.ai/code/session_014zdc1izkTSMnA7f1PcbFsC)_