### PR TITLE
feat(resources): typed ArtifactSpec + populate for contratos/atas (Drift-B, prep)

### DIFF
--- a/docs/plans/pncp-resource-pipeline.md
+++ b/docs/plans/pncp-resource-pipeline.md
@@ -138,19 +138,22 @@ Pinado em
 (prova explicitamente que dedup composto não derruba linhas que
 colidiriam num anti-join de coluna única).
 
-### Drift-B — `ArtifactSpec` formalizado
+### Drift-B — `ArtifactSpec` formalizado (parcial)
 
-**Estado atual:** lógica de filename / IA item / file_type / sort_key /
-bloom_filter_columns está espalhada em `IAUploader._update_remote_manifest`
-+ `MonthlyExporter.export_month` + `IAConsolidator`.
-**Bloqueia:** novos formatos (anual particionado por UF, JSON dim
-cumulativo per-resource, índices full-text). Adicionar PCA com
-`partition_strategy="annual"` força a abstração ou cria uma branch
-condicional dentro de cada chamada de upload.
-**Plano:** dataclass `ArtifactSpec` em `specs.py`; lista
-`PNCPResource.artifacts: list[ArtifactSpec]` populada com pelo menos
-o artefato monthly_canonical para contratos/atas; uploader/consolidator
-iteram sobre `spec.artifacts` em vez de hardcodar.
+**Estado atual:** o tipo `ArtifactSpec` está em `specs.py` e
+`PNCPResource.artifacts` está populada para contratos (monthly_canonical
++ monthly_uf + annual_canonical) e atas (monthly_canonical +
+annual_canonical — sem UF). Pinado em
+`tests/unit/test_artifact_spec.py`, incluindo um teste de cruzamento
+que falha se `partition_by_uf` discordar da presença de monthly_uf
+nos artifacts.
+
+**Falta:** `IAUploader._update_remote_manifest`,
+`MonthlyExporter.export_month` e `IAConsolidator` ainda hardcodam os
+mesmos fatos (filename, IA item, file_type) que `ArtifactSpec`
+agora descreve. A reescrita iterativa para ler de `spec.artifacts`
+fica para o PR de promoção do PCA — neste momento ela seria 100%
+behavior-preserving para contratos/atas.
 
 ### Drift-C — `FrontendExposureSpec` + `isCanonicalRow` extensível ✓
 

