### PR TITLE
Improve homepage onboarding: citizen-first language, cleaner nav

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -42,7 +42,7 @@
         "prettier": "^3.8.3",
         "svelte-check": "^4.4.7",
         "svelte-eslint-parser": "^1.6.0",
-        "typescript": "^5.7.3",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.59.1",
         "vitest": "^4.1.5"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -55,7 +55,7 @@
     "prettier": "^3.8.3",
     "svelte-check": "^4.4.7",
     "svelte-eslint-parser": "^1.6.0",
-    "typescript": "^5.7.3",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.1",
     "vitest": "^4.1.5"
   },

--- a/web/src/components/CityHero.svelte
+++ b/web/src/components/CityHero.svelte
@@ -60,12 +60,12 @@
 <section aria-labelledby="city-hero-title">
   <header>
     <hgroup>
-      <p class="eyebrow">Painel cívico · O que é o Baliza?</p>
+      <p class="eyebrow">Radar cívico de contratações públicas</p>
       <h1 id="city-hero-title">
         O que <mark>{cityState.nome}{cityState.uf ? ` / ${cityState.uf}` : ''}</mark> está comprando?
       </h1>
       <p>
-        <strong>B</strong>ackup <strong>A</strong>berto de <strong>Li</strong>citações <strong>Z</strong>elando pelo <strong>A</strong>cesso.
+        Contratações do PNCP organizadas para você sair com uma resposta — não com uma tabela crua.
       </p>
     </hgroup>
   </header>

