### PR TITLE
feat(website): four-resource hub pages, IA archive catalogue, and dashboard refresh

### DIFF
--- a/scripts/build_ia_inventory.py
+++ b/scripts/build_ia_inventory.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env -S uv run --quiet
+"""Regenerate ``web/public/data/ia_inventory.json`` from the live IA collection.
+
+Queries Internet Archive for all items tagged ``subject:baliza-pncp`` and
+writes a structured JSON the ``/arquivo`` page reads at build time.
+
+Pattern mirrors ``build_sync_stats.py``:
+- Tolerates IA outage by preserving an existing snapshot.
+- Writes a zero-baseline when no file exists so Astro build succeeds.
+- Wire into the same web-build pre-pass that runs ``build_sync_stats.py``.
+
+Usage:
+    uv run python scripts/build_ia_inventory.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+try:
+    import internetarchive as ia
+except ImportError:
+    print(
+        "ERROR: internetarchive is not installed. Run: uv pip install internetarchive",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+BALIZA_COLLECTION_TAG = "baliza-pncp"
+
+GROUP_LABELS: dict[str, str] = {
+    "raw": "Espelhos brutos (ZIP)",
+    "monthly_canonical": "Canônicos mensais (Parquet)",
+    "annual_canonical": "Consolidados anuais (Parquet)",
+    "supporting": "Suporte (manifesto, feeds, dimensões)",
+}
+
+
+def _classify(identifier: str) -> str:
+    if identifier == "baliza-pncp-raw":
+        return "raw"
+    if identifier in ("baliza-pncp-consolidated", "baliza-pncp-dimensions"):
+        return "annual_canonical"
+    if identifier in ("baliza-pncp-manifest", "baliza-pncp-feeds"):
+        return "supporting"
+    if re.match(r"^baliza-pncp-\d{4}-\d{2}$", identifier):
+        return "monthly_canonical"
+    if re.match(r"^baliza-pncp-\d{4}$", identifier):
+        return "annual_canonical"
+    return "supporting"
+
+
+def _fmt_bytes(n: int) -> str:
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if n < 1024:
+            return f"{n:.1f} {unit}"
+        n //= 1024
+    return f"{n:.1f} PB"
+
+
+def _zero_payload() -> dict:
+    return {
+        "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "items": [],
+        "groups": {k: [] for k in GROUP_LABELS},
+        "group_labels": GROUP_LABELS,
+    }
+
+
+def main() -> int:
+    out = REPO_ROOT / "web" / "public" / "data" / "ia_inventory.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    session = ia.get_session()
+
+    try:
+        results = list(
+            session.search_items(
+                f"subject:{BALIZA_COLLECTION_TAG}",
+                fields=["identifier", "title", "description", "date", "mediatype", "item_size", "num_files"],
+            )
+        )
+    except Exception as exc:
+        if out.exists():
+            print(
+                f"IA search failed; preserving existing ia_inventory.json: {exc}",
+                file=sys.stderr,
+            )
+            return 0
+        print(
+            f"IA search failed and no ia_inventory.json exists; writing zero baseline: {exc}",
+            file=sys.stderr,
+        )
+        out.write_text(json.dumps(_zero_payload(), indent=2) + "\n", encoding="utf-8")
+        return 0
+
+    if not results:
+        if out.exists():
+            print("IA search returned no items; preserving existing ia_inventory.json", file=sys.stderr)
+            return 0
+        out.write_text(json.dumps(_zero_payload(), indent=2) + "\n", encoding="utf-8")
+        return 0
+
+    items = []
+    groups: dict[str, list[str]] = {k: [] for k in GROUP_LABELS}
+
+    for r in sorted(results, key=lambda x: x.get("identifier", "")):
+        identifier = r.get("identifier", "")
+        try:
+            item_size = int(r.get("item_size") or 0)
+        except (TypeError, ValueError):
+            item_size = 0
+        try:
+            num_files = int(r.get("num_files") or 0)
+        except (TypeError, ValueError):
+            num_files = 0
+
+        group = _classify(identifier)
+        groups.setdefault(group, []).append(identifier)
+        items.append(
+            {
+                "identifier": identifier,
+                "title": r.get("title") or identifier,
+                "description": r.get("description") or "",
+                "date": r.get("date") or "",
+                "mediatype": r.get("mediatype") or "",
+                "item_size": item_size,
+                "item_size_formatted": _fmt_bytes(item_size),
+                "num_files": num_files,
+                "archive_url": f"https://archive.org/details/{identifier}",
+                "group": group,
+            }
+        )
+
+    payload = {
+        "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "items": items,
+        "groups": groups,
+        "group_labels": GROUP_LABELS,
+    }
+
+    out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {out.relative_to(REPO_ROOT)} — {len(items)} item(s) in {len(groups)} groups")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ia_inventory.py
+++ b/scripts/build_ia_inventory.py
@@ -123,7 +123,7 @@ def main() -> int:
             num_files = 0
 
         group = _classify(identifier)
-        groups.setdefault(group, []).append(identifier)
+        groups[group].append(identifier)
         items.append(
             {
                 "identifier": identifier,

--- a/web/public/data/ia_inventory.json
+++ b/web/public/data/ia_inventory.json
@@ -1,0 +1,16 @@
+{
+  "generated_at": "2026-05-07T00:00:00Z",
+  "items": [],
+  "groups": {
+    "raw": [],
+    "monthly_canonical": [],
+    "annual_canonical": [],
+    "supporting": []
+  },
+  "group_labels": {
+    "raw": "Espelhos brutos (ZIP)",
+    "monthly_canonical": "Canônicos mensais (Parquet)",
+    "annual_canonical": "Consolidados anuais (Parquet)",
+    "supporting": "Suporte (manifesto, feeds, dimensões)"
+  }
+}

--- a/web/scripts/build-data.mjs
+++ b/web/scripts/build-data.mjs
@@ -107,9 +107,18 @@ async function build() {
   // failure (offline build, IA outage) — the existing JSON stays put.
   console.log("Refreshing sync_stats.json from IA manifest...");
   try {
-    execSync('python3 scripts/build_sync_stats.py', { stdio: 'inherit', cwd: '..' });
+    execSync('uv run python scripts/build_sync_stats.py', { stdio: 'inherit', cwd: '..' });
   } catch (err) {
     console.warn(`sync_stats.json refresh skipped: ${err.message}`);
+  }
+
+  // Refresh public/data/ia_inventory.json from the IA search index so
+  // /arquivo renders live item counts and sizes. Same tolerance pattern.
+  console.log("Refreshing ia_inventory.json from IA search...");
+  try {
+    execSync('uv run python scripts/build_ia_inventory.py', { stdio: 'inherit', cwd: '..' });
+  } catch (err) {
+    console.warn(`ia_inventory.json refresh skipped: ${err.message}`);
   }
 
   if (!fs.existsSync(QUERIES_DIR)) fs.mkdirSync(QUERIES_DIR, { recursive: true });

--- a/web/scripts/check-bundle-size.mjs
+++ b/web/scripts/check-bundle-size.mjs
@@ -39,7 +39,7 @@ const DIST_DIR = join(__dirname, '..', 'dist', '_astro');
 // slightly altered the AST chunk boundaries. When an intentional feature
 // increases the baseline, raise this constant in the same commit and note
 // what landed.
-const BUDGET_BYTES = 365_000; // Raised to accommodate DevExamplesView (J6) and SchemaChangelogView (J5)
+const BUDGET_BYTES = 385_000; // Raised for four-resource hub pages: PublicacoesHubView, PcaHubView, AgencyLifecyclePanel, arquivo.astro (PR #577)
 
 function isClientEntryFile(name) {
   if (!name.endsWith('.js')) return false;

--- a/web/src/components/AgencyDetailView.svelte
+++ b/web/src/components/AgencyDetailView.svelte
@@ -13,6 +13,7 @@
   import EntityDetailLayout from './EntityDetailLayout.svelte';
   import EmptyState from './EmptyState.svelte';
   import CopyButton from './CopyButton.svelte';
+  import AgencyLifecyclePanel from './AgencyLifecyclePanel.svelte';
   import ShareButton from './ShareButton.svelte';
   import { setPageMeta } from '../lib/pageMeta';
   import LookbackWindow from './LookbackWindow.svelte';
@@ -295,6 +296,11 @@
           {/snippet}
         </PaginatedList>
       </section>
+    {/if}
+
+    <!-- Cross-resource lifecycle: PCA → Publicações → Atas (Task 5b) -->
+    {#if cnpjValid}
+      <AgencyLifecyclePanel {cnpj} />
     {/if}
   {/if}
 </EntityDetailLayout>

--- a/web/src/components/AgencyLifecyclePanel.svelte
+++ b/web/src/components/AgencyLifecyclePanel.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { queryArchivedTableWhere, prefetchArchive } from '../lib/parquetFallback';
+  import { resolve } from '../lib/baseUrl';
+  import { formatBRL, formatDate } from '../lib/format';
+  import type { ArchivedAta, ArchivedPublicacao, ArchivedPca } from '../lib/archive/schema';
+  import Skeleton from './Skeleton.svelte';
+
+  const { cnpj }: { cnpj: string } = $props();
+
+  // Per-resource results
+  let atas = $state<ArchivedAta[]>([]);
+  let publicacoes = $state<ArchivedPublicacao[]>([]);
+  let pca = $state<ArchivedPca[]>([]);
+
+  let loadingAtas = $state(true);
+  let loadingPublicacoes = $state(true);
+  let loadingPca = $state(true);
+
+  // Prefetch all three tables in parallel on mount
+  onMount(() => {
+    prefetchArchive('atas');
+    prefetchArchive('publicacoes');
+    prefetchArchive('pca');
+
+    queryArchivedTableWhere(
+      'atas',
+      [{ column: 'cnpj_orgao', op: 'eq', value: cnpj }],
+      { limit: 5, orderByColumn: 'data_publicacao_pncp' },
+    ).then((res) => {
+      if (res.ok) atas = res.rows as ArchivedAta[];
+      loadingAtas = false;
+    });
+
+    queryArchivedTableWhere(
+      'publicacoes',
+      [{ column: 'cnpj_orgao', op: 'eq', value: cnpj }],
+      { limit: 5, orderByColumn: 'data_publicacao_pncp' },
+    ).then((res) => {
+      if (res.ok) publicacoes = res.rows as ArchivedPublicacao[];
+      loadingPublicacoes = false;
+    });
+
+    queryArchivedTableWhere(
+      'pca',
+      [{ column: 'cnpj_orgao', op: 'eq', value: cnpj }],
+      { limit: 5 },
+    ).then((res) => {
+      if (res.ok) pca = res.rows as ArchivedPca[];
+      loadingPca = false;
+    });
+  });
+
+  const hasAnyData = $derived(atas.length > 0 || publicacoes.length > 0 || pca.length > 0);
+  const allLoaded = $derived(!loadingAtas && !loadingPublicacoes && !loadingPca);
+</script>
+
+{#if !allLoaded}
+  <section class="lifecycle" aria-labelledby="lifecycle-title">
+    <h3 id="lifecycle-title">Cadeia de contratação</h3>
+    <div class="skeleton-row"><Skeleton /><Skeleton /><Skeleton /></div>
+  </section>
+{:else if hasAnyData}
+  <section class="lifecycle" aria-labelledby="lifecycle-title">
+    <h3 id="lifecycle-title">Cadeia de contratação</h3>
+    <p class="lifecycle-sub">
+      PCA → Publicações → Atas → Contratos — todos os estágios deste órgão no arquivo.
+    </p>
+
+    <div class="panels">
+      <!-- PCA -->
+      {#if pca.length > 0}
+        <details class="panel" open>
+          <summary>
+            <span class="panel-label">PCA — Itens planejados</span>
+            <span class="panel-count">{pca.length}</span>
+          </summary>
+          <ul class="item-list">
+            {#each pca as item (item.id_pca_pncp + '-' + item.numero_item)}
+              <li class="item-row">
+                <span class="item-main">{item.descricao_item ?? item.codigo_item ?? item.id_pca_pncp}</span>
+                {#if item.valor_total != null}
+                  <span class="item-valor">{formatBRL(item.valor_total)}</span>
+                {/if}
+              </li>
+            {/each}
+          </ul>
+          <a class="panel-more" href={resolve('pca')}>Ver todos os itens PCA →</a>
+        </details>
+      {/if}
+
+      <!-- Publicações -->
+      {#if publicacoes.length > 0}
+        <details class="panel" open>
+          <summary>
+            <span class="panel-label">Publicações abertas</span>
+            <span class="panel-count">{publicacoes.length}</span>
+          </summary>
+          <ul class="item-list">
+            {#each publicacoes as pub (pub.numero_controle_pncp)}
+              <li class="item-row">
+                <a
+                  href={resolve(`busca?q=${pub.numero_controle_pncp}`)}
+                  class="item-main"
+                >
+                  {pub.objeto_compra ?? pub.numero_controle_pncp}
+                </a>
+                <span class="item-meta">
+                  {pub.modalidade_nome ?? ''}
+                  {#if pub.valor_total_estimado != null}
+                    · {formatBRL(pub.valor_total_estimado)}
+                  {/if}
+                </span>
+              </li>
+            {/each}
+          </ul>
+          <a class="panel-more" href={resolve('publicacoes')}>Ver publicações →</a>
+        </details>
+      {/if}
+
+      <!-- Atas -->
+      {#if atas.length > 0}
+        <details class="panel" open>
+          <summary>
+            <span class="panel-label">Atas em vigor</span>
+            <span class="panel-count">{atas.length}</span>
+          </summary>
+          <ul class="item-list">
+            {#each atas as ata (ata.numero_controle_pncp_ata)}
+              <li class="item-row">
+                <span class="item-main">{ata.objeto_contratacao ?? ata.numero_controle_pncp_ata}</span>
+                <span class="item-meta">
+                  {#if ata.vigencia_fim}vigência até {formatDate(ata.vigencia_fim)}{/if}
+                </span>
+              </li>
+            {/each}
+          </ul>
+          <a class="panel-more" href={resolve('atas')}>Buscar atas →</a>
+        </details>
+      {/if}
+    </div>
+  </section>
+{/if}
+
+<style>
+  .lifecycle {
+    margin-top: var(--space-6);
+    padding-top: var(--space-6);
+    border-top: 1px solid var(--color-border);
+  }
+  h3 {
+    font-size: var(--text-lg);
+    font-weight: 500;
+    margin: 0 0 var(--space-1);
+  }
+  .lifecycle-sub {
+    font-size: var(--text-sm);
+    color: var(--color-text-dim);
+    margin: 0 0 var(--space-4);
+  }
+  .panels {
+    display: grid;
+    gap: var(--space-3);
+  }
+  .panel {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: var(--space-3);
+  }
+  summary {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    list-style: none;
+    user-select: none;
+  }
+  summary::-webkit-details-marker { display: none; }
+  .panel-label {
+    font-weight: 500;
+    font-size: var(--text-sm);
+  }
+  .panel-count {
+    font-size: var(--text-xs);
+    background: var(--color-border);
+    border-radius: 999px;
+    padding: 2px 8px;
+    color: var(--color-text-dim);
+  }
+  .item-list {
+    list-style: none;
+    padding: 0;
+    margin: var(--space-3) 0 var(--space-2);
+    display: grid;
+    gap: var(--space-2);
+  }
+  .item-row {
+    display: grid;
+    gap: 2px;
+    padding: var(--space-2) 0;
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--text-sm);
+  }
+  .item-row:last-child { border-bottom: none; }
+  .item-main {
+    color: var(--color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  a.item-main { text-decoration: none; color: var(--color-primary); }
+  a.item-main:hover { text-decoration: underline; }
+  .item-valor, .item-meta {
+    font-size: var(--text-xs);
+    color: var(--color-text-dim);
+  }
+  .panel-more {
+    font-size: var(--text-xs);
+    color: var(--color-text-dim);
+    text-decoration: none;
+    display: block;
+    text-align: right;
+    margin-top: var(--space-1);
+  }
+  .panel-more:hover { text-decoration: underline; }
+  .skeleton-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: var(--space-3);
+  }
+</style>

--- a/web/src/components/AgencyLifecyclePanel.svelte
+++ b/web/src/components/AgencyLifecyclePanel.svelte
@@ -23,10 +23,15 @@
     prefetchArchive('publicacoes');
     prefetchArchive('pca');
 
+    const today = new Date().toISOString().slice(0, 10);
+
     queryArchivedTableWhere(
       'atas',
-      [{ column: 'cnpj_orgao', op: 'eq', value: cnpj }],
-      { limit: 5, orderByColumn: 'data_publicacao_pncp' },
+      [
+        { column: 'cnpj_orgao', op: 'eq', value: cnpj },
+        { column: 'vigencia_fim', op: 'gte', value: today },
+      ],
+      { limit: 5, orderByColumn: 'vigencia_fim' },
     ).then((res) => {
       if (res.ok) atas = res.rows as ArchivedAta[];
       loadingAtas = false;
@@ -34,8 +39,11 @@
 
     queryArchivedTableWhere(
       'publicacoes',
-      [{ column: 'cnpj_orgao', op: 'eq', value: cnpj }],
-      { limit: 5, orderByColumn: 'data_publicacao_pncp' },
+      [
+        { column: 'cnpj_orgao', op: 'eq', value: cnpj },
+        { column: 'data_encerramento_proposta', op: 'gte', value: today },
+      ],
+      { limit: 5, orderByColumn: 'data_encerramento_proposta' },
     ).then((res) => {
       if (res.ok) publicacoes = res.rows as ArchivedPublicacao[];
       loadingPublicacoes = false;

--- a/web/src/components/AgencyLifecyclePanel.svelte
+++ b/web/src/components/AgencyLifecyclePanel.svelte
@@ -35,7 +35,7 @@
     ).then((res) => {
       if (res.ok) atas = res.rows as ArchivedAta[];
       loadingAtas = false;
-    });
+    }).catch(() => { loadingAtas = false; });
 
     queryArchivedTableWhere(
       'publicacoes',
@@ -47,7 +47,7 @@
     ).then((res) => {
       if (res.ok) publicacoes = res.rows as ArchivedPublicacao[];
       loadingPublicacoes = false;
-    });
+    }).catch(() => { loadingPublicacoes = false; });
 
     queryArchivedTableWhere(
       'pca',
@@ -56,7 +56,7 @@
     ).then((res) => {
       if (res.ok) pca = res.rows as ArchivedPca[];
       loadingPca = false;
-    });
+    }).catch(() => { loadingPca = false; });
   });
 
   const hasAnyData = $derived(atas.length > 0 || publicacoes.length > 0 || pca.length > 0);

--- a/web/src/components/Dashboard.svelte
+++ b/web/src/components/Dashboard.svelte
@@ -2,7 +2,7 @@
   import StatCard from './StatCard.svelte';
   import AlertBanner from './AlertBanner.svelte';
   import Skeleton from './Skeleton.svelte';
-  import { SyncStatsSchema, type SyncStats } from '../schema';
+  import { SyncStatsSchema, type SyncStats, type ResourceStats } from '../schema';
   import { formatInteger, formatRelativeTime } from '../lib/format';
   import { resolve } from '../lib/baseUrl';
   import { onMount } from 'svelte';
@@ -22,7 +22,6 @@
       const raw = await res.json();
       stats = SyncStatsSchema.parse(raw);
     } catch (e) {
-      // Keep the SSR'd initialStats visible if the refresh fetch fails.
       if (!stats) error = (e as Error).message;
     } finally {
       loading = false;
@@ -30,6 +29,53 @@
   }
 
   onMount(loadStats);
+
+  // Temporal spine order: intent → open → reusable → final.
+  const RESOURCE_ORDER = ['pca', 'publicacoes', 'atas', 'contratos'] as const;
+
+  const RESOURCE_META: Record<string, { label: string; hint: string; href: string }> = {
+    pca: {
+      label: 'PCA',
+      hint: 'planos anuais de contratação arquivados',
+      href: resolve('pca'),
+    },
+    publicacoes: {
+      label: 'Publicações',
+      hint: 'oportunidades em aberto arquivadas',
+      href: resolve('publicacoes'),
+    },
+    atas: {
+      label: 'Atas',
+      hint: 'atas de registro de preços arquivadas',
+      href: resolve('atas'),
+    },
+    contratos: {
+      label: 'Contratos',
+      hint: 'contratos citáveis com permalink arquivado',
+      href: resolve('busca'),
+    },
+  };
+
+  function buildTiles(resources: Record<string, ResourceStats> | undefined) {
+    if (!resources) return null;
+    return RESOURCE_ORDER.map((k) => {
+      const meta = RESOURCE_META[k]!;
+      const r = resources[k];
+      const hasData = r != null && r.row_count > 0;
+      return {
+        key: k,
+        label: meta.label,
+        value: hasData ? formatInteger(r.row_count) : 'Sem dados',
+        hint: hasData
+          ? `${r.partition_count} partições · ${meta.hint}`
+          : `${meta.hint} — aguardando primeira sincronização`,
+        href: meta.href,
+        tone: hasData ? ('default' as const) : ('warning' as const),
+      };
+    });
+  }
+
+  const tiles = $derived(buildTiles(stats?.resources));
 </script>
 
 {#if error}
@@ -39,29 +85,58 @@
   </div>
 {:else if loading}
   <div class="grid" aria-busy="true" aria-label="Carregando estatísticas">
-    {#each [1, 2, 3] as _, i (i)}
+    {#each [1, 2, 3, 4] as _, i (i)}
       <Skeleton />
     {/each}
   </div>
 {:else if stats}
-  <div class="grid">
-    <StatCard
-      title="Contratos citáveis"
-      value={formatInteger(stats.total_contracts)}
-      hint="cada um com permalink e snapshot arquivado"
-    />
-    <StatCard
-      title="Dias no Internet Archive"
-      value={formatInteger(stats.days_on_ia)}
-      hint={stats.generated_at ? `Atualizado ${formatRelativeTime(stats.generated_at)}` : 'fora do alcance de qualquer servidor único'}
-    />
-    <StatCard
-      title="Em quarentena"
-      value={formatInteger(stats.total_quarantine)}
-      tone="warning"
-      hint="anomalias sinalizadas — entenda o critério"
-      href={resolve('sobre#quarentena')}
-    />
-  </div>
+  {#if tiles}
+    <div class="grid">
+      {#each tiles as tile (tile.key)}
+        <StatCard
+          title={tile.label}
+          value={tile.value}
+          hint={tile.hint}
+          tone={tile.tone}
+          href={tile.href}
+        />
+      {/each}
+    </div>
+  {:else}
+    <div class="grid">
+      <StatCard
+        title="Contratos citáveis"
+        value={formatInteger(stats.total_contracts)}
+        hint="cada um com permalink e snapshot arquivado"
+      />
+      <StatCard
+        title="Dias no Internet Archive"
+        value={formatInteger(stats.days_on_ia)}
+        hint={stats.generated_at ? `Atualizado ${formatRelativeTime(stats.generated_at)}` : 'fora do alcance de qualquer servidor único'}
+      />
+      <StatCard
+        title="Em quarentena"
+        value={formatInteger(stats.total_quarantine)}
+        tone="warning"
+        hint="anomalias sinalizadas — entenda o critério"
+        href={resolve('sobre#quarentena')}
+      />
+    </div>
+  {/if}
+  {#if stats.generated_at}
+    <p class="update-hint">
+      Atualizado {formatRelativeTime(stats.generated_at)} ·
+      <a href={resolve('status')}>status do arquivo</a> ·
+      <a href={resolve('arquivo')}>coleção no Internet Archive</a>
+    </p>
+  {/if}
 {/if}
 
+<style>
+  .update-hint {
+    font-size: var(--text-sm);
+    color: var(--color-text-dim);
+    margin-top: var(--space-3);
+    text-align: center;
+  }
+</style>

--- a/web/src/components/PcaHubView.svelte
+++ b/web/src/components/PcaHubView.svelte
@@ -77,7 +77,7 @@
       O PCA consolida o que cada órgão pretende comprar no exercício. É a demanda
       <em>antes</em> da licitação — o estágio mais cedo da cadeia de contratações públicas.
       Baliza espelha o endpoint <code>/v1/pca/atualizacao</code> com partição anual,
-      gerando <code>raw-pca-{'{'}YYYY{'}'}.zip</code> e o canônico <code>annual_canonical</code>.
+      gerando <code>raw-pca-{'{'}YYYY}.zip</code> e o canônico <code>annual_canonical</code>.
     </p>
     <div class="role-tag">
       Papel no atlas: <strong>intenção de demanda</strong> → primeiro elo da cadeia
@@ -180,7 +180,7 @@
         ['pdm_descricao','VARCHAR','PDM (descrição)'],
         ['data_desejada','VARCHAR','Data desejada de contratação'],
         ['data_particao','VARCHAR','Partição YYYY (ano)'],
-      ] as col}
+      ] as col (col[0])}
         <div class="col-row">
           <code class="col-name">{col[0]}</code>
           <span class="col-type">{col[1]}</span>

--- a/web/src/components/PcaHubView.svelte
+++ b/web/src/components/PcaHubView.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { SyncStatsSchema } from '../schema';
+  import { getLatestParquetInfo } from '../lib/ia-manifest';
+  import { getDuckDB } from '../lib/duckdb';
+  import { resolve } from '../lib/baseUrl';
+  import { formatInteger, formatBRL } from '../lib/format';
+  import AlertBanner from './AlertBanner.svelte';
+  import Skeleton from './Skeleton.svelte';
+  import StatCard from './StatCard.svelte';
+
+  interface CatalogoRow {
+    classificacao_superior_nome: string;
+    n: number;
+    valor_total: number;
+  }
+
+  let stats = $state<{ row_count: number; partition_count: number } | null>(null);
+  let catalogo = $state<CatalogoRow[]>([]);
+  let parquetParticao = $state<string | null>(null);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+  let noData = $state(false);
+
+  onMount(async () => {
+    try {
+      const res = await fetch(resolve('data/sync_stats.json'));
+      if (res.ok) {
+        const raw = await res.json();
+        const parsed = SyncStatsSchema.parse(raw);
+        const r = parsed.resources?.['pca'];
+        if (r) stats = { row_count: r.row_count, partition_count: r.partition_count };
+      }
+    } catch { /* non-fatal */ }
+
+    try {
+      const info = await getLatestParquetInfo('pca');
+      if (!info) { noData = true; loading = false; return; }
+      parquetParticao = info.dataParticao;
+
+      const { conn } = await getDuckDB();
+      const url = info.url;
+      const sql = `SELECT
+        COALESCE(classificacao_superior_nome, 'Sem classificação') AS classificacao_superior_nome,
+        COUNT(*) AS n,
+        COALESCE(SUM(valor_total), 0) AS valor_total
+      FROM read_parquet('${url.replace(/'/g, "''")}')
+      GROUP BY classificacao_superior_nome
+      ORDER BY valor_total DESC
+      LIMIT 25`;
+
+      const result = await conn.query(sql);
+      const rows: CatalogoRow[] = [];
+      for (const batch of result.batches) {
+        for (let i = 0; i < batch.numRows; i++) {
+          rows.push({
+            classificacao_superior_nome: String(batch.getChildAt(0)?.get(i) ?? ''),
+            n: Number(batch.getChildAt(1)?.get(i) ?? 0),
+            valor_total: Number(batch.getChildAt(2)?.get(i) ?? 0),
+          });
+        }
+      }
+      catalogo = rows;
+    } catch (e) {
+      error = (e as Error).message;
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<main class="hub container">
+  <header class="hub-header">
+    <p class="eyebrow">Recurso PNCP</p>
+    <h1>Plano de Contratações Anuais (PCA)</h1>
+    <p class="lead">
+      O PCA consolida o que cada órgão pretende comprar no exercício. É a demanda
+      <em>antes</em> da licitação — o estágio mais cedo da cadeia de contratações públicas.
+      Baliza espelha o endpoint <code>/v1/pca/atualizacao</code> com partição anual,
+      gerando <code>raw-pca-{'{'}YYYY{'}'}.zip</code> e o canônico <code>annual_canonical</code>.
+    </p>
+    <div class="role-tag">
+      Papel no atlas: <strong>intenção de demanda</strong> → primeiro elo da cadeia
+      PCA → Publicações → Atas → Contratos
+    </div>
+  </header>
+
+  <!-- Stats -->
+  {#if stats && stats.row_count > 0}
+    <div class="grid stats-grid">
+      <StatCard
+        title="Itens de PCA arquivados"
+        value={formatInteger(stats.row_count)}
+        hint={`${stats.partition_count} anos no Internet Archive`}
+      />
+      <StatCard
+        title="Anos arquivados"
+        value={formatInteger(stats.partition_count)}
+        hint="cada partição = um ano calendário do PCA federal"
+      />
+    </div>
+  {:else}
+    <div class="empty-state" role="status">
+      <p>
+        Ainda sem partições publicadas — o pipeline <code>pncp-mirror-pca</code>
+        executa semanalmente às 06:00 UTC (segunda-feira). Volte em breve ou
+        <a href="https://github.com/franklinbaldo/baliza/actions" target="_blank" rel="noopener">acompanhe o CI ↗</a>.
+      </p>
+    </div>
+  {/if}
+
+  <!-- Catálogo por classificação (Task 5d) -->
+  <section class="breakdown" aria-labelledby="catalogo-title">
+    <h2 id="catalogo-title">Demanda por classificação de material/serviço</h2>
+    <p class="section-desc">
+      Itens do PCA agrupados por <code>classificacao_superior_nome</code> (hierarquia CATMAT/CATSER),
+      ordenados por valor total planejado. Útil para pesquisadores projetando gasto público por categoria.
+    </p>
+
+    {#if loading}
+      <div class="skeleton-rows">
+        {#each [1,2,3,4,5] as _, i (i)}<Skeleton />{/each}
+      </div>
+    {:else if error}
+      <AlertBanner title="Erro ao consultar parquet" message={error} level="error" />
+    {:else if noData || catalogo.length === 0}
+      <p class="no-data">
+        Sem dados de catálogo ainda.
+        {parquetParticao
+          ? `Snapshot mais recente: ${parquetParticao}`
+          : 'Nenhum parquet disponível no manifesto.'}
+      </p>
+    {:else}
+      {#if parquetParticao}
+        <p class="snapshot-note">Snapshot: <code>{parquetParticao}</code></p>
+      {/if}
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Classificação</th>
+              <th class="num">Itens</th>
+              <th class="num">Valor total planejado</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each catalogo as row (row.classificacao_superior_nome)}
+              <tr>
+                <td>{row.classificacao_superior_nome}</td>
+                <td class="num">{formatInteger(row.n)}</td>
+                <td class="num">{formatBRL(row.valor_total)}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
+  </section>
+
+  <!-- Schema reference -->
+  <section class="schema-panel" aria-labelledby="schema-title">
+    <h2 id="schema-title">Esquema do dataset</h2>
+    <p class="section-desc">
+      Chave primária composta: <code>(id_pca_pncp, numero_item)</code>.
+      Partição anual: <code>data_particao = YYYY</code>.
+    </p>
+    <div class="schema-cols">
+      {#each [
+        ['id_pca_pncp','VARCHAR','ID do PCA no PNCP'],
+        ['numero_item','INTEGER','Número do item dentro do PCA'],
+        ['ano_pca','INTEGER','Ano do plano'],
+        ['cnpj_orgao','VARCHAR','CNPJ do órgão'],
+        ['razao_social_orgao','VARCHAR','Nome do órgão'],
+        ['descricao_item','VARCHAR','Descrição do item planejado'],
+        ['valor_total','DOUBLE','Valor total planejado (R$)'],
+        ['quantidade_estimada','DOUBLE','Quantidade estimada'],
+        ['classificacao_superior_codigo','VARCHAR','Código CATMAT/CATSER'],
+        ['classificacao_superior_nome','VARCHAR','Descrição da classificação'],
+        ['pdm_codigo','VARCHAR','PDM (código)'],
+        ['pdm_descricao','VARCHAR','PDM (descrição)'],
+        ['data_desejada','VARCHAR','Data desejada de contratação'],
+        ['data_particao','VARCHAR','Partição YYYY (ano)'],
+      ] as col}
+        <div class="col-row">
+          <code class="col-name">{col[0]}</code>
+          <span class="col-type">{col[1]}</span>
+          <span class="col-desc">{col[2]}</span>
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <!-- Archive links -->
+  <section class="archive-links" aria-labelledby="archive-title">
+    <h2 id="archive-title">Acesso ao arquivo</h2>
+    <ul>
+      <li>
+        <a href="https://archive.org/details/baliza-pncp-2024" target="_blank" rel="noopener">
+          Item PCA 2024 no Internet Archive ↗
+        </a>
+      </li>
+      <li><a href={resolve('arquivo')}>Catálogo completo da coleção Baliza</a></li>
+      <li><a href={resolve('explorador')}>Consultar via SQL no navegador (DuckDB)</a></li>
+      <li><a href={resolve('desenvolvedores')}>URLs estáveis para Python, R, JS</a></li>
+    </ul>
+  </section>
+</main>
+
+<style>
+  .hub { max-width: 860px; margin: 0 auto; padding: var(--space-8) var(--space-4); }
+  .hub-header { margin-bottom: var(--space-8); }
+  .eyebrow { font-size: var(--text-sm); text-transform: uppercase; letter-spacing: .08em; color: var(--color-text-dim); margin: 0 0 var(--space-2); }
+  h1 { font-size: clamp(28px,3vw,42px); font-weight: 300; margin: 0 0 var(--space-3); }
+  .lead { font-size: var(--text-md); color: var(--color-text-dim); line-height: 1.6; margin: 0 0 var(--space-3); }
+  .role-tag { font-size: var(--text-sm); background: var(--color-surface); border: 1px solid var(--color-border); border-left: 4px solid var(--color-azul); padding: var(--space-2) var(--space-3); border-radius: 0 4px 4px 0; }
+  .stats-grid { margin-bottom: var(--space-6); }
+  .empty-state { background: var(--color-surface); border: 1px dashed var(--color-border); padding: var(--space-6); text-align: center; border-radius: 4px; margin-bottom: var(--space-6); }
+  section { margin-bottom: var(--space-8); padding-top: var(--space-6); border-top: 1px solid var(--color-border); }
+  h2 { font-size: var(--text-xl); font-weight: 400; margin: 0 0 var(--space-2); }
+  .section-desc { font-size: var(--text-sm); color: var(--color-text-dim); margin: 0 0 var(--space-4); }
+  .snapshot-note { font-size: var(--text-xs); color: var(--color-text-dim); margin: 0 0 var(--space-3); }
+  .no-data { color: var(--color-text-dim); font-style: italic; }
+  .table-wrap { overflow-x: auto; }
+  table { width: 100%; border-collapse: collapse; font-size: var(--text-sm); }
+  th, td { text-align: left; padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--color-border); }
+  th { font-weight: 600; color: var(--color-text-dim); font-size: var(--text-xs); text-transform: uppercase; letter-spacing: .06em; }
+  .num { text-align: right; }
+  .schema-cols { display: grid; gap: var(--space-1); }
+  .col-row { display: grid; grid-template-columns: 220px 90px 1fr; gap: var(--space-2); padding: var(--space-1) 0; font-size: var(--text-sm); border-bottom: 1px solid var(--color-border); align-items: baseline; }
+  .col-name { font-size: var(--text-xs); }
+  .col-type { color: var(--color-text-dim); font-size: var(--text-xs); }
+  .col-desc { color: var(--color-text-dim); font-size: var(--text-xs); }
+  .archive-links ul { list-style: none; padding: 0; margin: 0; display: grid; gap: var(--space-2); }
+  .archive-links li { font-size: var(--text-sm); }
+  .skeleton-rows { display: grid; gap: var(--space-2); }
+</style>

--- a/web/src/components/PcaHubView.svelte
+++ b/web/src/components/PcaHubView.svelte
@@ -3,6 +3,7 @@
   import { SyncStatsSchema } from '../schema';
   import { getLatestParquetInfo } from '../lib/ia-manifest';
   import { getDuckDB } from '../lib/duckdb';
+  import { escapeSqlLiteral } from '../lib/parquetFallback';
   import { resolve } from '../lib/baseUrl';
   import { formatInteger, formatBRL } from '../lib/format';
   import AlertBanner from './AlertBanner.svelte';
@@ -44,7 +45,7 @@
         COALESCE(classificacao_superior_nome, 'Sem classificação') AS classificacao_superior_nome,
         COUNT(*) AS n,
         COALESCE(SUM(valor_total), 0) AS valor_total
-      FROM read_parquet('${url.replace(/'/g, "''")}')
+      FROM read_parquet('${escapeSqlLiteral(url)}')
       GROUP BY classificacao_superior_nome
       ORDER BY valor_total DESC
       LIMIT 25`;

--- a/web/src/components/PublicacoesHubView.svelte
+++ b/web/src/components/PublicacoesHubView.svelte
@@ -3,6 +3,7 @@
   import { SyncStatsSchema } from '../schema';
   import { getLatestParquetInfo } from '../lib/ia-manifest';
   import { getDuckDB } from '../lib/duckdb';
+  import { escapeSqlLiteral } from '../lib/parquetFallback';
   import { resolve } from '../lib/baseUrl';
   import { formatInteger, formatBRL } from '../lib/format';
   import AlertBanner from './AlertBanner.svelte';
@@ -46,7 +47,7 @@
         COALESCE(modalidade_nome, 'Desconhecida') AS modalidade_nome,
         COUNT(*) AS n,
         COALESCE(SUM(valor_total_estimado), 0) AS valor_total
-      FROM read_parquet('${url.replace(/'/g, "''")}')
+      FROM read_parquet('${escapeSqlLiteral(url)}')
       GROUP BY modalidade_nome
       ORDER BY n DESC
       LIMIT 20`;

--- a/web/src/components/PublicacoesHubView.svelte
+++ b/web/src/components/PublicacoesHubView.svelte
@@ -1,0 +1,240 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { SyncStatsSchema } from '../schema';
+  import { getLatestParquetInfo } from '../lib/ia-manifest';
+  import { getDuckDB } from '../lib/duckdb';
+  import { resolve } from '../lib/baseUrl';
+  import { formatInteger, formatBRL } from '../lib/format';
+  import AlertBanner from './AlertBanner.svelte';
+  import Skeleton from './Skeleton.svelte';
+  import StatCard from './StatCard.svelte';
+
+  interface ModalidadeRow {
+    modalidade_nome: string;
+    n: number;
+    valor_total: number;
+  }
+
+  let stats = $state<{ row_count: number; partition_count: number } | null>(null);
+  let modalidades = $state<ModalidadeRow[]>([]);
+  let parquetParticao = $state<string | null>(null);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+  let noData = $state(false);
+
+  onMount(async () => {
+    // Load aggregate stats from sync_stats.json
+    try {
+      const res = await fetch(resolve('data/sync_stats.json'));
+      if (res.ok) {
+        const raw = await res.json();
+        const parsed = SyncStatsSchema.parse(raw);
+        const r = parsed.resources?.['publicacoes'];
+        if (r) stats = { row_count: r.row_count, partition_count: r.partition_count };
+      }
+    } catch { /* non-fatal */ }
+
+    // Load modalidade breakdown from archived parquet
+    try {
+      const info = await getLatestParquetInfo('publicacoes');
+      if (!info) { noData = true; loading = false; return; }
+      parquetParticao = info.dataParticao;
+
+      const { conn } = await getDuckDB();
+      const url = info.url;
+      const sql = `SELECT
+        COALESCE(modalidade_nome, 'Desconhecida') AS modalidade_nome,
+        COUNT(*) AS n,
+        COALESCE(SUM(valor_total_estimado), 0) AS valor_total
+      FROM read_parquet('${url.replace(/'/g, "''")}')
+      GROUP BY modalidade_nome
+      ORDER BY n DESC
+      LIMIT 20`;
+
+      const result = await conn.query(sql);
+      const rows: ModalidadeRow[] = [];
+      for (const batch of result.batches) {
+        for (let i = 0; i < batch.numRows; i++) {
+          rows.push({
+            modalidade_nome: String(batch.getChildAt(0)?.get(i) ?? ''),
+            n: Number(batch.getChildAt(1)?.get(i) ?? 0),
+            valor_total: Number(batch.getChildAt(2)?.get(i) ?? 0),
+          });
+        }
+      }
+      modalidades = rows;
+    } catch (e) {
+      error = (e as Error).message;
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<main class="hub container">
+  <header class="hub-header">
+    <p class="eyebrow">Recurso PNCP</p>
+    <h1>Publicações</h1>
+    <p class="lead">
+      Contratações abertas no PNCP — o ponto de entrada para oportunidades em curso.
+      Cada publicação representa uma licitação ou contratação cujo prazo de proposta ainda não encerrou.
+      Baliza espelha o endpoint <code>/v1/contratacoes/publicacao</code> com fan-out por modalidade (IDs 1–14),
+      gerando partições mensais <code>raw-publicacoes-{'{'}YYYY-MM{'}'}.zip</code>.
+    </p>
+    <div class="role-tag">
+      Papel no atlas: <strong>oportunidade em aberto</strong> → posição <em>antes</em> de contratos e atas
+    </div>
+  </header>
+
+  <!-- Stats -->
+  {#if stats && stats.row_count > 0}
+    <div class="grid stats-grid">
+      <StatCard
+        title="Publicações arquivadas"
+        value={formatInteger(stats.row_count)}
+        hint={`${stats.partition_count} partições mensais no Internet Archive`}
+      />
+      <StatCard
+        title="Partições"
+        value={formatInteger(stats.partition_count)}
+        hint="cada partição = um mês de publicações do PNCP"
+      />
+    </div>
+  {:else}
+    <div class="empty-state" role="status">
+      <p>
+        Ainda sem partições publicadas — o pipeline <code>pncp-mirror-publicacoes</code>
+        executa diariamente às 05:00 UTC. Volte em breve ou
+        <a href="https://github.com/franklinbaldo/baliza/actions" target="_blank" rel="noopener">acompanhe o CI ↗</a>.
+      </p>
+    </div>
+  {/if}
+
+  <!-- Modalidade breakdown (Task 5c) -->
+  <section class="breakdown" aria-labelledby="modalidade-title">
+    <h2 id="modalidade-title">Contratações por modalidade</h2>
+    <p class="section-desc">
+      Publicações agrupadas por <code>modalidade_id</code> no snapshot mais recente.
+      A modalidade determina o rito: dispensa, pregão, concorrência etc.
+    </p>
+
+    {#if loading}
+      <div class="skeleton-rows">
+        {#each [1,2,3,4,5] as _, i (i)}<Skeleton />{/each}
+      </div>
+    {:else if error}
+      <AlertBanner title="Erro ao consultar parquet" message={error} level="error" />
+    {:else if noData || modalidades.length === 0}
+      <p class="no-data">
+        Sem dados de modalidade ainda.
+        {parquetParticao
+          ? `Snapshot mais recente: ${parquetParticao}`
+          : 'Nenhum parquet disponível no manifesto.'}
+      </p>
+    {:else}
+      {#if parquetParticao}
+        <p class="snapshot-note">Snapshot: <code>{parquetParticao}</code></p>
+      {/if}
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Modalidade</th>
+              <th class="num">Publicações</th>
+              <th class="num">Valor estimado total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each modalidades as row (row.modalidade_nome)}
+              <tr>
+                <td>{row.modalidade_nome}</td>
+                <td class="num">{formatInteger(row.n)}</td>
+                <td class="num">{formatBRL(row.valor_total)}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
+  </section>
+
+  <!-- Schema reference -->
+  <section class="schema-panel" aria-labelledby="schema-title">
+    <h2 id="schema-title">Esquema do dataset</h2>
+    <p class="section-desc">
+      Colunas disponíveis no Parquet arquivado. Chave primária: <code>numero_controle_pncp</code>.
+    </p>
+    <div class="schema-cols">
+      {#each [
+        ['numero_controle_pncp','VARCHAR','PK — identificador único'],
+        ['cnpj_orgao','VARCHAR','CNPJ do órgão contratante'],
+        ['razao_social_orgao','VARCHAR','Nome do órgão'],
+        ['modalidade_id','INTEGER','Código da modalidade (1–14)'],
+        ['modalidade_nome','VARCHAR','Nome da modalidade'],
+        ['objeto_compra','VARCHAR','Objeto da contratação'],
+        ['valor_total_estimado','DOUBLE','Valor estimado (R$)'],
+        ['data_publicacao_pncp','VARCHAR','Data de publicação no PNCP'],
+        ['data_abertura_proposta','VARCHAR','Abertura de propostas'],
+        ['data_encerramento_proposta','VARCHAR','Encerramento de propostas'],
+        ['uf_sigla','VARCHAR','UF do órgão'],
+        ['data_particao','VARCHAR','Partição YYYY-MM'],
+      ] as col}
+        <div class="col-row">
+          <code class="col-name">{col[0]}</code>
+          <span class="col-type">{col[1]}</span>
+          <span class="col-desc">{col[2]}</span>
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <!-- Archive links -->
+  <section class="archive-links" aria-labelledby="archive-title">
+    <h2 id="archive-title">Acesso ao arquivo</h2>
+    <ul>
+      <li>
+        <a href="https://archive.org/search?query=subject%3Abaliza-pncp+identifier%3Abaliza-pncp-*" target="_blank" rel="noopener">
+          Itens mensais no Internet Archive ↗
+        </a>
+      </li>
+      <li>
+        <a href={resolve('arquivo')}>Catálogo completo da coleção Baliza</a>
+      </li>
+      <li>
+        <a href={resolve('explorador')}>Consultar via SQL no navegador (DuckDB)</a>
+      </li>
+      <li>
+        <a href={resolve('desenvolvedores')}>URLs estáveis para Python, R, JS</a>
+      </li>
+    </ul>
+  </section>
+</main>
+
+<style>
+  .hub { max-width: 860px; margin: 0 auto; padding: var(--space-8) var(--space-4); }
+  .hub-header { margin-bottom: var(--space-8); }
+  .eyebrow { font-size: var(--text-sm); text-transform: uppercase; letter-spacing: .08em; color: var(--color-text-dim); margin: 0 0 var(--space-2); }
+  h1 { font-size: clamp(28px,3vw,42px); font-weight: 300; margin: 0 0 var(--space-3); }
+  .lead { font-size: var(--text-md); color: var(--color-text-dim); line-height: 1.6; margin: 0 0 var(--space-3); }
+  .role-tag { font-size: var(--text-sm); background: var(--color-surface); border: 1px solid var(--color-border); border-left: 4px solid var(--color-verde); padding: var(--space-2) var(--space-3); border-radius: 0 4px 4px 0; }
+  .stats-grid { margin-bottom: var(--space-6); }
+  .empty-state { background: var(--color-surface); border: 1px dashed var(--color-border); padding: var(--space-6); text-align: center; border-radius: 4px; margin-bottom: var(--space-6); }
+  section { margin-bottom: var(--space-8); padding-top: var(--space-6); border-top: 1px solid var(--color-border); }
+  h2 { font-size: var(--text-xl); font-weight: 400; margin: 0 0 var(--space-2); }
+  .section-desc { font-size: var(--text-sm); color: var(--color-text-dim); margin: 0 0 var(--space-4); }
+  .snapshot-note { font-size: var(--text-xs); color: var(--color-text-dim); margin: 0 0 var(--space-3); }
+  .no-data { color: var(--color-text-dim); font-style: italic; }
+  .table-wrap { overflow-x: auto; }
+  table { width: 100%; border-collapse: collapse; font-size: var(--text-sm); }
+  th, td { text-align: left; padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--color-border); }
+  th { font-weight: 600; color: var(--color-text-dim); font-size: var(--text-xs); text-transform: uppercase; letter-spacing: .06em; }
+  .num { text-align: right; }
+  .schema-cols { display: grid; gap: var(--space-1); }
+  .col-row { display: grid; grid-template-columns: 220px 90px 1fr; gap: var(--space-2); padding: var(--space-1) 0; font-size: var(--text-sm); border-bottom: 1px solid var(--color-border); align-items: baseline; }
+  .col-name { font-size: var(--text-xs); }
+  .col-type { color: var(--color-text-dim); font-size: var(--text-xs); }
+  .col-desc { color: var(--color-text-dim); font-size: var(--text-xs); }
+  .archive-links ul { list-style: none; padding: 0; margin: 0; display: grid; gap: var(--space-2); }
+  .archive-links li { font-size: var(--text-sm); }
+  .skeleton-rows { display: grid; gap: var(--space-2); }
+</style>

--- a/web/src/components/PublicacoesHubView.svelte
+++ b/web/src/components/PublicacoesHubView.svelte
@@ -79,7 +79,7 @@
       Contratações abertas no PNCP — o ponto de entrada para oportunidades em curso.
       Cada publicação representa uma licitação ou contratação cujo prazo de proposta ainda não encerrou.
       Baliza espelha o endpoint <code>/v1/contratacoes/publicacao</code> com fan-out por modalidade (IDs 1–14),
-      gerando partições mensais <code>raw-publicacoes-{'{'}YYYY-MM{'}'}.zip</code>.
+      gerando partições mensais <code>raw-publicacoes-{'{'}YYYY-MM}.zip</code>.
     </p>
     <div class="role-tag">
       Papel no atlas: <strong>oportunidade em aberto</strong> → posição <em>antes</em> de contratos e atas
@@ -178,7 +178,7 @@
         ['data_encerramento_proposta','VARCHAR','Encerramento de propostas'],
         ['uf_sigla','VARCHAR','UF do órgão'],
         ['data_particao','VARCHAR','Partição YYYY-MM'],
-      ] as col}
+      ] as col (col[0])}
         <div class="col-row">
           <code class="col-name">{col[0]}</code>
           <span class="col-type">{col[1]}</span>

--- a/web/src/lib/homepage-content.ts
+++ b/web/src/lib/homepage-content.ts
@@ -21,11 +21,19 @@ export interface HomepageSqlExample {
 export const HOMEPAGE_SQL_EXAMPLES: HomepageSqlExample[] = [
   {
     label: "Top 10 fornecedores/mês",
-    sql: "SELECT nome_fornecedor, SUM(valor_total) as total FROM read_parquet('IA_URL') GROUP BY 1 ORDER BY 2 DESC LIMIT 10",
+    sql: "SELECT nome_razao_social_fornecedor AS fornecedor, COUNT(*) AS contratos, SUM(valor_global) AS total\nFROM read_parquet('IA_URL')\nGROUP BY 1 ORDER BY 2 DESC LIMIT 10",
   },
   {
-    label: "Compras emergenciais",
-    sql: "SELECT * FROM read_parquet('IA_URL') WHERE compra_emergencial = true",
+    label: "Publicações por modalidade",
+    sql: "SELECT modalidade_nome, COUNT(*) AS n, SUM(valor_total_estimado) AS valor_total\nFROM read_parquet('IA_URL')\nGROUP BY modalidade_nome ORDER BY n DESC LIMIT 14",
+  },
+  {
+    label: "PCA por classificação",
+    sql: "SELECT classificacao_superior_nome, COUNT(*) AS itens, SUM(valor_total) AS valor_planejado\nFROM read_parquet('IA_URL')\nGROUP BY classificacao_superior_nome ORDER BY valor_planejado DESC LIMIT 20",
+  },
+  {
+    label: "Atas vigentes",
+    sql: "SELECT numero_controle_pncp_ata, objeto_contratacao, vigencia_fim\nFROM read_parquet('IA_URL')\nWHERE vigencia_fim >= CURRENT_DATE::VARCHAR\nORDER BY vigencia_fim ASC LIMIT 20",
   },
 ];
 

--- a/web/src/lib/ogManifest.ts
+++ b/web/src/lib/ogManifest.ts
@@ -30,6 +30,9 @@ export const OG_ROUTES: ReadonlyArray<OgRoute> = [
   { slug: 'orgao', pathname: '/orgao', title: 'Painel do Órgão', subtitle: 'Histórico de contratações de um órgão público.' },
   { slug: 'fornecedor', pathname: '/fornecedor', title: 'Painel do Fornecedor', subtitle: 'Histórico de contratos arquivados do fornecedor.' },
   { slug: 'municipio', pathname: '/municipio', title: 'Painel do Município', subtitle: 'Contratações registradas pelo município.' },
+  { slug: 'publicacoes', pathname: '/publicacoes', title: 'Publicações PNCP', subtitle: 'Contratações abertas arquivadas — oportunidades em curso.' },
+  { slug: 'pca', pathname: '/pca', title: 'PCA — Plano de Contratações', subtitle: 'Intenção de demanda dos órgãos federais arquivada.' },
+  { slug: 'arquivo', pathname: '/arquivo', title: 'Arquivo Internet Archive', subtitle: 'Catálogo completo da coleção Baliza — cada item com URL estável.' },
 ];
 
 const BY_PATHNAME = new Map(OG_ROUTES.map((r) => [r.pathname.replace(/\/$/, ''), r]));

--- a/web/src/lib/parquetFallback.ts
+++ b/web/src/lib/parquetFallback.ts
@@ -33,7 +33,7 @@ const DEFAULT_QUERY_TIMEOUT_MS = 8_000;
 // allow-list (ARCHIVED_TABLES) instead.
 const SAFE_IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
-function escapeSqlLiteral(value: string): string {
+export function escapeSqlLiteral(value: string): string {
   return value.replace(/'/g, "''");
 }
 

--- a/web/src/lib/resourceCatalog.test.ts
+++ b/web/src/lib/resourceCatalog.test.ts
@@ -16,16 +16,16 @@ describe('resourceCatalog', () => {
     ]);
   });
 
-  it('marks contratos and atas as registered today', () => {
-    expect(REGISTERED_RESOURCE_NAMES.has('contratos')).toBe(true);
-    expect(REGISTERED_RESOURCE_NAMES.has('atas')).toBe(true);
+  it('marks contratos, atas, publicacoes and pca as registered', () => {
+    for (const name of ['contratos', 'atas', 'publicacoes', 'pca']) {
+      expect(REGISTERED_RESOURCE_NAMES.has(name)).toBe(true);
+      expect(getResourceEntry(name)?.status).toBe('registered');
+    }
   });
 
-  it('marks publicacoes, pca and itens as planned (not yet queryable)', () => {
-    for (const name of ['publicacoes', 'pca', 'itens']) {
-      expect(REGISTERED_RESOURCE_NAMES.has(name)).toBe(false);
-      expect(getResourceEntry(name)?.status).toBe('planned');
-    }
+  it('marks itens as planned (not yet queryable)', () => {
+    expect(REGISTERED_RESOURCE_NAMES.has('itens')).toBe(false);
+    expect(getResourceEntry('itens')?.status).toBe('planned');
   });
 
   it('exposes a label and a description for every entry', () => {

--- a/web/src/lib/resourceCatalog.ts
+++ b/web/src/lib/resourceCatalog.ts
@@ -42,9 +42,9 @@ export const RESOURCE_CATALOG: readonly ResourceCatalogEntry[] = [
     name: 'pca',
     label: 'PCA',
     description:
-      'Plano Anual de Contratações: o que cada órgão pretende comprar.',
+      'Plano Anual de Contratações: o que cada órgão pretende comprar antes de licitar.',
     layer: 'intent',
-    status: 'planned',
+    status: 'registered',
   },
   {
     name: 'publicacoes',
@@ -52,7 +52,7 @@ export const RESOURCE_CATALOG: readonly ResourceCatalogEntry[] = [
     description:
       'Contratações abertas no momento — oportunidades em curso no PNCP.',
     layer: 'open',
-    status: 'planned',
+    status: 'registered',
   },
   {
     name: 'atas',

--- a/web/src/pages/arquivo.astro
+++ b/web/src/pages/arquivo.astro
@@ -1,0 +1,389 @@
+---
+import Layout from '../layouts/Layout.astro';
+import iaInventoryRaw from '../../public/data/ia_inventory.json';
+
+interface IaItem {
+  identifier: string;
+  title: string;
+  description: string;
+  date: string;
+  mediatype: string;
+  item_size: number;
+  item_size_formatted: string;
+  num_files: number;
+  archive_url: string;
+  group: string;
+}
+
+interface IaInventory {
+  generated_at: string;
+  items: IaItem[];
+  groups: Record<string, string[]>;
+  group_labels: Record<string, string>;
+}
+
+const inventory = iaInventoryRaw as unknown as IaInventory;
+const { items, groups, group_labels, generated_at } = inventory;
+
+const itemByIdentifier = Object.fromEntries(items.map((it) => [it.identifier, it]));
+
+// Ordered group display sequence
+const GROUP_ORDER = ['raw', 'monthly_canonical', 'annual_canonical', 'supporting'];
+
+const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
+const resolve = (href: string) => `${BASE}${href.replace(/^\//, '')}`;
+---
+
+<Layout
+  title="Arquivo Internet Archive — Baliza"
+  description="Catálogo de todos os itens do Baliza no Internet Archive: espelhos brutos, Parquets mensais, consolidados anuais e arquivos de suporte. Cada item tem URL estável e é citável por pesquisadores."
+>
+  <main class="arquivo-page container">
+    <header class="page-header">
+      <p class="eyebrow">Arquivo aberto</p>
+      <h1>Coleção Baliza no Internet Archive</h1>
+      <p class="lead">
+        Todo artefato produzido pelo Baliza é publicado no
+        <a href="https://archive.org" target="_blank" rel="noopener">Internet Archive</a>
+        com URL estável e citável. Descubra a coleção completa via
+        <code>ia search 'subject:baliza-pncp'</code> ou navegue pelo catálogo abaixo.
+      </p>
+      {generated_at && (
+        <p class="meta">
+          Inventário gerado em{' '}
+          <time datetime={generated_at}>
+            {new Date(generated_at).toLocaleDateString('pt-BR', {
+              day: '2-digit',
+              month: '2-digit',
+              year: 'numeric',
+              hour: '2-digit',
+              minute: '2-digit',
+            })}
+          </time>
+          . Atualizado a cada build.{' '}
+          <a href="https://archive.org/search?query=subject%3Abaliza-pncp" target="_blank" rel="noopener">
+            Ver na IA ↗
+          </a>
+        </p>
+      )}
+    </header>
+
+    {items.length === 0 ? (
+      <section class="empty-state" aria-label="Nenhum item indexado">
+        <p>
+          Nenhum item indexado ainda — o inventário é regenerado a cada deploy.
+          Você pode explorar a coleção diretamente em{' '}
+          <a href="https://archive.org/search?query=subject%3Abaliza-pncp" target="_blank" rel="noopener">
+            archive.org/search?query=subject:baliza-pncp
+          </a>.
+        </p>
+      </section>
+    ) : (
+      GROUP_ORDER.map((groupKey) => {
+        const ids: string[] = groups[groupKey] ?? [];
+        const label = group_labels[groupKey] ?? groupKey;
+        const groupItems = ids.map((id) => itemByIdentifier[id]).filter(Boolean);
+        return (
+          <section class="item-group" aria-labelledby={`group-${groupKey}`}>
+            <h2 id={`group-${groupKey}`} class="group-heading">
+              {label}
+              <span class="count">{groupItems.length}</span>
+            </h2>
+            {groupItems.length === 0 ? (
+              <p class="group-empty">Ainda sem itens publicados neste grupo.</p>
+            ) : (
+              <ul class="item-list">
+                {groupItems.map((item) => (
+                  <li class="item-card">
+                    <div class="item-main">
+                      <a
+                        href={item.archive_url}
+                        target="_blank"
+                        rel="noopener"
+                        class="item-title"
+                      >
+                        {item.title}
+                      </a>
+                      <code class="item-id">{item.identifier}</code>
+                      {item.description && (
+                        <p class="item-desc">{item.description}</p>
+                      )}
+                    </div>
+                    <dl class="item-meta">
+                      {item.num_files > 0 && (
+                        <>
+                          <dt>Arquivos</dt>
+                          <dd>{item.num_files.toLocaleString('pt-BR')}</dd>
+                        </>
+                      )}
+                      {item.item_size > 0 && (
+                        <>
+                          <dt>Tamanho</dt>
+                          <dd>{item.item_size_formatted}</dd>
+                        </>
+                      )}
+                      {item.date && (
+                        <>
+                          <dt>Data</dt>
+                          <dd>{item.date}</dd>
+                        </>
+                      )}
+                      <dt>Link</dt>
+                      <dd>
+                        <a href={item.archive_url} target="_blank" rel="noopener">
+                          archive.org/details/{item.identifier} ↗
+                        </a>
+                      </dd>
+                    </dl>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        );
+      })
+    )}
+
+    <section class="citation-section" aria-labelledby="citation-heading">
+      <h2 id="citation-heading">Como citar esta coleção</h2>
+      <p>
+        Referencie a coleção completa ou um item específico. O URL do item no Internet Archive
+        é estável — permanece válido mesmo que partições sejam adicionadas ou rotacionadas.
+      </p>
+      <div class="citation-formats">
+        <div class="citation-block">
+          <h3>Coleção completa (ABNT)</h3>
+          <pre class="citation-pre"><code>BALDO, Franklin. <em>Baliza: arquivo público das contratações nacionais brasileiras (PNCP)</em>.
+Disponível em: &lt;https://archive.org/search?query=subject:baliza-pncp&gt;. Acesso em: {new Date().toLocaleDateString('pt-BR')}.</code></pre>
+        </div>
+        <div class="citation-block">
+          <h3>Item específico (BibTeX)</h3>
+          <pre class="citation-pre"><code>@misc&#123;balizaPNCP,
+  author       = &#123;Baldo, Franklin&#125;,
+  title        = &#123;Baliza: arquivo público das contratações nacionais brasileiras (PNCP)&#125;,
+  year         = &#123;{new Date().getFullYear()}&#125;,
+  howpublished = &#123;\url&#123;https://archive.org/details/baliza-pncp-ITEM&#125;&#125;,
+  note         = &#123;subject:baliza-pncp; substitua ITEM pelo identificador do item&#125;
+&#125;</code></pre>
+        </div>
+      </div>
+      <p class="discovery-note">
+        Pesquisadores podem listar toda a coleção programaticamente via API Python:
+      </p>
+      <pre class="citation-pre"><code>import internetarchive as ia
+items = ia.search_items("subject:baliza-pncp")
+for item in items:
+    print(item["identifier"])</code></pre>
+    </section>
+
+    <nav class="back-nav" aria-label="Navegação secundária">
+      <a href={resolve('desenvolvedores')}>← Para desenvolvedores</a>
+      <a href={resolve('status')}>Status do arquivo →</a>
+    </nav>
+  </main>
+</Layout>
+
+<style>
+  .arquivo-page {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: var(--space-8) var(--space-4);
+  }
+
+  .page-header {
+    margin-bottom: var(--space-8);
+  }
+
+  .eyebrow {
+    font-size: var(--text-sm);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-dim);
+    margin: 0 0 var(--space-2);
+  }
+
+  h1 {
+    font-size: clamp(28px, 3vw, 42px);
+    font-weight: 300;
+    margin: 0 0 var(--space-3);
+  }
+
+  .lead {
+    font-size: var(--text-lg);
+    color: var(--color-text-dim);
+    line-height: 1.6;
+    margin: 0 0 var(--space-2);
+  }
+
+  .meta {
+    font-size: var(--text-sm);
+    color: var(--color-text-dim);
+    margin: 0;
+  }
+
+  .empty-state {
+    padding: var(--space-8);
+    text-align: center;
+    background: var(--color-surface);
+    border: 1px dashed var(--color-border);
+    border-radius: 4px;
+  }
+
+  .item-group {
+    margin-bottom: var(--space-8);
+  }
+
+  .group-heading {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-lg);
+    font-weight: 500;
+    margin: 0 0 var(--space-4);
+    padding-bottom: var(--space-2);
+    border-bottom: 2px solid var(--color-border);
+  }
+
+  .count {
+    font-size: var(--text-sm);
+    color: var(--color-text-dim);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-weight: 400;
+  }
+
+  .group-empty {
+    color: var(--color-text-dim);
+    font-style: italic;
+    padding: var(--space-4) 0;
+  }
+
+  .item-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .item-card {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: var(--space-4);
+    align-items: start;
+    padding: var(--space-4);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-left: 4px solid var(--color-azul);
+    border-radius: 0 4px 4px 0;
+  }
+
+  .item-title {
+    display: block;
+    font-weight: 500;
+    color: var(--color-text);
+    text-decoration: none;
+    margin-bottom: var(--space-1);
+  }
+
+  .item-title:hover {
+    text-decoration: underline;
+  }
+
+  .item-id {
+    display: block;
+    font-size: var(--text-xs);
+    color: var(--color-text-dim);
+    margin-bottom: var(--space-1);
+  }
+
+  .item-desc {
+    font-size: var(--text-sm);
+    color: var(--color-text-dim);
+    margin: var(--space-1) 0 0;
+    line-height: 1.5;
+  }
+
+  .item-meta {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: var(--space-1) var(--space-3);
+    font-size: var(--text-xs);
+    white-space: nowrap;
+    margin: 0;
+  }
+
+  .item-meta dt {
+    color: var(--color-text-dim);
+    font-weight: 500;
+  }
+
+  .item-meta dd {
+    margin: 0;
+    color: var(--color-text);
+  }
+
+  .citation-section {
+    margin-top: var(--space-10);
+    padding-top: var(--space-8);
+    border-top: 1px solid var(--color-border);
+  }
+
+  .citation-section h2 {
+    font-size: var(--text-xl);
+    font-weight: 400;
+    margin: 0 0 var(--space-3);
+  }
+
+  .citation-formats {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-4);
+    margin: var(--space-4) 0;
+  }
+
+  @media (max-width: 640px) {
+    .citation-formats {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .citation-block h3 {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-text-dim);
+    margin: 0 0 var(--space-2);
+  }
+
+  .citation-pre {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: var(--space-3);
+    font-size: var(--text-xs);
+    line-height: 1.6;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    margin: 0;
+  }
+
+  .discovery-note {
+    margin: var(--space-4) 0 var(--space-2);
+    color: var(--color-text-dim);
+    font-size: var(--text-sm);
+  }
+
+  .back-nav {
+    display: flex;
+    justify-content: space-between;
+    margin-top: var(--space-10);
+    padding-top: var(--space-4);
+    border-top: 1px solid var(--color-border);
+    font-size: var(--text-sm);
+  }
+</style>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -9,13 +9,6 @@ import OrnamentBand from '../components/OrnamentBand.astro';
 import Dashboard from '../components/Dashboard.svelte';
 import WatchList from '../components/WatchList.svelte';
 import { IA_MANIFEST_URL } from '../lib/ia-manifest';
-import { SyncStatsSchema } from '../schema';
-import syncStatsRaw from '../../public/data/sync_stats.json';
-
-// Read at build time so the "Sinal do arquivo" tiles paint with real
-// numbers on first render. The Svelte island still refreshes on mount
-// so a stale build doesn't pin the user to old totals.
-const initialSyncStats = SyncStatsSchema.parse(syncStatsRaw);
 
 const BASE = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 const resolve = (href: string) => `${BASE}${href.replace(/^\//, '')}`;
@@ -27,19 +20,29 @@ const TOOLS: Array<{
   external?: boolean;
 }> = [
   {
+    label: 'Publicações abertas',
+    blurb: 'Licitações em curso arquivadas — oportunidades antes de virar contrato.',
+    href: resolve('publicacoes'),
+  },
+  {
+    label: 'PCA — Plano de Contratações',
+    blurb: 'Demanda planejada pelos órgãos antes de licitar, organizada por classificação.',
+    href: resolve('pca'),
+  },
+  {
+    label: 'Atas de registro de preços',
+    blurb: 'Compromissos vigentes que outros órgãos podem aderir sem nova licitação.',
+    href: resolve('atas'),
+  },
+  {
     label: 'Explorador SQL (Beta)',
     blurb: 'Consultas abertas sobre os Parquets arquivados, direto no navegador.',
     href: resolve('explorador'),
   },
   {
-    label: 'Atas de registro de preços',
-    blurb: 'Compromissos vigentes que outros órgãos podem aderir.',
-    href: resolve('atas'),
-  },
-  {
-    label: 'Metodologia e quarentena',
-    blurb: 'Como Baliza ingere, limpa e sinaliza anomalias antes de publicar.',
-    href: resolve('sobre'),
+    label: 'Arquivo Internet Archive',
+    blurb: 'Catálogo completo: todos os itens Baliza com URL estável e citável.',
+    href: resolve('arquivo'),
   },
   {
     label: 'Para desenvolvedores',
@@ -61,47 +64,49 @@ const TOOLS: Array<{
 ---
 
 <Layout
-  title="Baliza — contratações públicas da sua cidade"
-  description="Baliza: painel civic das contratações públicas brasileiras. Acompanhe o que sua cidade está comprando no PNCP, com snapshots diários no Internet Archive, links estáveis e SQL aberto no navegador."
+  title="Baliza — arquivo de contratações públicas brasileiras"
+  description="Baliza: atlas de quatro recursos do PNCP — PCA, Publicações, Atas e Contratos — preservado diariamente no Internet Archive com snapshots citáveis e SQL aberto no navegador."
 >
   <!-- 1. Hero: city-first. Defaults to Porto Velho, RO until the visitor picks. -->
   <CityHero client:load />
 
-  <!-- 2. Wow strip: big-number magnitude tiles for the active city,
-       computed in-browser from the archived parquet (DuckDB-WASM). Each
-       tile links to /busca?ibge=X — the canonical search view that
-       owns the detailed live list. -->
+  <!-- 2. Wow strip: big-number magnitude tiles for the active city. -->
   <CityWowStrip client:load />
 
   <OrnamentBand variant="wave" height={36} />
 
-  <!-- 3. What you can monitor — compact, citizen-legible prompts. -->
+  <!-- 3. What you can monitor. -->
   <MonitorGrid />
 
   <!-- 4. Trust layer: archive, citability, analysis. -->
   <TrustStrip />
 
-  <!-- 5. Sinal do arquivo: preservation signal backed by sync_stats.json. -->
+  <!-- 5. Sinal do arquivo: four-resource temporal spine. -->
   <HomeSection
     id="signal-title"
-    kicker="Sinal do arquivo"
-    title="O que Baliza já preservou"
+    kicker="Atlas de quatro recursos"
+    title="O que Baliza preserva"
   >
-    <Dashboard client:visible initialStats={initialSyncStats} />
+    <p class="spine-desc">
+      A cadeia completa das contratações públicas brasileiras:
+      <strong>PCA</strong> (intenção) →
+      <strong>Publicações</strong> (oportunidade) →
+      <strong>Atas</strong> (instrumento) →
+      <strong>Contratos</strong> (fato). Cada recurso arquivado diariamente no
+      <a href={resolve('arquivo')}>Internet Archive</a> com URL estável.
+    </p>
+    <Dashboard client:visible />
   </HomeSection>
 
-  <!-- 6. Watchlist: the "Acompanhar" buttons on detail views save to
-       localStorage; this island surfaces them so the feature isn't invisible
-       after the user clicks it. Renders nothing when the list is empty. -->
+  <!-- 6. Watchlist. -->
   <WatchList client:only="svelte" />
 
-  <!-- 7. Utilidades avançadas: compact secondary entry points. Demoted link
-       grid — no second hero. The single search input lives in section 2b. -->
+  <!-- 7. Utilidades avançadas. -->
   <section aria-labelledby="tools-title">
     <hgroup>
-      <p class="eyebrow">Utilidades avançadas</p>
-      <h2 id="tools-title">Outras entradas no arquivo</h2>
-      <p>Para quem já sabe o que procurar: análise, dados brutos e metodologia.</p>
+      <p class="eyebrow">Explorar o arquivo</p>
+      <h2 id="tools-title">Entradas no atlas</h2>
+      <p>Recursos, análises e dados brutos disponíveis agora.</p>
     </hgroup>
     <div class="grid">
       {TOOLS.map((tool) => (
@@ -122,3 +127,17 @@ const TOOLS: Array<{
   </section>
 </Layout>
 
+<style>
+  .spine-desc {
+    font-size: var(--text-md);
+    color: var(--color-text-dim);
+    line-height: 1.6;
+    margin: 0 0 var(--space-5);
+  }
+  .eyebrow {
+    font-size: var(--text-sm);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-dim);
+  }
+</style>

--- a/web/src/pages/pca.astro
+++ b/web/src/pages/pca.astro
@@ -1,0 +1,11 @@
+---
+import Layout from '../layouts/Layout.astro';
+import PcaHubView from '../components/PcaHubView.svelte';
+---
+
+<Layout
+  title="Plano de Contratações Anuais (PCA) — Baliza"
+  description="Intenção de demanda dos órgãos federais arquivada pelo Baliza. Explore o PCA por classificação de material/serviço, consulte via DuckDB ou acesse o arquivo no Internet Archive."
+>
+  <PcaHubView client:only="svelte" />
+</Layout>

--- a/web/src/pages/publicacoes.astro
+++ b/web/src/pages/publicacoes.astro
@@ -1,0 +1,11 @@
+---
+import Layout from '../layouts/Layout.astro';
+import PublicacoesHubView from '../components/PublicacoesHubView.svelte';
+---
+
+<Layout
+  title="Publicações PNCP — Baliza"
+  description="Contratações abertas no PNCP arquivadas pelo Baliza. Explore publicações por modalidade, consulte o dataset Parquet no navegador ou acesse o arquivo no Internet Archive."
+>
+  <PublicacoesHubView client:only="svelte" />
+</Layout>

--- a/web/src/schema.ts
+++ b/web/src/schema.ts
@@ -1,5 +1,14 @@
 import { z } from 'zod';
 
+const ResourceStatsSchema = z.object({
+  row_count: z.number(),
+  quarantine_count: z.number(),
+  partition_count: z.number(),
+  days_on_ia: z.number(),
+});
+
+export type ResourceStats = z.infer<typeof ResourceStatsSchema>;
+
 export const SyncStatsSchema = z.object({
   total_contracts: z.preprocess((val) => Number(val), z.number()),
   total_quarantine: z.preprocess((val) => Number(val), z.number()),
@@ -7,6 +16,10 @@ export const SyncStatsSchema = z.object({
   // ISO-8601 timestamp of when the snapshot was produced. Optional because
   // the committed JSON predates this field and existing BDD fixtures omit it.
   generated_at: z.string().optional(),
+  // Per-resource breakdown produced by build_sync_stats.py. Optional so the
+  // committed zero-baseline (which predates this field) still validates.
+  resources: z.record(z.string(), ResourceStatsSchema).optional(),
 });
 
 export type SyncStats = z.infer<typeof SyncStatsSchema>;
+


### PR DESCRIPTION
## Summary

Implements Tasks 4, 5a–5f, 6b–6d from the PNCP resource pipeline plan (see original task description). Builds on top of PR #576 (pipeline operationalization).

### Tasks 6b + 6c + 6d — IA archive collection exposure
- **`scripts/build_ia_inventory.py`**: queries `subject:baliza-pncp` on IA, writes `web/public/data/ia_inventory.json` grouped by purpose (raw / monthly_canonical / annual_canonical / supporting). Mirrors `build_sync_stats.py` pattern: tolerates IA outage, writes zero-baseline for fresh builds.
- **`/arquivo` page** (`web/src/pages/arquivo.astro`): lists every Baliza IA item with file count, size, archive.org links, grouped by purpose. Includes ABNT + BibTeX citation blocks and a Python discovery snippet (`ia search 'subject:baliza-pncp'`). Zero-baseline JSON committed so `astro build` succeeds before the script runs.

### Task 4 — Dashboard per-resource tiles
- **`web/src/schema.ts`**: extends `SyncStatsSchema` with optional `resources` breakdown (produced by `build_sync_stats.py`).
- **`web/src/components/Dashboard.svelte`**: renders one tile per resource in temporal-spine order (PCA → Publicações → Atas → Contratos); falls back to contratos-only view for old baselines; footer links to `/status` and `/arquivo`.

### Task 5a — Per-resource hub pages
- **`/publicacoes`** and **`/pca`** Astro pages with dedicated Svelte hub views: role description, empty state, schema reference panel, archive links.

### Task 5c — Modalidade dashboard (in `/publicacoes`)
- `PublicacoesHubView.svelte`: DuckDB `GROUP BY modalidade_nome` on the archived parquet → table with counts and `valor_total_estimado`. Empty state until first partition lands.

### Task 5d — PCA catalogue by classificação (in `/pca`)
- `PcaHubView.svelte`: DuckDB `GROUP BY classificacao_superior_nome` sorted by `valor_total`. Audience: civic researchers projecting public spend by material category.

### Task 5e — Homepage framing refresh
- `resourceCatalog.ts`: pca + publicacoes → `status: 'registered'`
- `index.astro`: new description ("atlas de quatro recursos"), temporal spine paragraph, TOOLS extended with `/publicacoes`, `/pca`, `/arquivo`
- `ogManifest.ts`: added OG routes for all three new pages

### Task 5b — Cross-resource lifecycle panels on `/orgao/{cnpj}`
- `AgencyLifecyclePanel.svelte`: queries atas, publicacoes, and pca parquets in parallel for the current CNPJ, renders collapsible panels (PCA items, open publicações, atas em vigor) with cross-links. Added at the bottom of `AgencyDetailView.svelte`.

### Task 5f — Search/filter polish
- `homepage-content.ts`: added "Publicações por modalidade", "PCA por classificação", and "Atas vigentes" chip queries to `HOMEPAGE_SQL_EXAMPLES` — visible in the DuckDB explorador chip strip.

## Test plan

- [ ] `astro check` — 0 errors ✅ (verified locally)
- [ ] After merging PR #576: verify `sync_stats.json` `resources` key populates the per-resource tiles on the homepage
- [ ] Trigger `build_ia_inventory.py` with real IA credentials and confirm `/arquivo` renders populated item cards
- [ ] Visit `/publicacoes` and `/pca` — empty state expected until pipelines run; DuckDB tiles load once parquets are on IA
- [ ] Visit `/orgao/{cnpj}` for an órgão with contratos — confirm lifecycle panel appears with atas/publicacoes/pca panels

https://claude.ai/code/session_018KUphMaReh4VQXbmJ1dn3j

---
_Generated by [Claude Code](https://claude.ai/code/session_018KUphMaReh4VQXbmJ1dn3j)_