--- a/src/baliza/resources/__init__.py
+++ b/src/baliza/resources/__init__.py
@@ -3,6 +3,7 @@ from .contratos import CONTRATOS
 from .pca import PCA
 from .publicacoes import PUBLICACOES
 from .specs import (
+    ArtifactSpec,
     CanonicalTableSpec,
     EntitySpec,
     FetchSpec,
@@ -80,6 +81,7 @@ __all__ = [
     "FetchSpec",
     "RawDatasetSpec",
     "EntitySpec",
+    "ArtifactSpec",
     "CanonicalTableSpec",
     "FrontendExposureSpec",
     "PartitionStrategy",

--- a/src/baliza/resources/atas.py
+++ b/src/baliza/resources/atas.py
@@ -3,6 +3,7 @@ from datetime import date
 from ..models import RecuperarAtaDTO
 from ..transforms import _flatten_ata
 from .specs import (
+    ArtifactSpec,
     CanonicalTableSpec,
     EntitySpec,
     FetchSpec,
@@ -61,6 +62,21 @@ ATAS = PNCPResource(
             artifact_name="atas",
             table_alias="atas",
             is_canonical=True,
+        ),
+    ],
+    # Atas does not produce monthly_uf shards (partition_by_uf=False
+    # on the canonical table — atas API responses don't carry buyer's
+    # UF). monthly_canonical + annual_canonical only.
+    artifacts=[
+        ArtifactSpec(
+            file_type="monthly_canonical",
+            ia_item_id="baliza-pncp-{partition}",
+            description="Per-month deduplicated canonical atas snapshot.",
+        ),
+        ArtifactSpec(
+            file_type="annual_canonical",
+            ia_item_id="baliza-pncp-consolidated",
+            description="Yearly rollup of monthly canonicals.",
         ),
     ],
 )

--- a/src/baliza/resources/contratos.py
+++ b/src/baliza/resources/contratos.py
@@ -79,10 +79,16 @@ CONTRATOS = PNCPResource(
             description="Per-month deduplicated canonical contratos snapshot.",
         ),
         ArtifactSpec(
+            # IAConsolidator.consolidate_year uploads the per-UF shards
+            # to baliza-pncp-consolidated alongside the annual rollup
+            # — NOT to the per-month item. Verified at
+            # consolidator.py:395 + register_monthly_uf_shards rows
+            # carrying ia_item_id=CONSOLIDATED_IA_ITEM.
             file_type="monthly_uf",
-            ia_item_id="baliza-pncp-{partition}",
+            ia_item_id="baliza-pncp-consolidated",
             description="Per-UF shard of the monthly canonical, "
-            "gated by CanonicalTableSpec.partition_by_uf.",
+            "gated by CanonicalTableSpec.partition_by_uf. Uploaded by "
+            "the consolidator alongside the annual rollup.",
         ),
         ArtifactSpec(
             file_type="annual_canonical",

--- a/src/baliza/resources/contratos.py
+++ b/src/baliza/resources/contratos.py
@@ -3,6 +3,7 @@ from datetime import date
 from ..models import RecuperarContratoDTO
 from ..transforms import _flatten_contrato
 from .specs import (
+    ArtifactSpec,
     CanonicalTableSpec,
     EntitySpec,
     FetchSpec,
@@ -66,6 +67,28 @@ CONTRATOS = PNCPResource(
             artifact_name="contratos",
             table_alias="contratos",
             is_canonical=True,
+        ),
+    ],
+    # Artifacts contratos publishes today. Drift-B prep: declared in
+    # one place; the uploader / consolidator still hardcode the same
+    # facts and will be rewired in the follow-up PR.
+    artifacts=[
+        ArtifactSpec(
+            file_type="monthly_canonical",
+            ia_item_id="baliza-pncp-{partition}",
+            description="Per-month deduplicated canonical contratos snapshot.",
+        ),
+        ArtifactSpec(
+            file_type="monthly_uf",
+            ia_item_id="baliza-pncp-{partition}",
+            description="Per-UF shard of the monthly canonical, "
+            "gated by CanonicalTableSpec.partition_by_uf.",
+        ),
+        ArtifactSpec(
+            file_type="annual_canonical",
+            ia_item_id="baliza-pncp-consolidated",
+            description="Yearly rollup of monthly canonicals into a "
+            "single Parquet for explorer queries.",
         ),
     ],
 )

--- a/src/baliza/resources/specs.py
+++ b/src/baliza/resources/specs.py
@@ -104,6 +104,45 @@ class CanonicalTableSpec:
     # presence isn't always derivable from sort/bloom column lists.
     partition_by_uf: bool = False
 
+@dataclass(frozen=True)
+class ArtifactSpec:
+    """Declarative description of one artifact a resource publishes.
+
+    Today the uploader, consolidator and exporter each carry their own
+    branches that hardcode artifact-axis facts: filename shape, IA
+    item, ``file_type`` written to the manifest, sort/bloom columns
+    used at export time. ``ArtifactSpec`` is the type that lets a new
+    resource (PCA's annual rollup, future per-cnpj index, ...) declare
+    those facts in one place and have the runtime iterate over
+    ``resource.artifacts``.
+
+    This PR only introduces the type and populates it for the
+    artifacts contratos / atas already produce today; the runtime
+    paths still hardcode the same facts. The follow-up wiring PR
+    deletes those branches in favor of iterating ``artifacts``.
+    """
+
+    # Manifest ``file_type`` value the runtime writes for this artifact.
+    # Matches the strings ``isCanonicalRow`` / consolidator already emit
+    # so the wiring PR can be a behavior-preserving substitution.
+    file_type: str
+    # IA item the artifact lands in (e.g. ``baliza-pncp-consolidated``
+    # for annual rollups, ``baliza-pncp-{YYYY-MM}`` for monthly
+    # canonical — for partitioned items, this is the *prefix* the
+    # runtime appends the partition label to).
+    ia_item_id: str
+    # Optional human label for plan/docs and future explorer surfaces.
+    description: str = ""
+    # Sort + bloom columns used when materializing the artifact.
+    # Empty means "inherit from canonical_tables[0]" — keeps contratos
+    # / atas declarations tight while leaving the door open for
+    # per-artifact overrides (e.g. annual rollup sorted by year).
+    sort_columns: list[str] = field(default_factory=list)
+    bloom_filter_columns: list[str] = field(default_factory=list)
+    # Full ORDER BY override. Mirrors CanonicalTableSpec.order_by_sql.
+    order_by_sql: str | None = None
+
+
 @dataclass
 class PNCPResource:
     resource_name: str
@@ -128,6 +167,11 @@ class PNCPResource:
     # planned ones still missing flatten_fn) don't leak placeholder
     # entries into the generated TS.
     frontend_exposures: list["FrontendExposureSpec"] = field(default_factory=list)
+    # Artifacts the resource publishes (monthly_canonical, optional
+    # monthly_uf, optional annual_canonical, future per-cnpj index...).
+    # Empty default keeps PLANNED_RESOURCES that don't have a runtime
+    # path yet from having to spell artifacts they don't produce.
+    artifacts: list["ArtifactSpec"] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if not _RESOURCE_NAME_RE.match(self.resource_name):

--- a/src/baliza/resources/specs.py
+++ b/src/baliza/resources/specs.py
@@ -137,8 +137,11 @@ class ArtifactSpec:
     # Empty means "inherit from canonical_tables[0]" — keeps contratos
     # / atas declarations tight while leaving the door open for
     # per-artifact overrides (e.g. annual rollup sorted by year).
-    sort_columns: list[str] = field(default_factory=list)
-    bloom_filter_columns: list[str] = field(default_factory=list)
+    # Tuples (not lists) so ``frozen=True`` actually means immutable —
+    # a list field would still let a caller append at runtime and
+    # poison the shared registry for every later caller.
+    sort_columns: tuple[str, ...] = ()
+    bloom_filter_columns: tuple[str, ...] = ()
     # Full ORDER BY override. Mirrors CanonicalTableSpec.order_by_sql.
     order_by_sql: str | None = None
 

--- a/src/baliza/resources/specs.py
+++ b/src/baliza/resources/specs.py
@@ -145,6 +145,20 @@ class ArtifactSpec:
     # Full ORDER BY override. Mirrors CanonicalTableSpec.order_by_sql.
     order_by_sql: str | None = None
 
+    def __post_init__(self) -> None:
+        # Type annotations don't enforce runtime: a caller passing
+        # ``sort_columns=[...]`` would still slip through and the list
+        # could be mutated later, poisoning the shared registry.
+        # Coerce to tuple so the immutability claim is real regardless
+        # of how the spec was constructed. ``object.__setattr__`` is
+        # required because the dataclass is frozen.
+        if not isinstance(self.sort_columns, tuple):
+            object.__setattr__(self, "sort_columns", tuple(self.sort_columns))
+        if not isinstance(self.bloom_filter_columns, tuple):
+            object.__setattr__(
+                self, "bloom_filter_columns", tuple(self.bloom_filter_columns),
+            )
+
 
 @dataclass
 class PNCPResource:

--- a/src/baliza/resources/specs.py
+++ b/src/baliza/resources/specs.py
@@ -188,13 +188,23 @@ class PNCPResource:
     # monthly_uf, optional annual_canonical, future per-cnpj index...).
     # Empty default keeps PLANNED_RESOURCES that don't have a runtime
     # path yet from having to spell artifacts they don't produce.
-    artifacts: list["ArtifactSpec"] = field(default_factory=list)
+    artifacts: tuple["ArtifactSpec", ...] = ()
 
     def __post_init__(self) -> None:
         if not _RESOURCE_NAME_RE.match(self.resource_name):
             raise ValueError(
                 f"Invalid resource_name {self.resource_name!r}: must match {_RESOURCE_NAME_RE.pattern}"
             )
+        # PNCPResource itself isn't frozen (existing fields like
+        # entities / canonical_tables predate this PR and stay as
+        # lists), but ``artifacts`` describes the runtime publish
+        # contract — an accidental ``.append()`` on the registry
+        # singleton would silently change which artifacts get
+        # uploaded once the wiring PR consumes it (Codex P2). Coerce
+        # to tuple so callers passing list literals still work while
+        # in-place mutation fails.
+        if not isinstance(self.artifacts, tuple):
+            self.artifacts = tuple(self.artifacts)
 
     @property
     def name(self) -> str:

--- a/tests/unit/test_artifact_spec.py
+++ b/tests/unit/test_artifact_spec.py
@@ -70,6 +70,19 @@ def test_artifact_spec_collection_fields_are_immutable():
             assert isinstance(artifact.bloom_filter_columns, tuple)
 
 
+def test_pncp_resource_artifacts_is_a_tuple():
+    """Codex P2: ``PNCPResource.artifacts`` describes the runtime
+    publish contract. A list field would let a caller .append() on
+    the global registry singleton and silently change which artifacts
+    get uploaded once the wiring PR consumes it. Tuples block
+    in-place mutation."""
+    for resource in (CONTRATOS, ATAS):
+        assert isinstance(resource.artifacts, tuple), (
+            f"{resource.resource_name}.artifacts must be a tuple, "
+            f"got {type(resource.artifacts).__name__}"
+        )
+
+
 def test_artifact_spec_coerces_list_inputs_to_tuples():
     """Codex P2 follow-up: type annotations aren't enforced at runtime,
     so a caller passing ``sort_columns=[...]`` would silently slip a

--- a/tests/unit/test_artifact_spec.py
+++ b/tests/unit/test_artifact_spec.py
@@ -70,6 +70,32 @@ def test_artifact_spec_collection_fields_are_immutable():
             assert isinstance(artifact.bloom_filter_columns, tuple)
 
 
+def test_artifact_ia_items_match_runtime_upload_targets():
+    """Codex P2: ArtifactSpec must describe what the runtime *actually*
+    does today, otherwise the wiring PR will silently redirect uploads.
+    Pin the (file_type → ia_item_id) shape against the values
+    uploader / consolidator currently use:
+
+    - monthly_canonical → ``baliza-pncp-{partition}`` (one item per month
+      via ``IAUploader.upload_parquet``).
+    - monthly_uf → ``baliza-pncp-consolidated`` (uploaded by
+      ``IAConsolidator.consolidate_year``, NOT the per-month item).
+    - annual_canonical → ``baliza-pncp-consolidated``.
+    """
+    expected = {
+        "monthly_canonical": "baliza-pncp-{partition}",
+        "monthly_uf": "baliza-pncp-consolidated",
+        "annual_canonical": "baliza-pncp-consolidated",
+    }
+    for resource in (CONTRATOS, ATAS):
+        for artifact in resource.artifacts:
+            assert artifact.ia_item_id == expected[artifact.file_type], (
+                f"{resource.resource_name}/{artifact.file_type} "
+                f"declares ia_item_id={artifact.ia_item_id!r} but "
+                f"runtime uploads to {expected[artifact.file_type]!r}"
+            )
+
+
 def test_every_artifact_has_a_known_file_type():
     """Whitelist of file_type strings the runtime knows how to handle.
     Adding a new value here is a deliberate cross-cutting change

--- a/tests/unit/test_artifact_spec.py
+++ b/tests/unit/test_artifact_spec.py
@@ -70,6 +70,22 @@ def test_artifact_spec_collection_fields_are_immutable():
             assert isinstance(artifact.bloom_filter_columns, tuple)
 
 
+def test_artifact_spec_coerces_list_inputs_to_tuples():
+    """Codex P2 follow-up: type annotations aren't enforced at runtime,
+    so a caller passing ``sort_columns=[...]`` would silently slip a
+    mutable list onto the spec. ``__post_init__`` must coerce."""
+    spec = ArtifactSpec(
+        file_type="x",
+        ia_item_id="y",
+        sort_columns=["a", "b"],         # type: ignore[arg-type]
+        bloom_filter_columns=["c"],      # type: ignore[arg-type]
+    )
+    assert spec.sort_columns == ("a", "b")
+    assert spec.bloom_filter_columns == ("c",)
+    assert isinstance(spec.sort_columns, tuple)
+    assert isinstance(spec.bloom_filter_columns, tuple)
+
+
 def test_artifact_ia_items_match_runtime_upload_targets():
     """Codex P2: ArtifactSpec must describe what the runtime *actually*
     does today, otherwise the wiring PR will silently redirect uploads.

--- a/tests/unit/test_artifact_spec.py
+++ b/tests/unit/test_artifact_spec.py
@@ -1,0 +1,69 @@
+"""Pins the ArtifactSpec shape introduced in Drift-B (prep).
+
+The runtime paths (uploader, consolidator, exporter) still hardcode
+artifact-axis facts today; this test fixes the declarative target
+shape so the wiring PR can be a behavior-preserving substitution
+rather than a re-design.
+"""
+from __future__ import annotations
+
+from baliza.resources import ATAS, CONTRATOS, ArtifactSpec
+
+
+def _file_types(resource) -> list[str]:
+    return [a.file_type for a in resource.artifacts]
+
+
+def test_contratos_publishes_three_artifacts():
+    """Monthly canonical + per-UF shards (gated by partition_by_uf=True)
+    + annual rollup. Drops or additions here are runtime-visible
+    changes — bump the test deliberately."""
+    assert _file_types(CONTRATOS) == [
+        "monthly_canonical",
+        "monthly_uf",
+        "annual_canonical",
+    ]
+
+
+def test_atas_publishes_two_artifacts():
+    """No monthly_uf — atas canonical has partition_by_uf=False (the
+    PNCP atas payload doesn't carry buyer UF)."""
+    assert _file_types(ATAS) == ["monthly_canonical", "annual_canonical"]
+
+
+def test_atas_artifact_set_matches_canonical_partition_by_uf():
+    """Cross-check: a resource that says ``partition_by_uf=False`` on
+    its canonical table must NOT advertise a monthly_uf artifact, and
+    vice versa. Catches drift between the two declarations."""
+    for resource in (CONTRATOS, ATAS):
+        canonical = resource.canonical_tables[0]
+        has_uf_artifact = "monthly_uf" in _file_types(resource)
+        assert has_uf_artifact == canonical.partition_by_uf, (
+            f"{resource.resource_name}: partition_by_uf="
+            f"{canonical.partition_by_uf} but monthly_uf in artifacts="
+            f"{has_uf_artifact}"
+        )
+
+
+def test_artifact_spec_is_frozen():
+    """Mutability would let a runtime caller poison the registry for
+    every subsequent caller in the same process. Pin frozen=True."""
+    spec = ArtifactSpec(file_type="x", ia_item_id="y")
+    try:
+        spec.file_type = "z"  # type: ignore[misc]
+    except Exception:
+        return
+    raise AssertionError("ArtifactSpec must be frozen")
+
+
+def test_every_artifact_has_a_known_file_type():
+    """Whitelist of file_type strings the runtime knows how to handle.
+    Adding a new value here is a deliberate cross-cutting change
+    (manifest schema, isCanonicalRow, consolidator branch)."""
+    known = {"monthly_canonical", "monthly_uf", "annual_canonical"}
+    for resource in (CONTRATOS, ATAS):
+        for artifact in resource.artifacts:
+            assert artifact.file_type in known, (
+                f"unknown file_type {artifact.file_type!r} in "
+                f"{resource.resource_name}.artifacts"
+            )

--- a/tests/unit/test_artifact_spec.py
+++ b/tests/unit/test_artifact_spec.py
@@ -56,6 +56,20 @@ def test_artifact_spec_is_frozen():
     raise AssertionError("ArtifactSpec must be frozen")
 
 
+def test_artifact_spec_collection_fields_are_immutable():
+    """Codex P2: ``frozen=True`` only blocks attribute reassignment.
+    A ``list`` field would still let a caller append/mutate the
+    registry-owned object. Tuples enforce real immutability."""
+    spec = ArtifactSpec(file_type="x", ia_item_id="y")
+    assert isinstance(spec.sort_columns, tuple)
+    assert isinstance(spec.bloom_filter_columns, tuple)
+    # And declared instances on real resources too.
+    for resource in (CONTRATOS, ATAS):
+        for artifact in resource.artifacts:
+            assert isinstance(artifact.sort_columns, tuple)
+            assert isinstance(artifact.bloom_filter_columns, tuple)
+
+
 def test_every_artifact_has_a_known_file_type():
     """Whitelist of file_type strings the runtime knows how to handle.
     Adding a new value here is a deliberate cross-cutting change


### PR DESCRIPTION
## Summary

Partial close of Drift-B from `docs/plans/pncp-resource-pipeline.md`. Today filename / IA item / `file_type` / sort_columns / bloom_filter_columns are scattered across `IAUploader._update_remote_manifest`, `MonthlyExporter.export_month`, and `IAConsolidator` — adding PCA's annual rollup or any future per-cnpj index forces either an abstraction or a conditional branch inside every upload site.

This PR introduces the typed primitive both call paths will consume:

- `ArtifactSpec` (frozen dataclass on `resources/specs.py`): `file_type`, `ia_item_id`, optional `description`, `sort_columns`, `bloom_filter_columns`, `order_by_sql`.
- `PNCPResource.artifacts: list[ArtifactSpec]`, populated for contratos (monthly_canonical + monthly_uf + annual_canonical) and atas (monthly_canonical + annual_canonical — no UF since `partition_by_uf=False`).

`tests/unit/test_artifact_spec.py` pins:

- The artifact set per resource (drops/additions are runtime-visible — bump deliberately).
- Cross-check that `monthly_uf` presence matches `CanonicalTableSpec.partition_by_uf` so the two declarations can't drift independently.
- ArtifactSpec is frozen.
- Every artifact's `file_type` is in a known whitelist.

## Why partial?

The plan also asks the uploader/consolidator/exporter to iterate over `spec.artifacts`. That migration touches three runtime files and changes nothing observable for contratos/atas — the right time to do it is alongside PCA promotion, where the new `annual` artifact actually lights up the iteration. The plan was updated to call this out.

## Stacking

Branched off `claude/drift-d-partition-period` (PR #563, which stacks on #562 / #561 / #560). Diff against the parent branch is `specs.py` + contratos/atas + the new test only.

## References

- Plan: [`docs/plans/pncp-resource-pipeline.md`](docs/plans/pncp-resource-pipeline.md) §3 Drift-B.

## Test plan

- [x] `uv run ruff check src/ tests/ scripts/`
- [x] `uv run pytest tests/unit/test_artifact_spec.py -v` → 5 passed
- [x] `uv run pytest tests/ --ignore=tests/integration/test_pncp_cassettes.py` → 175 passed (170 → +5 ArtifactSpec tests)

https://claude.ai/code/session_014zdc1izkTSMnA7f1PcbFsC

---
_Generated by [Claude Code](https://claude.ai/code/session_014zdc1izkTSMnA7f1PcbFsC)_