--- a/web/src/components/MonitorGrid.astro
+++ b/web/src/components/MonitorGrid.astro
@@ -55,11 +55,11 @@ const ITEMS = [
 
 <section aria-labelledby="monitor-title">
   <hgroup>
-    <small>O que é possível monitorar</small>
-    <h2 id="monitor-title">Perguntas que Baliza ajuda a responder</h2>
+    <small>O que você pode monitorar agora</small>
+    <h2 id="monitor-title">Perguntas com resposta, não com planilha</h2>
     <p>
-      São os mesmos dados públicos do PNCP, organizados para que você saia
-      com uma resposta em vez de uma tabela crua.
+      Os mesmos dados públicos do PNCP — organizados para que você chegue
+      à resposta em vez de ter que construir a pergunta em SQL.
     </p>
   </hgroup>
 

--- a/web/src/components/Navigation.astro
+++ b/web/src/components/Navigation.astro
@@ -14,6 +14,8 @@ const isActive = (path: string) => {
 const cleanPath = pathname.replace(/\/$/, '') || '/';
 const cityPrefix = (BASE + 'municipio').replace(/\/$/, '');
 const isCityActive = cleanPath === cityPrefix;
+const monitorPaths = ['atas', 'dispensas', 'publicacoes'].map(p => (BASE + p).replace(/\/$/, ''));
+const isMonitorActive = monitorPaths.some(p => cleanPath === p);
 ---
 
 <nav class="container">
@@ -39,17 +41,25 @@ const isCityActive = cleanPath === cityPrefix;
       </details>
     </li>
     <li>
-      <a href={BASE + 'atas'} aria-current={isActive(BASE + 'atas') ? 'page' : undefined}>
-        <Icon name="document" /> Atas
-      </a>
+      <details role="list">
+        <summary aria-haspopup="listbox" aria-current={isMonitorActive ? 'page' : undefined}>
+          <Icon name="document" /> Monitorar
+        </summary>
+        <ul role="listbox">
+          <li><a href={BASE + 'atas'} aria-current={isActive(BASE + 'atas') ? 'page' : undefined}><Icon name="document" /> Atas de preços</a></li>
+          <li><a href={BASE + 'dispensas'} aria-current={isActive(BASE + 'dispensas') ? 'page' : undefined}><Icon name="warning" /> Dispensas e inexigibilidades</a></li>
+          <li><a href={BASE + 'publicacoes'} aria-current={isActive(BASE + 'publicacoes') ? 'page' : undefined}><Icon name="signal" /> Publicações abertas</a></li>
+        </ul>
+      </details>
     </li>
     <li>
       <details role="list" dir="rtl">
-        <summary aria-haspopup="listbox"><Icon name="database" /> Dados Abertos</summary>
+        <summary aria-haspopup="listbox"><Icon name="database" /> Dados & Dev</summary>
         <ul role="listbox">
           <li><a href={BASE + 'explorador'}><Icon name="code" /> Explorador SQL</a></li>
           <li><a href={BASE + 'desenvolvedores'}><Icon name="code" /> Devs & API</a></li>
-          <li><a href={BASE + 'status'}><Icon name="signal" /> Status do Arquivo</a></li>
+          <li><a href={BASE + 'arquivo'}><Icon name="archive" /> Arquivo</a></li>
+          <li><a href={BASE + 'status'}><Icon name="signal" /> Status</a></li>
         </ul>
       </details>
     </li>

--- a/web/src/components/TrustStrip.astro
+++ b/web/src/components/TrustStrip.astro
@@ -7,20 +7,20 @@ const PILLARS = [
   {
     kicker: 'Arquivo',
     iconKind: 'archive' as const,
-    title: 'Snapshots diários no Internet Archive',
-    body: 'Cada dia de contratações vira um Parquet aberto fora do alcance de qualquer servidor único. Mesmo que o PNCP saia do ar, o dia de ontem segue consultável.',
+    title: 'Cada número pode ser conferido e citado depois',
+    body: 'Contratações são arquivadas diariamente fora do PNCP. Mesmo que o portal saia do ar, o registro de ontem segue acessível — em formato aberto, sem depender de nenhum servidor nosso.',
     cta: { label: 'Metodologia', href: 'sobre' },
   },
   {
     kicker: '🔗 Citação',
-    title: 'Links estáveis e hashes verificáveis',
-    body: 'Todo contrato tem permalink Baliza com hash do snapshot. O link que você compartilha hoje reproduz a mesma evidência amanhã.',
+    title: 'Todo contrato tem um link permanente',
+    body: 'O link que você compartilha hoje mostra a mesma evidência amanhã. Cada snapshot carrega uma impressão digital (hash) que confirma que nada foi alterado.',
     cta: { label: 'Desenvolvedores', href: 'desenvolvedores' },
   },
   {
-    kicker: '🦆 Análise',
-    title: 'SQL aberto direto no navegador',
-    body: 'Consultas completas rodam no seu navegador via DuckDB WASM. Nada passa por um backend nosso — sua análise é privada e reprodutível.',
+    kicker: '🔒 Privacidade',
+    title: 'Sua análise não passa por nenhum servidor nosso',
+    body: 'As consultas rodam inteiramente no seu navegador. Não coletamos o que você pesquisa — seus filtros e perguntas ficam só com você.',
     cta: { label: 'Explorador SQL', href: 'explorador' },
   },
 ];
@@ -28,8 +28,8 @@ const PILLARS = [
 
 <section aria-labelledby="trust-title">
   <hgroup>
-    <small>✨ Por que Baliza é diferente</small>
-    <h2 id="trust-title">Arquivo permanente, citação estável, análise sem servidor</h2>
+    <small>Por que você pode confiar nos números</small>
+    <h2 id="trust-title">Transparência com recibo</h2>
   </hgroup>
 
   <div class="grid">

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -35,28 +35,28 @@ const TOOLS: Array<{
     href: resolve('atas'),
   },
   {
-    label: 'Explorador SQL (Beta)',
-    blurb: 'Consultas abertas sobre os Parquets arquivados, direto no navegador.',
+    label: 'Explorador SQL',
+    blurb: 'Faça perguntas livres sobre os dados arquivados — tudo roda no seu navegador, sem conta.',
     href: resolve('explorador'),
   },
   {
-    label: 'Arquivo Internet Archive',
-    blurb: 'Catálogo completo: todos os itens Baliza com URL estável e citável.',
+    label: 'Arquivo de snapshots',
+    blurb: 'Catálogo completo com URL estável e citável para cada dia de dados preservados.',
     href: resolve('arquivo'),
   },
   {
     label: 'Para desenvolvedores',
-    blurb: 'URLs estáveis em Python, R e JS — sem chave de API.',
+    blurb: 'Acesse os dados via Python, R ou JS — sem chave de API, sem cadastro.',
     href: resolve('desenvolvedores'),
   },
   {
-    label: 'Status do arquivo',
-    blurb: 'Última sincronização com o PNCP e o Internet Archive.',
+    label: 'Status da atualização',
+    blurb: 'Veja quando os dados foram sincronizados pela última vez com o PNCP.',
     href: resolve('status'),
   },
   {
-    label: 'Datasets Parquet',
-    blurb: 'Manifesto CSV com partição, URL e hash no Internet Archive.',
+    label: 'Baixar datasets',
+    blurb: 'Manifesto com todos os arquivos Parquet: partição, URL e hash de integridade.',
     href: IA_MANIFEST_URL,
     external: true,
   },
@@ -64,8 +64,8 @@ const TOOLS: Array<{
 ---
 
 <Layout
-  title="Baliza — arquivo de contratações públicas brasileiras"
-  description="Baliza: atlas de quatro recursos do PNCP — PCA, Publicações, Atas e Contratos — preservado diariamente no Internet Archive com snapshots citáveis e SQL aberto no navegador."
+  title="Baliza — O que sua cidade está comprando?"
+  description="Baliza monitora as contratações públicas do PNCP: quem contratou, quanto pagou, quais fornecedores se repetem, e onde há dispensas sem concorrência. Dados verificáveis, arquivados diariamente."
 >
   <!-- 1. Hero: city-first. Defaults to Porto Velho, RO until the visitor picks. -->
   <CityHero client:load />
@@ -104,9 +104,9 @@ const TOOLS: Array<{
   <!-- 7. Utilidades avançadas. -->
   <section aria-labelledby="tools-title">
     <hgroup>
-      <p class="eyebrow">Explorar o arquivo</p>
-      <h2 id="tools-title">Entradas no atlas</h2>
-      <p>Recursos, análises e dados brutos disponíveis agora.</p>
+      <p class="eyebrow">Mais ferramentas</p>
+      <h2 id="tools-title">Por onde entrar</h2>
+      <p>Cada porta leva a uma fatia diferente dos dados — escolha a que faz sentido para você.</p>
     </hgroup>
     <div class="grid">
       {TOOLS.map((tool) => (


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Kill the BALIZA acronym** in the hero — replaced with "Contratações do PNCP organizadas para você sair com uma resposta — não com uma tabela crua." The acronym gymnastics ("Backup Aberto de Licitações Zelando pelo Acesso") is hidden; the product hook stays.
- **TrustStrip reframed** — pillars now lead with citizen benefits ("Cada número pode ser conferido e citado depois", "Todo contrato tem um link permanente", "Sua análise não passa por nenhum servidor nosso") instead of infrastructure names (Internet Archive, hashes verificáveis, DuckDB WASM). The tech detail is preserved in the body text as supporting evidence, not as the headline.
- **Navigation split into two explicit paths**: "Monitorar" (Atas de preços, Dispensas e inexigibilidades, Publicações abertas) for citizens/journalists; "Dados & Dev" (SQL Explorer, Devs & API, Arquivo, Status) for researchers/developers. Dispensas was previously invisible in the nav — it's now a first-class link.
- **Homepage meta title** changed from "arquivo de contratações públicas brasileiras" to "O que sua cidade está comprando?" — the actual product hook.
- **MonitorGrid** kicker/title tweaked: "Perguntas que Baliza ajuda a responder" → "Perguntas com resposta, não com planilha".
- **Tools section** heading changed from "Entradas no atlas" to "Por onde entrar" with plain-language blurbs ("Faça perguntas livres sobre os dados arquivados", "Baixar datasets", etc.).

## Test plan

- [ ] Build passes (`astro check` — 0 errors, confirmed locally)
- [ ] Hero no longer shows the BALIZA acronym expansion
- [ ] Navigation shows "Monitorar" dropdown with Atas, Dispensas, Publicações
- [ ] Navigation shows "Dados & Dev" dropdown with SQL, Devs, Arquivo, Status
- [ ] TrustStrip section title reads "Transparência com recibo"
- [ ] Homepage `<title>` contains "O que sua cidade está comprando?"

https://claude.ai/code/session_019PT1HYcFxHCujDBUKXb8pp
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019PT1HYcFxHCujDBUKXb8pp)_